### PR TITLE
コア専有プラン

### DIFF
--- a/api/product_server.go
+++ b/api/product_server.go
@@ -25,12 +25,12 @@ func NewProductServerAPI(client *Client) *ProductServerAPI {
 }
 
 // GetBySpec 指定のコア数/メモリサイズ/世代のプランを取得
-func (api *ProductServerAPI) GetBySpec(core int, memGB int, gen sacloud.PlanGenerations) (*sacloud.ProductServer, error) {
+func (api *ProductServerAPI) GetBySpec(core, memGB int, gen sacloud.PlanGenerations) (*sacloud.ProductServer, error) {
 	return api.GetBySpecCommitment(core, memGB, gen, sacloud.ECommitmentStandard)
 }
 
 // GetBySpecCommitment 指定のコア数/メモリサイズ/世代のプランを取得
-func (api *ProductServerAPI) GetBySpecCommitment(core int, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error) {
+func (api *ProductServerAPI) GetBySpecCommitment(core, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error) {
 	plans, err := api.Reset().Find()
 	if err != nil {
 		return nil, err

--- a/api/product_server.go
+++ b/api/product_server.go
@@ -26,6 +26,11 @@ func NewProductServerAPI(client *Client) *ProductServerAPI {
 
 // GetBySpec 指定のコア数/メモリサイズ/世代のプランを取得
 func (api *ProductServerAPI) GetBySpec(core int, memGB int, gen sacloud.PlanGenerations) (*sacloud.ProductServer, error) {
+	return api.GetBySpecCommitment(core, memGB, gen, sacloud.ECommitmentStandard)
+}
+
+// GetBySpecCommitment 指定のコア数/メモリサイズ/世代のプランを取得
+func (api *ProductServerAPI) GetBySpecCommitment(core int, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error) {
 	plans, err := api.Reset().Find()
 	if err != nil {
 		return nil, err
@@ -33,7 +38,7 @@ func (api *ProductServerAPI) GetBySpec(core int, memGB int, gen sacloud.PlanGene
 	var res sacloud.ProductServer
 	var found bool
 	for _, plan := range plans.ServerPlans {
-		if plan.CPU == core && plan.GetMemoryGB() == memGB {
+		if plan.CPU == core && plan.GetMemoryGB() == memGB || plan.Commitment == commitment {
 			if gen == sacloud.PlanDefault || gen == plan.Generation {
 				// PlanDefaultの場合は複数ヒットしうる。
 				// この場合より新しい世代を優先する。

--- a/builder/api_client.go
+++ b/builder/api_client.go
@@ -36,7 +36,7 @@ type APIClient interface {
 	InterfaceConnectToPacketFilter(interfaceID int64, packetFilterID int64) (bool, error)
 	InterfaceSetDisplayIPAddress(interfaceID int64, ip string) (bool, error) // Interface
 
-	ServerPlanGetBySpec(core int, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error)
+	ServerPlanGetBySpec(core, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error)
 
 	ArchiveFindByOSType(os ostype.ArchiveOSTypes) (*sacloud.Archive, error)
 
@@ -139,7 +139,7 @@ func (a *apiClient) InterfaceSetDisplayIPAddress(interfaceID int64, ip string) (
 	return a.client.Interface.SetDisplayIPAddress(interfaceID, ip)
 }
 
-func (a *apiClient) ServerPlanGetBySpec(core int, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error) {
+func (a *apiClient) ServerPlanGetBySpec(core, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error) {
 	if string(commitment) == "" {
 		commitment = sacloud.ECommitmentStandard
 	}

--- a/builder/api_client.go
+++ b/builder/api_client.go
@@ -36,7 +36,7 @@ type APIClient interface {
 	InterfaceConnectToPacketFilter(interfaceID int64, packetFilterID int64) (bool, error)
 	InterfaceSetDisplayIPAddress(interfaceID int64, ip string) (bool, error) // Interface
 
-	ServerPlanGetBySpec(core int, memGB int, gen sacloud.PlanGenerations) (*sacloud.ProductServer, error)
+	ServerPlanGetBySpec(core int, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error)
 
 	ArchiveFindByOSType(os ostype.ArchiveOSTypes) (*sacloud.Archive, error)
 
@@ -139,8 +139,11 @@ func (a *apiClient) InterfaceSetDisplayIPAddress(interfaceID int64, ip string) (
 	return a.client.Interface.SetDisplayIPAddress(interfaceID, ip)
 }
 
-func (a *apiClient) ServerPlanGetBySpec(core int, memGB int, gen sacloud.PlanGenerations) (*sacloud.ProductServer, error) {
-	return a.client.Product.Server.GetBySpec(core, memGB, gen)
+func (a *apiClient) ServerPlanGetBySpec(core int, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error) {
+	if string(commitment) == "" {
+		commitment = sacloud.ECommitmentStandard
+	}
+	return a.client.Product.Server.GetBySpecCommitment(core, memGB, gen, commitment)
 }
 
 func (a *apiClient) ArchiveFindByOSType(os ostype.ArchiveOSTypes) (*sacloud.Archive, error) {

--- a/builder/server.go
+++ b/builder/server.go
@@ -18,6 +18,7 @@ type serverBuilder struct {
 	serverName      string
 	core            int
 	memory          int
+	commitment      sacloud.ECommitment
 	interfaceDriver sacloud.EInterfaceDriver
 	description     string
 	iconID          int64
@@ -72,6 +73,7 @@ func newServerBuilder(client APIClient, serverName string) *serverBuilder {
 		serverName:         serverName,
 		core:               DefaultCore,
 		memory:             DefaultMemory,
+		commitment:         sacloud.ECommitmentStandard,
 		interfaceDriver:    DefaultInterfaceDriver,
 		description:        DefaultDescription,
 		iconID:             DefaultIconID,
@@ -179,7 +181,7 @@ func (b *serverBuilder) buildServerParams() error {
 	b.callEventHandlerIfExists(ServerBuildOnSetPlanBefore)
 
 	// plan
-	plan, err := b.client.ServerPlanGetBySpec(b.core, b.memory, sacloud.PlanDefault)
+	plan, err := b.client.ServerPlanGetBySpec(b.core, b.memory, sacloud.PlanDefault, b.commitment)
 	if err != nil {
 		err = fmt.Errorf("Error building server parameters : setting plan / [%s]", err)
 		return err
@@ -384,6 +386,16 @@ func (b *serverBuilder) GetMemory() int {
 // SetMemory メモリサイズ(GB単位) 設定
 func (b *serverBuilder) SetMemory(memory int) {
 	b.memory = memory
+}
+
+// GetCommitment サーバプランCPUコミットメント 取得
+func (b *serverBuilder) GetCommitment() sacloud.ECommitment {
+	return b.commitment
+}
+
+// SetCommitment サーバプランCPUコミットメント 設定
+func (b *serverBuilder) SetCommitment(commitment sacloud.ECommitment) {
+	b.commitment = commitment
 }
 
 // GetInterfaceDriver インターフェースドライバ 取得

--- a/builder/server_test.go
+++ b/builder/server_test.go
@@ -50,6 +50,24 @@ func TestServerBuilder_DisklessDefaults(t *testing.T) {
 	assert.Equal(t, builder.GetServerName(), serverBuilderTestServerName)        // サーバー名
 	assert.Equal(t, builder.GetCore(), 1)                                        // コア数 : デフォルト1
 	assert.Equal(t, builder.GetMemory(), 1)                                      // メモリ : デフォルト1GB
+	assert.Equal(t, builder.GetCommitment(), sacloud.ECommitmentStandard)        // コミットメント: デフォルト standard
+	assert.Equal(t, builder.GetInterfaceDriver(), sacloud.InterfaceDriverVirtIO) // 準仮想化モード(@virtio-net-pci) : デフォルト有効
+
+}
+
+func TestServerBuilder_DisklessDedicatedCPU(t *testing.T) {
+	defer initServers()()
+
+	builder := ServerDiskless(NewAPIClient(client), serverBuilderTestServerName)
+
+	builder.SetCore(2)
+	builder.SetMemory(4)
+	builder.SetCommitment("dedicatedcpu")
+
+	assert.Equal(t, builder.GetServerName(), serverBuilderTestServerName)        // サーバー名
+	assert.Equal(t, builder.GetCore(), 2)                                        // コア数 : デフォルト1
+	assert.Equal(t, builder.GetMemory(), 4)                                      // メモリ : デフォルト1GB
+	assert.Equal(t, builder.GetCommitment(), sacloud.ECommitmentDedicatedCPU)    // コミットメント: デフォルト standard
 	assert.Equal(t, builder.GetInterfaceDriver(), sacloud.InterfaceDriverVirtIO) // 準仮想化モード(@virtio-net-pci) : デフォルト有効
 
 }

--- a/builder/types.go
+++ b/builder/types.go
@@ -76,6 +76,11 @@ type CommonProperty interface {
 	// SetMemory メモリサイズ(GB単位) 設定
 	SetMemory(memory int)
 
+	// GetCommitment サーバプランCPUコミットメント 取得
+	GetCommitment() sacloud.ECommitment
+	// SetCommitment サーバプランCPUコミットメント 設定
+	SetCommitment(commitment sacloud.ECommitment)
+
 	// GetInterfaceDriver インターフェースドライバ 取得
 	GetInterfaceDriver() sacloud.EInterfaceDriver
 	// SetInterfaceDriver インターフェースドライバ 設定

--- a/sacloud/common_types.go
+++ b/sacloud/common_types.go
@@ -168,6 +168,16 @@ var (
 	}
 )
 
+// ECommitment サーバプランCPUコミットメント
+type ECommitment string
+
+var (
+	// ECommitmentStandard 通常
+	ECommitmentStandard = ECommitment("standard")
+	// ECommitmentDedicatedCPU コア専有
+	ECommitmentDedicatedCPU = ECommitment("dedicatedcpu")
+)
+
 // SakuraCloudResources さくらのクラウド上のリソース種別一覧
 type SakuraCloudResources struct {
 	Server          *Server             `json:",omitempty"`     // サーバー

--- a/sacloud/product_server.go
+++ b/sacloud/product_server.go
@@ -10,4 +10,5 @@ type ProductServer struct {
 	propMemoryMB                     // メモリサイズ(MB単位)
 	propServiceClass                 // サービスクラス
 	Generation       PlanGenerations `json:",omitempty"` // 世代
+	Commitment       ECommitment     `json:",omitempty"`
 }


### PR DESCRIPTION
ProductServerAPIの`GetBySpec`メソッドのシグニチャは後方互換のため変更しない。
Commitment含めてプランを検索したい場合は`GetBySpecCommitment`メソッドを利用する。

`builder`パッケージについては設定されていない場合はCommitmentに`standard`を利用する。
