### PR TITLE
Use json.Number for NFS.Remark.Plan.ID

### DIFF
--- a/api/nfs.go
+++ b/api/nfs.go
@@ -115,7 +115,7 @@ func (api *NFSAPI) CreateWithPlan(value *sacloud.CreateNFSValue, plan sacloud.NF
 	}
 
 	nfs.Plan = sacloud.NewResource(planID)
-	nfs.Remark.Plan = sacloud.NewResource(planID)
+	nfs.Remark.SetRemarkPlanID(planID)
 
 	return api.request(func(res *nfsResponse) error {
 		return api.create(api.createRequest(nfs), res)

--- a/sacloud/nfs.go
+++ b/sacloud/nfs.go
@@ -15,10 +15,22 @@ type NFS struct {
 // NFSRemark リマーク
 type NFSRemark struct {
 	*ApplianceRemarkBase
-	propPlanID
+	Plan *struct {
+		ID json.Number `json:",omitempty"`
+	} `json:",omitempty"` // プラン
 	// TODO Zone
 	//Zone *Resource
 	//SourceAppliance *Resource // クローン元DB
+}
+
+// SetRemarkPlanID プランID設定
+func (n NFSRemark) SetRemarkPlanID(planID int64) {
+	if n.Plan == nil {
+		n.Plan = &struct {
+			ID json.Number `json:",omitempty"`
+		}{}
+	}
+	n.Plan.ID = json.Number(planID)
 }
 
 // NFSSettings NFS設定リスト

--- a/sacloud/nfs_test.go
+++ b/sacloud/nfs_test.go
@@ -51,7 +51,7 @@ var testNFSJSON = `
                 "NetworkMaskLen": 24
             },
             "Plan": {
-                "ID": 100
+                "ID": "100"
             },
             "Servers": [
                 {
@@ -92,7 +92,7 @@ var testNFSJSON = `
 
 func TestMarshalNFSJSON(t *testing.T) {
 	var nfs NFS
-	err := json.Unmarshal([]byte(testLoadBalancerJSON), &nfs)
+	err := json.Unmarshal([]byte(testNFSJSON), &nfs)
 
 	assert.NoError(t, err)
 	assert.NotEmpty(t, nfs)


### PR DESCRIPTION
NFS has Plan.ID in following two places.

- NFS.Plan.ID
- NFS.Remark.Plan.ID

But they have different type. It causes unmarshal json error as follows.
`json: cannot unmarshal string into Go struct field Resource.ID of type int64`

So we can't use `*sacloud.Resource` for Plan resources.

This PR changes type of NFS.Remark.Plan.ID to json.Number.
