### PR TITLE
remove api-package dependency in builder

### DIFF
--- a/builder/api_client.go
+++ b/builder/api_client.go
@@ -1,0 +1,152 @@
+package builder
+
+import (
+	"time"
+
+	"github.com/sacloud/libsacloud/api"
+	"github.com/sacloud/libsacloud/sacloud"
+	"github.com/sacloud/libsacloud/sacloud/ostype"
+)
+
+// APIClient represents SAKURA CLOUD api client
+type APIClient interface {
+	ServerNew() *sacloud.Server
+	ServerRead(serverID int64) (*sacloud.Server, error)
+	ServerCreate(value *sacloud.Server) (*sacloud.Server, error)
+	ServerSleepUntilUp(serverID int64, timeout time.Duration) error
+	ServerInsertCDROM(serverID int64, cdromID int64) (bool, error)
+	ServerBoot(serverID int64) (bool, error)
+
+	SSHKeyNew() *sacloud.SSHKey
+	SSHKeyCreate(value *sacloud.SSHKey) (*sacloud.SSHKey, error)
+	SSHKeyDelete(sshKeyID int64) (*sacloud.SSHKey, error)
+	SSHKeyGenerate(name string, passPhrase string, desc string) (*sacloud.SSHKeyGenerated, error)
+
+	NoteNew() *sacloud.Note
+	NoteCreate(value *sacloud.Note) (*sacloud.Note, error)
+	NoteDelete(noteID int64) (*sacloud.Note, error)
+
+	DiskNew() *sacloud.Disk
+	DiskNewCondig() *sacloud.DiskEditValue
+	DiskCreate(value *sacloud.Disk) (*sacloud.Disk, error)
+	DiskCreateWithConfig(value *sacloud.Disk, config *sacloud.DiskEditValue, bootAtAvailable bool) (*sacloud.Disk, error)
+	DiskSleepWhileCopying(id int64, timeout time.Duration) error
+	DiskConnectToServer(diskID int64, serverID int64) (bool, error)
+
+	InterfaceConnectToPacketFilter(interfaceID int64, packetFilterID int64) (bool, error)
+	InterfaceSetDisplayIPAddress(interfaceID int64, ip string) (bool, error) // Interface
+
+	ServerPlanGetBySpec(core int, memGB int, gen sacloud.PlanGenerations) (*sacloud.ProductServer, error)
+
+	ArchiveFindByOSType(os ostype.ArchiveOSTypes) (*sacloud.Archive, error)
+
+	GetTimeoutDuration() time.Duration
+}
+
+// NewAPIClient create new APICLient from *api.Client
+func NewAPIClient(client *api.Client) APIClient {
+	return &apiClient{client: client}
+}
+
+type apiClient struct {
+	client *api.Client
+}
+
+func (a *apiClient) ServerNew() *sacloud.Server {
+	return a.client.Server.New()
+}
+
+func (a *apiClient) ServerRead(serverID int64) (*sacloud.Server, error) {
+	return a.client.Server.Read(serverID)
+}
+
+func (a *apiClient) ServerCreate(value *sacloud.Server) (*sacloud.Server, error) {
+	return a.client.Server.Create(value)
+}
+
+func (a *apiClient) ServerSleepUntilUp(serverID int64, timeout time.Duration) error {
+	return a.client.Server.SleepUntilUp(serverID, timeout)
+}
+
+func (a *apiClient) ServerInsertCDROM(serverID int64, cdromID int64) (bool, error) {
+	return a.client.Server.InsertCDROM(serverID, cdromID)
+}
+
+func (a *apiClient) ServerBoot(serverID int64) (bool, error) {
+	return a.client.Server.Boot(serverID)
+}
+
+func (a *apiClient) SSHKeyNew() *sacloud.SSHKey {
+	return a.client.SSHKey.New()
+}
+
+func (a *apiClient) SSHKeyCreate(value *sacloud.SSHKey) (*sacloud.SSHKey, error) {
+	return a.client.SSHKey.Create(value)
+}
+
+func (a *apiClient) SSHKeyDelete(sshKeyID int64) (*sacloud.SSHKey, error) {
+	return a.client.SSHKey.Delete(sshKeyID)
+}
+
+func (a *apiClient) SSHKeyGenerate(name string, passPhrase string, desc string) (*sacloud.SSHKeyGenerated, error) {
+	return a.client.SSHKey.Generate(name, passPhrase, desc)
+}
+
+func (a *apiClient) NoteNew() *sacloud.Note {
+	return a.client.Note.New()
+}
+
+func (a *apiClient) NoteCreate(value *sacloud.Note) (*sacloud.Note, error) {
+	return a.client.Note.Create(value)
+}
+
+func (a *apiClient) NoteDelete(noteID int64) (*sacloud.Note, error) {
+	return a.client.Note.Delete(noteID)
+}
+
+func (a *apiClient) DiskNew() *sacloud.Disk {
+	return a.client.Disk.New()
+}
+
+func (a *apiClient) DiskNewCondig() *sacloud.DiskEditValue {
+	return a.client.Disk.NewCondig()
+}
+
+func (a *apiClient) DiskCreate(value *sacloud.Disk) (*sacloud.Disk, error) {
+	return a.client.Disk.Create(value)
+}
+
+func (a *apiClient) DiskCreateWithConfig(
+	value *sacloud.Disk,
+	config *sacloud.DiskEditValue,
+	bootAtAvailable bool) (*sacloud.Disk, error) {
+	return a.client.Disk.CreateWithConfig(value, config, bootAtAvailable)
+}
+
+func (a *apiClient) DiskSleepWhileCopying(id int64, timeout time.Duration) error {
+	return a.client.Disk.SleepWhileCopying(id, timeout)
+}
+
+func (a *apiClient) DiskConnectToServer(diskID int64, serverID int64) (bool, error) {
+	return a.client.Disk.ConnectToServer(diskID, serverID)
+}
+
+func (a *apiClient) InterfaceConnectToPacketFilter(interfaceID int64, packetFilterID int64) (bool, error) {
+	return a.client.Interface.ConnectToPacketFilter(interfaceID, packetFilterID)
+}
+
+func (a *apiClient) InterfaceSetDisplayIPAddress(interfaceID int64, ip string) (bool, error) {
+	return a.client.Interface.SetDisplayIPAddress(interfaceID, ip)
+}
+
+func (a *apiClient) ServerPlanGetBySpec(core int, memGB int, gen sacloud.PlanGenerations) (*sacloud.ProductServer, error) {
+	return a.client.Product.Server.GetBySpec(core, memGB, gen)
+}
+
+func (a *apiClient) ArchiveFindByOSType(os ostype.ArchiveOSTypes) (*sacloud.Archive, error) {
+	return a.client.Archive.FindByOSType(os)
+}
+
+func (a *apiClient) GetTimeoutDuration() time.Duration {
+	return a.client.DefaultTimeoutDuration
+}

