### PR TITLE
Make http.Client configurable from outside of api.Client

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -45,6 +45,8 @@ type Client struct {
 	RetryMax int
 	// 503エラー時のリトライ待ち時間
 	RetryInterval time.Duration
+	// APIコール時に利用される*http.Client 未指定の場合http.DefaultClientが利用される
+	HTTPClient *http.Client
 }
 
 // NewClient APIクライアント作成
@@ -112,6 +114,7 @@ func (c *Client) isOkStatus(code int) bool {
 func (c *Client) newRequest(method, uri string, body interface{}) ([]byte, error) {
 	var (
 		client = &retryableHTTPClient{
+			Client:        c.HTTPClient,
 			retryMax:      c.RetryMax,
 			retryInterval: c.RetryInterval,
 		}
@@ -233,12 +236,15 @@ func newRequest(method, url string, body io.ReadSeeker) (*request, error) {
 }
 
 type retryableHTTPClient struct {
-	http.Client
+	*http.Client
 	retryInterval time.Duration
 	retryMax      int
 }
 
 func (c *retryableHTTPClient) Do(req *request) (*http.Response, error) {
+	if c.Client == nil {
+		c.Client = http.DefaultClient
+	}
 	for i := 0; ; i++ {
 
 		if req.body != nil {


### PR DESCRIPTION
(from https://github.com/go-acme/lego/pull/850#issuecomment-480828019)

Currently, libsacloud doesn't have any ability that configure inner http.Client.
(for example, timeout, transport, and more..)

This PR makes inner http.Client configurable from outside of api.Client.  
