### PR TITLE
Use NoteAPI for choose plan of NFS

### DIFF
--- a/api/nfs.go
+++ b/api/nfs.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -93,6 +94,58 @@ func (api *NFSAPI) Create(value *sacloud.NFS) (*sacloud.NFS, error) {
 	return api.request(func(res *nfsResponse) error {
 		return api.create(api.createRequest(value), res)
 	})
+}
+
+// CreateWithPlan プラン/サイズを指定してNFSを作成
+func (api *NFSAPI) CreateWithPlan(value *sacloud.CreateNFSValue, plan sacloud.NFSPlan, size sacloud.NFSSize) (*sacloud.NFS, error) {
+
+	nfs := sacloud.NewNFS(value)
+	// get plan
+	plans, err := api.GetNFSPlans()
+	if err != nil {
+		return nil, err
+	}
+	if plans == nil {
+		return nil, errors.New("NFS plans not found")
+	}
+
+	planID := plans.FindPlanID(plan, size)
+	if planID < 0 {
+		return nil, errors.New("NFS plans not found")
+	}
+
+	nfs.Plan = sacloud.NewResource(planID)
+	nfs.Remark.Plan = sacloud.NewResource(planID)
+
+	return api.request(func(res *nfsResponse) error {
+		return api.create(api.createRequest(nfs), res)
+	})
+}
+
+// GetNFSPlans プラン一覧取得
+func (api *NFSAPI) GetNFSPlans() (*sacloud.NFSPlans, error) {
+	notes, err := api.client.Note.Reset().Find()
+	if err != nil {
+		return nil, err
+	}
+	for _, note := range notes.Notes {
+		if note.Class == sacloud.ENoteClass("json") && note.Name == "sys-nfs" {
+			rawPlans := note.Content
+
+			var plans struct {
+				Plans *sacloud.NFSPlans `json:"plans"`
+			}
+
+			err := json.Unmarshal([]byte(rawPlans), &plans)
+			if err != nil {
+				return nil, err
+			}
+
+			return plans.Plans, nil
+		}
+	}
+
+	return nil, nil
 }
 
 // Read 読み取り

--- a/api/nfs_test.go
+++ b/api/nfs_test.go
@@ -11,7 +11,6 @@ import (
 const testNFSName = "libsacloud_test_NFS"
 
 var createNFSValues = &sacloud.CreateNFSValue{
-	Plan:         sacloud.NFSPlan100G,
 	IPAddress:    "192.168.11.11",
 	MaskLen:      24,
 	DefaultRoute: "192.168.11.1",
@@ -35,9 +34,7 @@ func TestNFSCRUD(t *testing.T) {
 
 	//CREATE
 	createNFSValues.SwitchID = fmt.Sprintf("%d", sw.ID)
-	newItem := sacloud.NewNFS(createNFSValues)
-
-	item, err := api.Create(newItem)
+	item, err := api.CreateWithPlan(createNFSValues, sacloud.NFSPlanHDD, sacloud.NFSSize100G)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, item)

--- a/utils/setup/setup_test.go
+++ b/utils/setup/setup_test.go
@@ -49,17 +49,16 @@ func TestAccRetryAbleSetUp(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, sw)
 
-	param := sacloud.NewNFS(&sacloud.CreateNFSValue{
+	param := &sacloud.CreateNFSValue{
 		SwitchID:  sw.GetStrID(),
-		Plan:      sacloud.NFSPlan100G,
 		IPAddress: "192.2.0.1",
 		MaskLen:   24,
 		Name:      testResourceName,
-	})
+	}
 
 	nfsBuilder := &RetryableSetup{
 		Create: func() (sacloud.ResourceIDHolder, error) {
-			return client.NFS.Create(param)
+			return client.NFS.CreateWithPlan(param, sacloud.NFSPlanSSD, sacloud.NFSSize100G)
 		},
 		AsyncWaitForCopy: func(id int64) (chan interface{}, chan interface{}, chan error) {
 			c, p, e := client.NFS.AsyncSleepWhileCopying(id, client.DefaultTimeoutDuration, 5)


### PR DESCRIPTION
**Note: This PR includes breaking change**

NFS plan information is in Note like follows, so we should use NoteAPI when we choose plan.

```js
{
      "plans": {
        "HDD": [
          {
            "size": 100,
            "availability": "available",
            "planId": "1001012001"
          },
          {
            "size": 500,
            "availability": "available",
            "planId": "1001012005"
          },
          {
            "size": 1024,
            "availability": "available",
            "planId": "1001012010"
          },
          {
            "size": 2048,
            "availability": "available",
            "planId": "1001012020"
          },
          {
            "size": 4096,
            "availability": "available",
            "planId": "1001012040"
          },
          {
            "size": 8192,
            "availability": "available",
            "planId": "1001012080"
          },
          {
            "size": 12288,
            "availability": "available",
            "planId": "1001012120"
          }
        ],
        "SSD": [
          {
            "size": 100,
            "availability": "available",
            "planId": "1001014001"
          },
          {
            "size": 500,
            "availability": "available",
            "planId": "1001014005"
          },
          {
            "size": 1024,
            "availability": "available",
            "planId": "1001014010"
          },
          {
            "size": 2048,
            "availability": "available",
            "planId": "1001014020"
          },
          {
            "size": 4096,
            "availability": "available",
            "planId": "1001014040"
          }
        ]
      }
    }
```