--- a/builder/base_builder.go
+++ b/builder/base_builder.go
@@ -3,12 +3,10 @@ package builder
 import (
 	"fmt"
 	"strings"
-
-	"github.com/sacloud/libsacloud/api"
 )
 
 type baseBuilder struct {
-	client *api.Client
+	client APIClient
 	errors []error
 }
 

--- a/builder/doc.go
+++ b/builder/doc.go
@@ -18,7 +18,7 @@
 //		client := api.NewClient("PUT-YOUR-TOKEN", "PUT-YOUR-SECRET", "tk1a")
 //
 //		// パブリックアーカイブ(CentOS)から作成するビルダー、共有セグメントに接続、以外はデフォルト値で作成
-//      b := builder.serverPublicArchiveUnix(client, ostype.CentOS, "ServerName", "Password")
+//      b := builder.serverPublicArchiveUnix(builder.NewAPIClient(client), ostype.CentOS, "ServerName", "Password")
 //      b.AddPublicNWConnectedNIC()
 //		res , err := b.WithAddPublicNWConnectedNIC().Build()
 //
@@ -45,38 +45,38 @@
 //	type PublicArchiveUnixServerBuilder interface { ... }
 //
 //	// ビルダー作成用関数
-//	func serverPublicArchiveUnix(client *api.Client, os ostype.ArchiveOSTypes, name string, password string) PublicArchiveUnixServerBuilder
+//	func serverPublicArchiveUnix(client APIClient, os ostype.ArchiveOSTypes, name string, password string) PublicArchiveUnixServerBuilder
 //
 // - Windows系パブリックアーカイブ
 //	// ビルダー
 //	type PublicArchiveWindowsServerBuilder interface { ... }
 //
 //	// ビルダー作成用関数
