### PR TITLE
Add AcceptLanguage to Client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -34,6 +34,8 @@ type Client struct {
 	DefaultTimeoutDuration time.Duration
 	// ユーザーエージェント
 	UserAgent string
+	// Accept-Language
+	AcceptLanguage string
 	// リクエストパラメーター トレーサー
 	RequestTracer io.Writer
 	// レスポンス トレーサー
@@ -53,6 +55,7 @@ func NewClient(token, tokenSecret, zone string) *Client {
 		TraceMode:              false,
 		DefaultTimeoutDuration: 20 * time.Minute,
 		UserAgent:              fmt.Sprintf("libsacloud/%s", libsacloud.Version),
+		AcceptLanguage:         "",
 		RetryMax:               0,
 		RetryInterval:          5 * time.Second,
 	}
@@ -69,6 +72,7 @@ func (c *Client) Clone() *Client {
 		TraceMode:              c.TraceMode,
 		DefaultTimeoutDuration: c.DefaultTimeoutDuration,
 		UserAgent:              c.UserAgent,
+		AcceptLanguage:         c.AcceptLanguage,
 		RetryMax:               c.RetryMax,
 		RetryInterval:          c.RetryInterval,
 	}
@@ -154,6 +158,9 @@ func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error
 	//	req.Header.Add("X-Sakura-API-Beautify", "1") // format response-JSON
 	//}
 	req.Header.Add("User-Agent", c.UserAgent)
+	if c.AcceptLanguage != "" {
+		req.Header.Add("Accept-Language", c.AcceptLanguage)
+	}
 	req.Method = method
 
 	resp, err := client.Do(req)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -30,6 +30,7 @@ func TestMain(m *testing.M) {
 	client = NewClient(accessToken, accessTokenSecret, region)
 	client.DefaultTimeoutDuration = 30 * time.Minute
 	client.UserAgent = fmt.Sprintf("test-libsacloud/%s", libsacloud.Version)
+	client.AcceptLanguage = "en-US,en;q=0.9"
 
 	ret := m.Run()
 	os.Exit(ret)


### PR DESCRIPTION
`c.AcceptLanguage = "en-US,en;q=0.9"` の形式で `Accept-Language` を設定できるように `AcceptLanguage` を追加しました。実際にさくらのクラウドから英語で `ErrorMessage` が返却されることを確認済みです。