### PR TITLE
Fix SIMList is failed due to change SIMInfo.traffic_bytes_of_current_month type to string

### DIFF
--- a/sacloud/sim.go
+++ b/sacloud/sim.go
@@ -2,6 +2,7 @@ package sacloud
 
 import (
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -49,8 +50,8 @@ type SIMInfo struct {
 
 // SIMTrafficBytes 当月通信量
 type SIMTrafficBytes struct {
-	UplinkBytes   int64 `json:"uplink_bytes,omitempty"`
-	DownlinkBytes int64 `json:"downlink_bytes,omitempty"`
+	UplinkBytes   uint64 `json:"uplink_bytes,omitempty"`
+	DownlinkBytes uint64 `json:"downlink_bytes,omitempty"`
 }
 
 // UnmarshalJSON JSONアンマーシャル(配列、オブジェクトが混在するためここで対応)
@@ -60,15 +61,22 @@ func (s *SIMTrafficBytes) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	tmp := &struct {
-		UplinkBytes   int64 `json:"uplink_bytes,omitempty"`
-		DownlinkBytes int64 `json:"downlink_bytes,omitempty"`
+		UplinkBytes   string `json:"uplink_bytes,omitempty"`
+		DownlinkBytes string `json:"downlink_bytes,omitempty"`
 	}{}
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err
 	}
 
-	s.UplinkBytes = tmp.UplinkBytes
-	s.DownlinkBytes = tmp.DownlinkBytes
+	var err error
+	s.UplinkBytes, err = strconv.ParseUint(tmp.UplinkBytes, 10, 64)
+	if err != nil {
+		return err
+	}
+	s.DownlinkBytes, err = strconv.ParseUint(tmp.DownlinkBytes, 10, 64)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/sacloud/sim_test.go
+++ b/sacloud/sim_test.go
@@ -50,8 +50,8 @@ const testSIMStatusBody = `
     "activated_date": "2018-04-04T07:48:48+00:00",
     "deactivated_date": "2018-04-04T07:46:02+00:00",
     "traffic_bytes_of_current_month": {
-      "uplink_bytes": 169734354,
-      "downlink_bytes": 509606410
+      "uplink_bytes": "169734354",
+      "downlink_bytes": "509606410"
     },
     "connected_imei": "xxxxxxxxxxxxxxx"
   },


### PR DESCRIPTION
クラウドAPI側でtraffic_bytes_of_current_monthの中のuplink_bytes,downlink_bytesがstringになったため、JSONのパースでエラーになってしまっていたのを修正しました。
また、uplink_bytesなどは内部的にはuint64で持っているデータなので、uint64にしておくのが良さそうです。