-//	func serverPublicArchiveWindows(client *api.Client, name string, archiveID int64) PublicArchiveWindowsServerBuilder
+//	func serverPublicArchiveWindows(client APIClient, name string, archiveID int64) PublicArchiveWindowsServerBuilder
 //
 // - 汎用
 //	// ビルダー
 //	type CommonServerBuilder interface { ... }
 //
 //	// ビルダー作成用関数(アーカイブから作成)
-//	func serverFromArchive(client *api.Client, name string, sourceArchiveID int64) CommonServerBuilder
+//	func serverFromArchive(client APIClient, name string, sourceArchiveID int64) CommonServerBuilder
 //
 //	// ビルダー作成用関数(ディスクから作成)
-//	func serverFromDisk(client *api.Client, name string, sourceDiskID int64) CommonServerBuilder
+//	func serverFromDisk(client APIClient, name string, sourceDiskID int64) CommonServerBuilder
 //
 // - ディスクレス
 //	// ビルダー
 //	type DisklessServerBuilder interface { ... }
 //
 //	// ビルダー作成用関数
-//	func ServerDiskless(client *api.Client, name string) DisklessServerBuilder
+//	func ServerDiskless(client APIClient, name string) DisklessServerBuilder
 //
 // - 空のディスク
 //	// ビルダー
 //	type BlankDiskServerBuilder interface { ... }
 //
 //	// ビルダー作成用関数
-//	func ServerBlankDisk(client *api.Client, name string) BlankDiskServerBuilder
+//	func ServerBlankDisk(client APIClient, name string) BlankDiskServerBuilder
 //
 //
 //
@@ -88,7 +88,7 @@
 //		client := api.NewClient("PUT-YOUR-TOKEN", "PUT-YOUR-SECRET", "tk1a")
 //
 //		// ディスクレスビルダー、イベントハンドラ(ServerBuildOnComplete)を登録
-//		b := builder.ServerDiskless(client, "example")
+//		b := builder.ServerDiskless(builder.NewAPIClient(client), "example")
 //		b.SetEventHandler(builder.ServerBuildOnComplete, callbackFunc).
 //		b.Build()
 //	}

