### PR TITLE
API definitions refactoring

### DIFF
--- a/internal/define/apis.go
+++ b/internal/define/apis.go
@@ -17,20 +17,20 @@ import "github.com/sacloud/libsacloud/v2/internal/schema"
 var APIs schema.Resources
 
 func init() {
-	APIs.Def(archiveAPI)      // アーカイブ
-	APIs.Def(bridgeAPI)       // ブリッジ
-	APIs.Def(cdromAPI)        // ISOイメージ(CD-ROM)
-	APIs.Def(diskAPI)         // ディスク
-	APIs.Def(gslbAPI)         // GSLB
-	APIs.Def(interfaceAPI)    // インターフェース(NIC)
-	APIs.Def(internetAPI)     // スイッチ+ルータ
-	APIs.Def(loadBalancerAPI) // ロードバランサ
-	APIs.Def(nfsAPI)          // NFS
-	APIs.Def(noteAPI)         // スタートアップスクリプト
-	APIs.Def(packetFilterAPI) // パケットフィルタ
-	APIs.Def(serverAPI)       // サーバ
-	APIs.Def(simAPI)          // SIM
-	APIs.Def(switchAPI)       // スイッチ
-	APIs.Def(vpcRouterAPI)    // VPCルータ
-	APIs.Def(zoneAPI)         // ゾーン
+	APIs.Define(archiveAPI)      // アーカイブ
+	APIs.Define(bridgeAPI)       // ブリッジ
+	APIs.Define(cdromAPI)        // ISOイメージ(CD-ROM)
+	APIs.Define(diskAPI)         // ディスク
+	APIs.Define(gslbAPI)         // GSLB
+	APIs.Define(interfaceAPI)    // インターフェース(NIC)
+	APIs.Define(internetAPI)     // スイッチ+ルータ
+	APIs.Define(loadBalancerAPI) // ロードバランサ
+	APIs.Define(nfsAPI)          // NFS
+	APIs.Define(noteAPI)         // スタートアップスクリプト
+	APIs.Define(packetFilterAPI) // パケットフィルタ
+	APIs.Define(serverAPI)       // サーバ
+	APIs.Define(simAPI)          // SIM
+	APIs.Define(switchAPI)       // スイッチ
+	APIs.Define(vpcRouterAPI)    // VPCルータ
+	APIs.Define(zoneAPI)         // ゾーン
 }

--- a/internal/define/apis.go
+++ b/internal/define/apis.go
@@ -13,24 +13,24 @@ package define
 
 import "github.com/sacloud/libsacloud/v2/internal/schema"
 
-// Resources APIでの操作対象リソースの定義
-var Resources schema.Resources
+// APIs APIでの操作対象リソースの定義
+var APIs schema.Resources
 
 func init() {
-	Resources.Def(archiveAPI)      // アーカイブ
-	Resources.Def(bridgeAPI)       // ブリッジ
-	Resources.Def(cdromAPI)        // ISOイメージ(CD-ROM)
-	Resources.Def(diskAPI)         // ディスク
-	Resources.Def(gslbAPI)         // GSLB
-	Resources.Def(interfaceAPI)    // インターフェース(NIC)
-	Resources.Def(internetAPI)     // スイッチ+ルータ
-	Resources.Def(loadBalancerAPI) // ロードバランサ
-	Resources.Def(nfsAPI)          // NFS
-	Resources.Def(noteAPI)         // スタートアップスクリプト
-	Resources.Def(packetFilterAPI) // パケットフィルタ
-	Resources.Def(serverAPI)       // サーバ
-	Resources.Def(simAPI)          // SIM
-	Resources.Def(switchAPI)       // スイッチ
-	Resources.Def(vpcRouterAPI)    // VPCルータ
-	Resources.Def(zoneAPI)         // ゾーン
+	APIs.Def(archiveAPI)      // アーカイブ
+	APIs.Def(bridgeAPI)       // ブリッジ
+	APIs.Def(cdromAPI)        // ISOイメージ(CD-ROM)
+	APIs.Def(diskAPI)         // ディスク
+	APIs.Def(gslbAPI)         // GSLB
+	APIs.Def(interfaceAPI)    // インターフェース(NIC)
+	APIs.Def(internetAPI)     // スイッチ+ルータ
+	APIs.Def(loadBalancerAPI) // ロードバランサ
+	APIs.Def(nfsAPI)          // NFS
+	APIs.Def(noteAPI)         // スタートアップスクリプト
+	APIs.Def(packetFilterAPI) // パケットフィルタ
+	APIs.Def(serverAPI)       // サーバ
+	APIs.Def(simAPI)          // SIM
+	APIs.Def(switchAPI)       // スイッチ
+	APIs.Def(vpcRouterAPI)    // VPCルータ
+	APIs.Def(zoneAPI)         // ゾーン
 }

