### PR TITLE
Fix GetBySpecCommitment - set search limit to 1000

### DIFF
--- a/api/product_server.go
+++ b/api/product_server.go
@@ -31,7 +31,7 @@ func (api *ProductServerAPI) GetBySpec(core, memGB int, gen sacloud.PlanGenerati
 
 // GetBySpecCommitment 指定のコア数/メモリサイズ/世代のプランを取得
 func (api *ProductServerAPI) GetBySpecCommitment(core, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error) {
-	plans, err := api.Reset().Find()
+	plans, err := api.Reset().Limit(1000).Find()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
石狩第1ゾーンでサーバプラン検索を行うとページングの1ページあたりの上限(100件)に引っかかり検索できないプランが発生する。

このため検索時のLimitパラメータに十分大きな数(1000)を設定して対応する。
頻繁に呼ばれるものではない、かつ件数はさほど大きくないため現状では影響は小さいはず。

もしサーバプランが今後増える場合は再考する。