--- a/builder/doc_test.go
+++ b/builder/doc_test.go
@@ -35,10 +35,10 @@ exit 0`
 	//---------------------------------------------------------------------
 
 	// APIクライアントの作成
-	client := api.NewClient(token, secret, zone)
+	client :=  api.NewClient(token, secret, zone)
 
 	// CentOSパブリックアーカイブからサーバー作成
-	builder := builder.ServerPublicArchiveUnix(client, ostype.CentOS, serverName, password)
+	builder := builder.ServerPublicArchiveUnix(builder.NewAPIClient(client), ostype.CentOS, serverName, password)
 	builder.AddPublicNWConnectedNIC() // NIC:共有セグメントに接続
 	builder.SetCore(core)             // スペック指定(コア数)
 	builder.SetMemory(memory)         // スペック指定(メモリ)

--- a/builder/factory.go
+++ b/builder/factory.go
@@ -3,12 +3,11 @@ package builder
 import (
 	"fmt"
 
-	"github.com/sacloud/libsacloud/api"
 	"github.com/sacloud/libsacloud/sacloud/ostype"
 )
 
 // ServerDiskless ディスクレスサーバービルダー
-func ServerDiskless(client *api.Client, name string) DisklessServerBuilder {
+func ServerDiskless(client APIClient, name string) DisklessServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -17,7 +16,7 @@ func ServerDiskless(client *api.Client, name string) DisklessServerBuilder {
 }
 
 // ServerPublicArchiveUnix ディスクの編集が可能なLinux(Unix)系パブリックアーカイブを利用するビルダー
-func ServerPublicArchiveUnix(client *api.Client, os ostype.ArchiveOSTypes, name string, password string) PublicArchiveUnixServerBuilder {
+func ServerPublicArchiveUnix(client APIClient, os ostype.ArchiveOSTypes, name string, password string) PublicArchiveUnixServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -33,7 +32,7 @@ func ServerPublicArchiveUnix(client *api.Client, os ostype.ArchiveOSTypes, name 
 }
 
 // ServerPublicArchiveFixedUnix ディスクの編集が不可なLinux(Unix)系パブリックアーカイブを利用するビルダー
-func ServerPublicArchiveFixedUnix(client *api.Client, os ostype.ArchiveOSTypes, name string) FixedUnixArchiveServerBuilder {
+func ServerPublicArchiveFixedUnix(client APIClient, os ostype.ArchiveOSTypes, name string) FixedUnixArchiveServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -48,7 +47,7 @@ func ServerPublicArchiveFixedUnix(client *api.Client, os ostype.ArchiveOSTypes, 
 }
 
 // ServerPublicArchiveWindows Windows系パブリックアーカイブを利用するビルダー
-func ServerPublicArchiveWindows(client *api.Client, os ostype.ArchiveOSTypes, name string) PublicArchiveWindowsServerBuilder {
+func ServerPublicArchiveWindows(client APIClient, os ostype.ArchiveOSTypes, name string) PublicArchiveWindowsServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -63,7 +62,7 @@ func ServerPublicArchiveWindows(client *api.Client, os ostype.ArchiveOSTypes, na
 }
 
 //ServerBlankDisk 空のディスクを利用するビルダー
-func ServerBlankDisk(client *api.Client, name string) BlankDiskServerBuilder {
+func ServerBlankDisk(client APIClient, name string) BlankDiskServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -77,7 +76,7 @@ func ServerBlankDisk(client *api.Client, name string) BlankDiskServerBuilder {
 }
 
 // ServerFromExistsDisk 既存ディスクを接続するビルダー
-func ServerFromExistsDisk(client *api.Client, name string, sourceDiskID int64) ConnectDiskServerBuilder {
+func ServerFromExistsDisk(client APIClient, name string, sourceDiskID int64) ConnectDiskServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -88,7 +87,7 @@ func ServerFromExistsDisk(client *api.Client, name string, sourceDiskID int64) C
 }
 
 // ServerFromDisk 既存ディスクをコピーして新たなディスクを作成するビルダー
-func ServerFromDisk(client *api.Client, name string, sourceDiskID int64) CommonServerBuilder {
+func ServerFromDisk(client APIClient, name string, sourceDiskID int64) CommonServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -104,7 +103,7 @@ func ServerFromDisk(client *api.Client, name string, sourceDiskID int64) CommonS
 }
 
 // ServerFromArchive 既存アーカイブをコピーして新たなディスクを作成するビルダー
-func ServerFromArchive(client *api.Client, name string, sourceArchiveID int64) CommonServerBuilder {
+func ServerFromArchive(client APIClient, name string, sourceArchiveID int64) CommonServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -124,7 +123,7 @@ func (b *serverBuilder) serverPublicArchiveUnix(os ostype.ArchiveOSTypes, passwo
 		b.errors = append(b.errors, fmt.Errorf("%q is not support EditDisk", os))
 	}
 
-	archive, err := b.client.Archive.FindByOSType(os)
+	archive, err := b.client.ArchiveFindByOSType(os)
 	if err != nil {
 		b.errors = append(b.errors, err)
 	}
@@ -136,7 +135,7 @@ func (b *serverBuilder) serverPublicArchiveUnix(os ostype.ArchiveOSTypes, passwo
 }
 
 func (b *serverBuilder) serverPublicArchiveFixedUnix(os ostype.ArchiveOSTypes) {
-	archive, err := b.client.Archive.FindByOSType(os)
+	archive, err := b.client.ArchiveFindByOSType(os)
 	if err != nil {
 		b.errors = append(b.errors, err)
 	}
@@ -150,7 +149,7 @@ func (b *serverBuilder) serverPublicArchiveWindows(os ostype.ArchiveOSTypes) {
 		b.errors = append(b.errors, fmt.Errorf("%q is not windows", os))
 	}
 
-	archive, err := b.client.Archive.FindByOSType(os)
+	archive, err := b.client.ArchiveFindByOSType(os)
 	if err != nil {
 		b.errors = append(b.errors, err)
 	}

--- a/builder/server_test.go
+++ b/builder/server_test.go
@@ -20,7 +20,7 @@ exit 0
 
 func TestServerBuilder_buildParams(t *testing.T) {
 
-	builder := ServerDiskless(client, serverBuilderTestServerName).(*serverBuilder)
+	builder := ServerDiskless(NewAPIClient(client), serverBuilderTestServerName).(*serverBuilder)
 
 	// この段階では ディスクレス/ISOイメージレス/NICレス、全ての設定がデフォルト値のサーバーになる
 	builder.currentBuildValue = &ServerBuildValue{}
@@ -35,7 +35,7 @@ func TestServerBuilder_buildParams(t *testing.T) {
 	//builder.GetPassword()
 
 	// Unix系アーカイブからのインストールの場合、パスワードの設定などのディスクの編集ができるようになる。
-	tempBuilder := ServerPublicArchiveUnix(client, ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
+	tempBuilder := ServerPublicArchiveUnix(NewAPIClient(client), ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
 
 	assert.NotNil(t, tempBuilder)
 	assert.Equal(t, tempBuilder.GetPassword(), serverBuilderTestPassword)
@@ -45,7 +45,7 @@ func TestServerBuilder_buildParams(t *testing.T) {
 func TestServerBuilder_DisklessDefaults(t *testing.T) {
 	defer initServers()()
 
-	builder := ServerDiskless(client, serverBuilderTestServerName)
+	builder := ServerDiskless(NewAPIClient(client), serverBuilderTestServerName)
 
 	assert.Equal(t, builder.GetServerName(), serverBuilderTestServerName)        // サーバー名
 	assert.Equal(t, builder.GetCore(), 1)                                        // コア数 : デフォルト1
@@ -57,7 +57,7 @@ func TestServerBuilder_DisklessDefaults(t *testing.T) {
 func TestDisklessServerBuilder_ServerPublicArchiveUnixDefaults(t *testing.T) {
 	defer initServers()()
 
-	b := ServerPublicArchiveUnix(client, ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
+	b := ServerPublicArchiveUnix(NewAPIClient(client), ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
 
 	assert.Equal(t, b.GetServerName(), serverBuilderTestServerName)        // サーバー名
 	assert.Equal(t, b.GetCore(), 1)                                        // コア数 : デフォルト1
@@ -73,7 +73,7 @@ func TestDisklessServerBuilder_ServerPublicArchiveUnixDefaults(t *testing.T) {
 func TestServerBuilder_Build_WithMinimum(t *testing.T) {
 	defer initServers()()
 
-	builder := ServerPublicArchiveUnix(client, ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
+	builder := ServerPublicArchiveUnix(NewAPIClient(client), ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
 	builder.AddPublicNWConnectedNIC()
 	result, err := builder.Build()
 
@@ -88,7 +88,7 @@ func TestServerBuilder_Build_WithMinimum(t *testing.T) {
 func TestServerBuilder_Build_WithPacketFilter(t *testing.T) {
 	defer initServers()()
 
-	builder := ServerDiskless(client, serverBuilderTestServerName)
+	builder := ServerDiskless(NewAPIClient(client), serverBuilderTestServerName)
 
 	pfReq := client.PacketFilter.New()
 	pfReq.Name = "Test"
@@ -110,7 +110,7 @@ func TestServerBuilder_Build_WithPacketFilter(t *testing.T) {
 func TestServerBuilder_Build_WithSSHKeyAndNoteEphemeral(t *testing.T) {
 	defer initServers()()
 
-	builder := ServerPublicArchiveUnix(client, ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
+	builder := ServerPublicArchiveUnix(NewAPIClient(client), ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
 
 	builder.AddPublicNWConnectedNIC()
 	builder.AddNote(serverBuilderTestNote)
@@ -144,7 +144,7 @@ func TestServerBuilder_Build_WithExistsSwitch(t *testing.T) {
 	assert.NoError(t, err)
 
 	expectAddr := "19.2.0.1"
-	builder := ServerDiskless(client, serverBuilderTestServerName)
+	builder := ServerDiskless(NewAPIClient(client), serverBuilderTestServerName)
 	builder.AddExistsSwitchConnectedNICWithDisplayIP(sw.GetStrID(), expectAddr)
 	res, err := builder.Build()
 	assert.NoError(t, err)
@@ -155,7 +155,7 @@ func TestServerBuilder_Build_WithExistsSwitch(t *testing.T) {
 func TestServerBuilder_Build_WithSSHKeyAndNote(t *testing.T) {
 	defer initServers()()
 
-	builder := ServerPublicArchiveUnix(client, ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
+	builder := ServerPublicArchiveUnix(NewAPIClient(client), ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
 
 	builder.AddPublicNWConnectedNIC()
 	builder.AddNote(serverBuilderTestNote)
@@ -197,7 +197,7 @@ func TestServerBuilder_Build_WithSSHKeyAndNote(t *testing.T) {
 func TestServerBuilder_Build_WithEventHandler(t *testing.T) {
 	defer initServers()()
 
-	builder := ServerPublicArchiveUnix(client, ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
+	builder := ServerPublicArchiveUnix(NewAPIClient(client), ostype.CentOS, serverBuilderTestServerName, serverBuilderTestPassword)
 
 	serverEvents := []ServerBuildEvents{
 		ServerBuildOnStart,

--- a/builder/types.go
+++ b/builder/types.go
@@ -1,6 +1,8 @@
 package builder
 
-import "github.com/sacloud/libsacloud/sacloud"
+import (
+	"github.com/sacloud/libsacloud/sacloud"
+)
 
 const (
 	// DefaultCore コア数(デフォルト値)


### PR DESCRIPTION
`builder`パッケージの`api`パッケージへの依存を除去する。
これにより`builder`パッケージを利用する箇所の単体テストを容易にする。

### 変更内容

- `builder.APIClient`インターフェースを追加
- `builder`パッケージ内のファクトリメソッドの引数を`*api.Client`から`builder.APIClient`に変更

これにより、従来`builder`パッケージを利用する際にファクトリメソッドに`*api.Client`を指定する必要があったものが`builder.APIClient`を渡せるようになり、builderパッケージ利用者はテストなどのために独自の`builder.APIClient`の実装を指定可能となる。必ずしも`*api.Client`を必要としなくなるためテストが容易になる。

また、あわせて`builder.APIClient`を実装したstructを返すfunc `builder.NewAPIClient(*api.Client)`も追加することで従来のbuilderパッケージ利用者が容易に`builder.APIClient`の実装を取得できるようにする。

### 互換性について

この変更はbreaking-changeとなる。

従来の`builder`パッケージ利用者は`*api.Client`を指定する代わりに`builder.NewAPIClient(*api.Client)`を呼び出すように変更する必要がある。

#### 例

変更前:

```go
// APIクライアントの作成
client := api.NewClient(token, secret, zone)
 
// *api.Clientを渡す必要があった
builder := builder.ServerPublicArchiveUnix(client, ostype.CentOS, serverName, password)
serverName, password)
```

変更後: 

```go
// APIクライアントの作成
client :=  api.NewClient(token, secret, zone)
 
// *api.Clientの代わりにbuilder.APIClientインターフェースを渡す
builder := builder.ServerPublicArchiveUnix(builder.NewAPIClient(client), ostype.CentOS, serverName, password)
```