--- a/internal/define/archive.go
+++ b/internal/define/archive.go
@@ -89,6 +89,8 @@ var (
 	archiveNakedType = meta.Static(naked.Archive{})
 
 	archiveView = &schema.Model{
+		Name:      archiveAPIName,
+		NakedType: archiveNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -117,6 +119,8 @@ var (
 	}
 
 	archiveCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(archiveAPIName),
+		NakedType: archiveNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.SourceDiskID(),
 			fields.SourceArchiveID(),
@@ -128,7 +132,8 @@ var (
 	}
 
 	archiveCreateBlankParam = &schema.Model{
-		Name: "ArchiveCreateBlankRequest",
+		Name:      "ArchiveCreateBlankRequest",
+		NakedType: archiveNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.SizeMB(),
 			fields.Name(),
@@ -139,6 +144,8 @@ var (
 	}
 
 	archiveUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(archiveAPIName),
+		NakedType: archiveNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/bridge.go
+++ b/internal/define/bridge.go
@@ -1,6 +1,7 @@
 package define
 
 import (
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -38,6 +39,8 @@ var (
 	bridgeNakedType = meta.Static(naked.Bridge{})
 
 	bridgeView = &schema.Model{
+		Name:      bridgeAPIName,
+		NakedType: bridgeNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -50,6 +53,8 @@ var (
 	}
 
 	bridgeCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(bridgeAPIName),
+		NakedType: bridgeNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),
@@ -57,6 +62,8 @@ var (
 	}
 
 	bridgeUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(bridgeAPIName),
+		NakedType: bridgeNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/cdrom.go
+++ b/internal/define/cdrom.go
@@ -83,6 +83,8 @@ var (
 	cdromNakedType = meta.Static(naked.CDROM{})
 
 	cdromView = &schema.Model{
+		Name:      cdromAPIName,
+		NakedType: cdromNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -99,7 +101,8 @@ var (
 	}
 
 	cdromCreateParam = &schema.Model{
-		Name: "CDROMCreateRequest",
+		Name:      names.CreateParameterName(cdromAPIName),
+		NakedType: cdromNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.SizeMB(),
 			fields.Name(),
@@ -107,10 +110,11 @@ var (
 			fields.Tags(),
 			fields.IconID(),
 		},
-		NakedType: cdromNakedType,
 	}
 
 	cdromUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(cdromAPIName),
+		NakedType: cdromNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/conditions.go
+++ b/internal/define/conditions.go
@@ -26,6 +26,7 @@ var monitorParameter = &schema.Model{
 }
 
 var findParameter = &schema.Model{
+	Name: "FindCondition",
 	Fields: []*schema.FieldDesc{
 		conditions.Count(),
 		conditions.From(),

--- a/internal/define/disk.go
+++ b/internal/define/disk.go
@@ -3,6 +3,7 @@ package define
 import (
 	"net/http"
 
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -310,7 +311,8 @@ var (
 	diskDistantFromType = meta.Static([]types.ID{})
 
 	diskModel = &schema.Model{
-		Name: "Disk",
+		Name:      diskAPIName,
+		NakedType: diskNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -339,6 +341,8 @@ var (
 	}
 
 	diskCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(diskAPIName),
+		NakedType: diskNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.DiskPlanID(),
 			fields.DiskConnection(),
@@ -354,6 +358,8 @@ var (
 	}
 
 	diskUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(diskAPIName),
+		NakedType: diskNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/gslb.go
+++ b/internal/define/gslb.go
@@ -1,6 +1,7 @@
 package define
 
 import (
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -39,6 +40,8 @@ var (
 	gslbNakedType = meta.Static(naked.GSLB{})
 
 	gslbView = &schema.Model{
+		Name:      gslbAPIName,
+		NakedType: gslbNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -65,6 +68,8 @@ var (
 	}
 
 	gslbCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(gslbAPIName),
+		NakedType: gslbNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.GSLBProviderClass(),
 
@@ -86,6 +91,8 @@ var (
 	}
 
 	gslbUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(gslbAPIName),
+		NakedType: gslbNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.GSLBHealthCheckProtocol(),
 			fields.GSLBHealthCheckHostHeader(),

--- a/internal/define/interface.go
+++ b/internal/define/interface.go
@@ -3,6 +3,7 @@ package define
 import (
 	"net/http"
 
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -62,6 +63,8 @@ var (
 	interfaceNakedType = meta.Static(naked.Interface{})
 
 	interfaceView = &schema.Model{
+		Name:      interfaceAPIName,
+		NakedType: interfaceNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.MACAddress(),
@@ -77,12 +80,16 @@ var (
 	}
 
 	interfaceCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(interfaceAPIName),
+		NakedType: interfaceNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ServerID(),
 		},
 	}
 
 	interfaceUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(interfaceAPIName),
+		NakedType: interfaceNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.UserIPAddress(),
 		},

--- a/internal/define/internet.go
+++ b/internal/define/internet.go
@@ -3,6 +3,7 @@ package define
 import (
 	"net/http"
 
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -142,6 +143,8 @@ var (
 	internetView = models.internetModel()
 
 	internetCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(internetAPIName),
+		NakedType: internetNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),
@@ -153,6 +156,8 @@ var (
 	}
 
 	internetUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(internetAPIName),
+		NakedType: internetNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/load_balancer.go
+++ b/internal/define/load_balancer.go
@@ -1,6 +1,7 @@
 package define
 
 import (
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -53,6 +54,8 @@ var (
 	loadBalancerNakedType = meta.Static(naked.LoadBalancer{})
 
 	loadBalancerView = &schema.Model{
+		Name:      loadBalancerAPIName,
+		NakedType: loadBalancerNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -89,6 +92,8 @@ var (
 	}
 
 	loadBalancerCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(loadBalancerAPIName),
+		NakedType: loadBalancerNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.LoadBalancerClass(),
 			fields.ApplianceSwitchID(),
@@ -106,6 +111,8 @@ var (
 	}
 
 	loadBalancerUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(loadBalancerAPIName),
+		NakedType: loadBalancerNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/names/resource_name.go
+++ b/internal/define/names/resource_name.go
@@ -25,3 +25,13 @@ func ResourceFieldName(resourceName string, form schema.PayloadForm) string {
 		return ""
 	}
 }
+
+// CreateParameterName Create操作に渡すパラメータの名称
+func CreateParameterName(resourceName string) string {
+	return resourceName + "CreateRequest"
+}
+
+// UpdateParameterName Create操作に渡すパラメータの名称
+func UpdateParameterName(resourceName string) string {
+	return resourceName + "UpdateRequest"
+}

--- a/internal/define/nfs.go
+++ b/internal/define/nfs.go
@@ -1,6 +1,7 @@
 package define
 
 import (
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -49,6 +50,8 @@ var (
 	nfsNakedType = meta.Static(naked.NFS{})
 
 	nfsView = &schema.Model{
+		Name:      nfsAPIName,
+		NakedType: nfsNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -81,6 +84,8 @@ var (
 	}
 
 	nfsCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(nfsAPIName),
+		NakedType: nfsNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.NFSClass(),
 			fields.ApplianceSwitchID(),
@@ -96,6 +101,8 @@ var (
 	}
 
 	nfsUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(nfsAPIName),
+		NakedType: nfsNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/note.go
+++ b/internal/define/note.go
@@ -1,6 +1,7 @@
 package define
 
 import (
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -39,6 +40,8 @@ var (
 	noteNakedType = meta.Static(naked.Note{})
 
 	noteView = &schema.Model{
+		Name:      noteAPIName,
+		NakedType: noteNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -55,6 +58,8 @@ var (
 	}
 
 	noteCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(noteAPIName),
+		NakedType: noteNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Tags(),
@@ -65,6 +70,8 @@ var (
 	}
 
 	noteUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(noteAPIName),
+		NakedType: noteNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Tags(),

--- a/internal/define/ops/operations.go
+++ b/internal/define/ops/operations.go
@@ -10,18 +10,6 @@ import (
 )
 
 func find(resourceName string, nakedType meta.Type, findParam, result *schema.Model, payloadName string) *schema.Operation {
-	if findParam.Name == "" {
-		findParam.Name = "FindCondition"
-	}
-
-	if result.Name == "" {
-		result.Name = resourceName
-	}
-
-	if result.NakedType == nil {
-		result.NakedType = nakedType
-	}
-
 	if payloadName == "" {
 		payloadName = names.ResourceFieldName(resourceName, schema.PayloadForms.Plural)
 	}
@@ -67,20 +55,6 @@ func FindCommonServiceItem(resourceName string, nakedType meta.Type, findParam, 
 }
 
 func create(resourceName string, nakedType meta.Type, createParam, result *schema.Model, payloadName string) *schema.Operation {
-	if createParam.Name == "" {
-		createParam.Name = resourceName + "CreateRequest"
-	}
-	if result.Name == "" {
-		result.Name = resourceName
-	}
-
-	if createParam.NakedType == nil {
-		createParam.NakedType = nakedType
-	}
-	if result.NakedType == nil {
-		result.NakedType = nakedType
-	}
-
 	if payloadName == "" {
 		payloadName = names.ResourceFieldName(resourceName, schema.PayloadForms.Singular)
 	}
@@ -129,14 +103,6 @@ func CreateCommonServiceItem(resourceName string, nakedType meta.Type, createPar
 }
 
 func read(resourceName string, nakedType meta.Type, result *schema.Model, payloadName string) *schema.Operation {
-	if result.Name == "" {
-		result.Name = resourceName
-	}
-
-	if result.NakedType == nil {
-		result.NakedType = nakedType
-	}
-
 	if payloadName == "" {
 		payloadName = names.ResourceFieldName(resourceName, schema.PayloadForms.Singular)
 	}
@@ -181,18 +147,6 @@ func ReadCommonServiceItem(resourceName string, nakedType meta.Type, result *sch
 }
 
 func update(resourceName string, nakedType meta.Type, updateParam, result *schema.Model, payloadName string) *schema.Operation {
-	if updateParam.Name == "" {
-		updateParam.Name = resourceName + "UpdateRequest"
-	}
-	if result.Name == "" {
-		result.Name = resourceName
-	}
-	if updateParam.NakedType == nil {
-		updateParam.NakedType = nakedType
-	}
-	if result.NakedType == nil {
-		result.NakedType = nakedType
-	}
 	if payloadName == "" {
 		payloadName = names.ResourceFieldName(resourceName, schema.PayloadForms.Singular)
 	}
@@ -462,10 +416,8 @@ func MonitorChild(resourceName, funcNameSuffix, childResourceName string, monito
 
 // MonitorChildBy アプライアンスなどでの内部リソースインデックスを持つアクティビティモニタ取得操作を定義
 func MonitorChildBy(resourceName, funcNameSuffix, childResourceName string, monitorParam, result *schema.Model) *schema.Operation {
-
 	pathSuffix := childResourceName + "/{{if eq .index 0}}{{.index}}{{end}}/monitor"
-
-	o := &schema.Operation{
+	return &schema.Operation{
 		ResourceName:    resourceName,
 		Name:            "Monitor" + funcNameSuffix,
 		PathFormat:      schema.IDAndSuffixPathFormat(pathSuffix),
@@ -493,5 +445,4 @@ func MonitorChildBy(resourceName, funcNameSuffix, childResourceName string, moni
 			},
 		},
 	}
-	return o
 }

--- a/internal/define/packet_filter.go
+++ b/internal/define/packet_filter.go
@@ -1,6 +1,7 @@
 package define
 
 import (
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -38,6 +39,8 @@ var (
 	packetFilterNakedType = meta.Static(naked.PacketFilter{})
 
 	packetFilterView = &schema.Model{
+		Name:      packetFilterAPIName,
+		NakedType: packetFilterNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -50,6 +53,8 @@ var (
 	}
 
 	packetFilterCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(packetFilterAPIName),
+		NakedType: packetFilterNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),
@@ -58,6 +63,8 @@ var (
 	}
 
 	packetFilterUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(packetFilterAPIName),
+		NakedType: packetFilterNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/server.go
+++ b/internal/define/server.go
@@ -133,7 +133,8 @@ var (
 	serverNakedType = meta.Static(naked.Server{})
 
 	serverView = &schema.Model{
-		Name: "Server",
+		Name:      serverAPIName,
+		NakedType: serverNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -190,6 +191,8 @@ var (
 	}
 
 	serverCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(serverAPIName),
+		NakedType: serverNakedType,
 		Fields: []*schema.FieldDesc{
 			// server plan
 			fields.ServerPlanCPU(),
@@ -230,6 +233,8 @@ var (
 	}
 
 	serverUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(serverAPIName),
+		NakedType: serverNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/sim.go
+++ b/internal/define/sim.go
@@ -3,6 +3,7 @@ package define
 import (
 	"net/http"
 
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -161,6 +162,8 @@ var (
 	simNakedType = meta.Static(naked.SIM{})
 
 	simView = &schema.Model{
+		Name:      simAPIName,
+		NakedType: simNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -176,6 +179,8 @@ var (
 	}
 
 	simCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(simAPIName),
+		NakedType: simNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),
@@ -188,6 +193,8 @@ var (
 	}
 
 	simUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(simAPIName),
+		NakedType: simNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/switch.go
+++ b/internal/define/switch.go
@@ -3,6 +3,7 @@ package define
 import (
 	"net/http"
 
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -51,6 +52,8 @@ var (
 	switchNakedType = meta.Static(naked.Switch{})
 
 	switchView = &schema.Model{
+		Name:      switchAPIName,
+		NakedType: switchNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -75,6 +78,8 @@ var (
 	}
 
 	switchCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(switchAPIName),
+		NakedType: switchNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.UserSubnetNetworkMaskLen(),
@@ -86,6 +91,8 @@ var (
 	}
 
 	switchUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(switchAPIName),
+		NakedType: switchNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.UserSubnetNetworkMaskLen(),

--- a/internal/define/vpc_router.go
+++ b/internal/define/vpc_router.go
@@ -3,6 +3,7 @@ package define
 import (
 	"net/http"
 
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/schema"
 	"github.com/sacloud/libsacloud/v2/internal/schema/meta"
@@ -74,6 +75,8 @@ var (
 	vpcRouterNakedType = meta.Static(naked.VPCRouter{})
 
 	vpcRouterView = &schema.Model{
+		Name:      vpcRouterAPIName,
+		NakedType: vpcRouterNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),
@@ -110,6 +113,8 @@ var (
 	}
 
 	vpcRouterCreateParam = &schema.Model{
+		Name:      names.CreateParameterName(vpcRouterAPIName),
+		NakedType: vpcRouterNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.VPCRouterClass(),
 			fields.Name(),
@@ -149,6 +154,8 @@ var (
 	}
 
 	vpcRouterUpdateParam = &schema.Model{
+		Name:      names.UpdateParameterName(vpcRouterAPIName),
+		NakedType: vpcRouterNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.Name(),
 			fields.Description(),

--- a/internal/define/zone.go
+++ b/internal/define/zone.go
@@ -26,6 +26,8 @@ var zoneAPI = &schema.Resource{
 var (
 	zoneNakedType = meta.Static(naked.Zone{})
 	zoneView      = &schema.Model{
+		Name:      zoneAPIName,
+		NakedType: zoneNakedType,
 		Fields: []*schema.FieldDesc{
 			fields.ID(),
 			fields.Name(),

--- a/internal/schema/operation_test.go
+++ b/internal/schema/operation_test.go
@@ -13,7 +13,7 @@ func TestOperation(t *testing.T) {
 	resource := &Resource{
 		Name: "Test",
 	}
-	resources.Def(resource)
+	resources.Define(resource)
 
 	type expectOperationValues struct {
 		methodName                 string

--- a/internal/schema/resource.go
+++ b/internal/schema/resource.go
@@ -23,8 +23,8 @@ func (r Resources) ImportStatementsForModelDef(additionalImports ...string) []st
 	return uniqStrings(ss)
 }
 
-// Def リソースの定義
-func (r *Resources) Def(rs *Resource) {
+// Define リソースの定義
+func (r *Resources) Define(rs *Resource) {
 	if *r == nil {
 		rr := Resources{}
 		*r = rr

--- a/internal/tools/gen-api-envelope/main.go
+++ b/internal/tools/gen-api-envelope/main.go
@@ -20,7 +20,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), outputPath),
 		Template:   tmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", outputPath)
 

--- a/internal/tools/gen-api-fake-op/main.go
+++ b/internal/tools/gen-api-fake-op/main.go
@@ -27,13 +27,13 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), outputPath),
 		Template:   apisTmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", outputPath)
 
 	// generate funcs
 	schema.IsOutOfSacloudPackage = true
-	for _, resource := range define.Resources {
+	for _, resource := range define.APIs {
 		dest := fmt.Sprintf(opsDestination, resource.FileSafeName())
 		wrote := tools.WriteFileWithTemplate(&tools.TemplateConfig{
 			OutputPath:         filepath.Join(tools.ProjectRootPath(), dest),
@@ -51,7 +51,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), outputPath),
 		Template:   testTmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", outputPath)
 

--- a/internal/tools/gen-api-fake-store/main.go
+++ b/internal/tools/gen-api-fake-store/main.go
@@ -22,7 +22,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), destination),
 		Template:   tmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", filepath.Join(destination))
 }

--- a/internal/tools/gen-api-interfaces/main.go
+++ b/internal/tools/gen-api-interfaces/main.go
@@ -19,7 +19,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), destination),
 		Template:   tmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", filepath.Join(destination))
 }

--- a/internal/tools/gen-api-meta/main.go
+++ b/internal/tools/gen-api-meta/main.go
@@ -20,7 +20,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), outputPath),
 		Template:   tmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", outputPath)
 }

--- a/internal/tools/gen-api-models/main.go
+++ b/internal/tools/gen-api-models/main.go
@@ -20,7 +20,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), outputPath),
 		Template:   tmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", outputPath)
 }

--- a/internal/tools/gen-api-op/main.go
+++ b/internal/tools/gen-api-op/main.go
@@ -20,7 +20,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), outputPath),
 		Template:   tmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", outputPath)
 }

--- a/internal/tools/gen-api-result/main.go
+++ b/internal/tools/gen-api-result/main.go
@@ -20,7 +20,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), outputPath),
 		Template:   tmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", outputPath)
 

--- a/internal/tools/gen-api-stub/main.go
+++ b/internal/tools/gen-api-stub/main.go
@@ -22,7 +22,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), destination),
 		Template:   tmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", filepath.Join(destination))
 }

--- a/internal/tools/gen-api-tracer/main.go
+++ b/internal/tools/gen-api-tracer/main.go
@@ -22,7 +22,7 @@ func main() {
 	tools.WriteFileWithTemplate(&tools.TemplateConfig{
 		OutputPath: filepath.Join(tools.ProjectRootPath(), destination),
 		Template:   tmpl,
-		Parameter:  define.Resources,
+		Parameter:  define.APIs,
 	})
 	log.Printf("generated: %s\n", filepath.Join(destination))
 }


### PR DESCRIPTION
`internal/define/ops`配下のAPI定義ヘルパー郡でOperationの各フィールドの値を暗黙的に操作するのをやめ、定義時に明示的に設定するようにリファクタする。