### PR TITLE
テスト実行時のAPIトレース

### DIFF
--- a/internal/tools/gen-api-tracer/main.go
+++ b/internal/tools/gen-api-tracer/main.go
@@ -37,8 +37,16 @@ import (
 {{- end }}
 )
 
-{{ range . }} {{ $typeName := .TypeName }}
+// AddClientFactoryHooks add client factory hooks
+func AddClientFactoryHooks() {
+{{ range . -}} 
+	sacloud.AddClientFacotyHookFunc("{{.TypeName}}", func(in interface{}) interface{} {
+		return New{{.TypeName}}Tracer(in.(sacloud.{{.TypeName}}API))
+	})
+{{ end -}}
+}
 
+{{ range . }} {{$typeName := .TypeName}}
 /************************************************* 
 * {{ $typeName }}Tracer
 *************************************************/

--- a/sacloud/test/package_test.go
+++ b/sacloud/test/package_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/accessor"
 	"github.com/sacloud/libsacloud/v2/sacloud/fake"
+	"github.com/sacloud/libsacloud/v2/sacloud/trace"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
@@ -47,6 +48,14 @@ func singletonAPICaller() sacloud.APICaller {
 	return apiCaller
 }
 
+func isAccTest() bool {
+	return os.Getenv("TESTACC") != ""
+}
+
+func isEnableTrace() bool {
+	return os.Getenv("SAKURACLOUD_TRACE") != ""
+}
+
 func TestMain(m *testing.M) {
 	testZone = os.Getenv("SAKURACLOUD_ZONE")
 	if testZone == "" {
@@ -56,6 +65,10 @@ func TestMain(m *testing.M) {
 	if !isAccTest() {
 		sacloud.DefaultStatePollInterval = 100 * time.Millisecond
 		fake.SwitchFactoryFuncToFake()
+	}
+
+	if isEnableTrace() {
+		trace.AddClientFactoryHooks()
 	}
 
 	ret := m.Run()

--- a/sacloud/test/testing_test.go
+++ b/sacloud/test/testing_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func isAccTest() bool {
-	return os.Getenv("TESTACC") == "1"
-}
-
 // TestT テストのライフサイクルを管理するためのインターフェース.
 //
 // 通常は*testing.Tを実装として利用する

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -11,6 +11,61 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
+// AddClientFactoryHooks add client factory hooks
+func AddClientFactoryHooks() {
+	sacloud.AddClientFacotyHookFunc("Archive", func(in interface{}) interface{} {
+		return NewArchiveTracer(in.(sacloud.ArchiveAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("AuthStatus", func(in interface{}) interface{} {
+		return NewAuthStatusTracer(in.(sacloud.AuthStatusAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("Bridge", func(in interface{}) interface{} {
+		return NewBridgeTracer(in.(sacloud.BridgeAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("CDROM", func(in interface{}) interface{} {
+		return NewCDROMTracer(in.(sacloud.CDROMAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("Disk", func(in interface{}) interface{} {
+		return NewDiskTracer(in.(sacloud.DiskAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("GSLB", func(in interface{}) interface{} {
+		return NewGSLBTracer(in.(sacloud.GSLBAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("Interface", func(in interface{}) interface{} {
+		return NewInterfaceTracer(in.(sacloud.InterfaceAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("Internet", func(in interface{}) interface{} {
+		return NewInternetTracer(in.(sacloud.InternetAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("LoadBalancer", func(in interface{}) interface{} {
+		return NewLoadBalancerTracer(in.(sacloud.LoadBalancerAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("NFS", func(in interface{}) interface{} {
+		return NewNFSTracer(in.(sacloud.NFSAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("Note", func(in interface{}) interface{} {
+		return NewNoteTracer(in.(sacloud.NoteAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("PacketFilter", func(in interface{}) interface{} {
+		return NewPacketFilterTracer(in.(sacloud.PacketFilterAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("Server", func(in interface{}) interface{} {
+		return NewServerTracer(in.(sacloud.ServerAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("SIM", func(in interface{}) interface{} {
+		return NewSIMTracer(in.(sacloud.SIMAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("Switch", func(in interface{}) interface{} {
+		return NewSwitchTracer(in.(sacloud.SwitchAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("VPCRouter", func(in interface{}) interface{} {
+		return NewVPCRouterTracer(in.(sacloud.VPCRouterAPI))
+	})
+	sacloud.AddClientFacotyHookFunc("Zone", func(in interface{}) interface{} {
+		return NewZoneTracer(in.(sacloud.ZoneAPI))
+	})
+}
+
 /*************************************************
 * ArchiveTracer
 *************************************************/


### PR DESCRIPTION
環境変数`SAKURACLOUD_TRACE`を設定することでテスト実行時にAPIトレースログを出力可能にする。
(`SAKURACLOUD_TRACE`が空でない場合にトレースを有効化)

このために、sacloudパッケージでのクライアントファクトリにフックを登録可能とする。
トレース用のフック登録処理はコード生成されるので、必要に応じて利用者側で呼ぶようにする。