### PR TITLE
テストコードの改善

### DIFF
--- a/sacloud/test/archive_op_test.go
+++ b/sacloud/test/archive_op_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestArchiveOpCRUD(t *testing.T) {
@@ -40,27 +40,27 @@ func TestArchiveOpCRUD(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testArchiveCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createArchiveExpected,
 				IgnoreFields: ignoreArchiveFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testArchiveRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createArchiveExpected,
 				IgnoreFields: ignoreArchiveFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testArchiveUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateArchiveExpected,
 					IgnoreFields: ignoreArchiveFields,
-				},
+				}),
 			},
 		},
 
@@ -137,18 +137,33 @@ func testArchiveDelete(testContext *CRUDTestContext, caller sacloud.APICaller) e
 }
 
 func TestArchiveOp_CreateBlank(t *testing.T) {
-	t.Parallel()
+	Run(t, &CRUDTestCase{
+		Parallel:           true,
+		IgnoreStartupWait:  true,
+		SetupAPICallerFunc: singletonAPICaller,
+		Create: &CRUDTestFunc{
+			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				client := sacloud.NewArchiveOp(singletonAPICaller())
+				archive, ftpServer, err := client.CreateBlank(context.Background(), testZone, &sacloud.ArchiveCreateBlankRequest{
+					SizeMB: 20 * 1024,
+					Name:   "libsacloud-archive-blank",
+				})
 
-	client := sacloud.NewArchiveOp(singletonAPICaller())
+				if err != nil {
+					return nil, err
+				}
 
-	archive, ftpServer, err := client.CreateBlank(context.Background(), testZone, &sacloud.ArchiveCreateBlankRequest{
-		SizeMB: 20 * 1024,
-		Name:   "libsacloud-archive-blank",
+				assert.NotNil(t, archive)
+				assert.NotNil(t, ftpServer)
+
+				return archive, err
+			},
+		},
+		Delete: &CRUDTestDeleteFunc{
+			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) error {
+				client := sacloud.NewArchiveOp(singletonAPICaller())
+				return client.Delete(context.Background(), testZone, testContext.ID)
+			},
+		},
 	})
-	require.NoError(t, err)
-	require.NotNil(t, archive)
-	require.NotNil(t, ftpServer)
-	defer func() {
-		client.Delete(context.Background(), testZone, archive.ID) // nolint ignore error
-	}()
 }

--- a/sacloud/test/archive_op_test.go
+++ b/sacloud/test/archive_op_test.go
@@ -54,11 +54,13 @@ func TestArchiveOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testArchiveUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateArchiveExpected,
-				IgnoreFields: ignoreArchiveFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testArchiveUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateArchiveExpected,
+					IgnoreFields: ignoreArchiveFields,
+				},
 			},
 		},
 

--- a/sacloud/test/auth_status_op_test.go
+++ b/sacloud/test/auth_status_op_test.go
@@ -9,9 +9,18 @@ import (
 )
 
 func TestAuthStatusOp_Read(t *testing.T) {
-	client := sacloud.NewAuthStatusOp(singletonAPICaller())
+	Run(t, &CRUDTestCase{
+		Parallel:           true,
+		SetupAPICallerFunc: singletonAPICaller,
+		Read: &CRUDTestFunc{
+			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				client := sacloud.NewAuthStatusOp(singletonAPICaller())
+				authStatus, err := client.Read(context.Background(), sacloud.APIDefaultZone)
 
-	authStatus, err := client.Read(context.Background(), sacloud.APIDefaultZone)
-	require.NoError(t, err)
-	require.NotNil(t, authStatus)
+				require.NotNil(t, authStatus)
+
+				return nil, err
+			},
+		},
+	})
 }

--- a/sacloud/test/auth_status_op_test.go
+++ b/sacloud/test/auth_status_op_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthStatusOp_Read(t *testing.T) {
@@ -17,7 +17,7 @@ func TestAuthStatusOp_Read(t *testing.T) {
 				client := sacloud.NewAuthStatusOp(singletonAPICaller())
 				authStatus, err := client.Read(context.Background(), sacloud.APIDefaultZone)
 
-				require.NotNil(t, authStatus)
+				assert.NotNil(t, authStatus)
 
 				return nil, err
 			},

--- a/sacloud/test/auto_backup_op_test.go
+++ b/sacloud/test/auto_backup_op_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAutoBackupOpCRUD(t *testing.T) {
@@ -22,12 +22,16 @@ func TestAutoBackupOpCRUD(t *testing.T) {
 				SizeMB:     20 * 1024,
 				DiskPlanID: types.ID(4), //SSD
 			})
-			require.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return err
+			}
 
 			_, err = sacloud.WaiterForReady(func() (interface{}, error) {
 				return diskOp.Read(context.Background(), testZone, disk.ID)
 			}).WaitForState(context.Background())
-			require.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return err
+			}
 
 			testContext.Values["autobackup/disk"] = disk.ID
 			createAutoBackupParam.DiskID = disk.ID
@@ -38,27 +42,27 @@ func TestAutoBackupOpCRUD(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testAutoBackupCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createAutoBackupExpected,
 				IgnoreFields: ignoreAutoBackupFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testAutoBackupRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createAutoBackupExpected,
 				IgnoreFields: ignoreAutoBackupFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testAutoBackupUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateAutoBackupExpected,
 					IgnoreFields: ignoreAutoBackupFields,
-				},
+				}),
 			},
 		},
 

--- a/sacloud/test/auto_backup_op_test.go
+++ b/sacloud/test/auto_backup_op_test.go
@@ -52,11 +52,13 @@ func TestAutoBackupOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testAutoBackupUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateAutoBackupExpected,
-				IgnoreFields: ignoreAutoBackupFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testAutoBackupUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateAutoBackupExpected,
+					IgnoreFields: ignoreAutoBackupFields,
+				},
 			},
 		},
 

--- a/sacloud/test/bridge_op_test.go
+++ b/sacloud/test/bridge_op_test.go
@@ -15,27 +15,27 @@ func TestBridgeOpCRUD(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testBridgeCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createBridgeExpected,
 				IgnoreFields: ignoreBridgeFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testBridgeRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createBridgeExpected,
 				IgnoreFields: ignoreBridgeFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testBridgeUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateBridgeExpected,
 					IgnoreFields: ignoreBridgeFields,
-				},
+				}),
 			},
 		},
 

--- a/sacloud/test/bridge_op_test.go
+++ b/sacloud/test/bridge_op_test.go
@@ -29,11 +29,13 @@ func TestBridgeOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testBridgeUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateBridgeExpected,
-				IgnoreFields: ignoreBridgeFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testBridgeUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateBridgeExpected,
+					IgnoreFields: ignoreBridgeFields,
+				},
 			},
 		},
 

--- a/sacloud/test/disk_op_test.go
+++ b/sacloud/test/disk_op_test.go
@@ -32,11 +32,13 @@ func TestDiskOpBlankDiskCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testDiskUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateDiskExpected,
-				IgnoreFields: ignoreDiskFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testDiskUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateDiskExpected,
+					IgnoreFields: ignoreDiskFields,
+				},
 			},
 		},
 

--- a/sacloud/test/disk_op_test.go
+++ b/sacloud/test/disk_op_test.go
@@ -2,12 +2,12 @@ package test
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"testing"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDiskOpBlankDiskCRUD(t *testing.T) {
@@ -18,27 +18,27 @@ func TestDiskOpBlankDiskCRUD(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testDiskCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createDiskExpected,
 				IgnoreFields: ignoreDiskFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testDiskRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createDiskExpected,
 				IgnoreFields: ignoreDiskFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testDiskUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateDiskExpected,
 					IgnoreFields: ignoreDiskFields,
-				},
+				}),
 			},
 		},
 
@@ -119,71 +119,82 @@ func testDiskDelete(testContext *CRUDTestContext, caller sacloud.APICaller) erro
 }
 
 func TestDiskOp_Config(t *testing.T) {
-	t.Parallel()
 
-	archiveClient := sacloud.NewArchiveOp(singletonAPICaller())
-	client := sacloud.NewDiskOp(singletonAPICaller())
-	ctx := context.Background()
-
-	// find source public archive
+	// source archive
 	var archiveID types.ID
-	archiveFindResult, err := archiveClient.Find(ctx, testZone, nil)
-	require.NoError(t, err)
-	for _, a := range archiveFindResult.Archives {
-		if strings.HasPrefix(a.Name, "CentOS 7") {
-			archiveID = a.ID
-			break
-		}
-	}
-	if archiveID.IsEmpty() {
-		t.Fatal("archive is not found")
-	}
 
-	// create
-	disk, err := client.Create(ctx, testZone, &sacloud.DiskCreateRequest{
-		Name:            "libsacloud-disk-edit",
-		DiskPlanID:      types.ID(4),
-		SizeMB:          20 * 1024,
-		SourceArchiveID: archiveID,
-	})
-	require.NoError(t, err)
+	Run(t, &CRUDTestCase{
+		Parallel:           true,
+		SetupAPICallerFunc: singletonAPICaller,
+		Setup: func(testContext *CRUDTestContext, caller sacloud.APICaller) error {
+			archiveName := "CentOS"
+			client := sacloud.NewArchiveOp(singletonAPICaller())
+			searched, err := client.Find(context.Background(), testZone, &sacloud.FindCondition{
+				Filter: map[string]interface{}{
+					"Name": archiveName,
+				},
+			})
+			if !assert.NoError(t, err) {
+				return err
+			}
+			if searched.Count == 0 {
+				return errors.New("archive is not found")
+			}
+			archiveID = searched.Archives[0].ID
+			return nil
+		},
+		Create: &CRUDTestFunc{
+			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				client := sacloud.NewDiskOp(singletonAPICaller())
+				disk, err := client.Create(context.Background(), testZone, &sacloud.DiskCreateRequest{
+					Name:            "libsacloud-disk-edit",
+					DiskPlanID:      types.ID(4),
+					SizeMB:          20 * 1024,
+					SourceArchiveID: archiveID,
+				})
+				if err != nil {
+					return nil, err
+				}
+				if _, err = sacloud.WaiterForReady(func() (interface{}, error) {
+					return client.Read(context.Background(), testZone, disk.ID)
+				}).WaitForState(context.TODO()); err != nil {
+					return disk, err
+				}
 
-	// wait for ready
-	waiter := sacloud.WaiterForReady(func() (interface{}, error) {
-		return client.Read(ctx, testZone, disk.ID)
-	})
-	_, err = waiter.WaitForState(ctx)
-	require.NoError(t, err)
-
-	defer func() {
-		// cleanup
-		if err := client.Delete(ctx, testZone, disk.ID); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	// edit disk
-	err = client.Config(context.Background(), testZone, disk.ID, &sacloud.DiskEditRequest{
-		Password: "password",
-		SSHKeys: []*sacloud.DiskEditSSHKey{
-			{
-				PublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4LDQuDiKecOJDPY9InS7EswZ2fPnoRZXc48T1EqyRLyJhgEYGSDWaBiMDs2R/lWgA81Hp37qhrNqZPjFHUkBr93FOXxt9W0m1TNlkNepK0Uyi+14B2n0pdoeqsKEkb3sTevWF0ztxxWrwUd7Mems2hf+wFODITHYye9RlDAKLKPCFRvlQ9xQj4bBWOogQwoaXMSK1znMPjudcm1tRry4KIifLdXmwVKU4qDPGxoXfqs44Dgsikk43UVBStQ7IFoqPgAqcJFSGHLoMS7tPKdTvY9+GME5QidWK84gl69piAkgIdwd+JTMUOc/J+9DXAt220HqZ6l3yhWG5nIgi0x8n",
+				return disk, nil
 			},
 		},
-		DisablePWAuth: true,
-		EnableDHCP:    true,
-		HostName:      "hostname",
-		//Notes: []*DiskEditNote{
-		//	{
-		//		ID: types.ID(123456789012),
-		//	},
-		//},
-		UserIPAddress: "192.2.0.11",
-		UserSubnet: &sacloud.DiskEditUserSubnet{
-			DefaultRoute:   "192.2.0.1",
-			NetworkMaskLen: 24,
+		Read: &CRUDTestFunc{
+			Func: testDiskRead,
+		},
+		Updates: []*CRUDTestFunc{
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					// edit disk
+					client := sacloud.NewDiskOp(singletonAPICaller())
+					err := client.Config(context.Background(), testZone, testContext.ID, &sacloud.DiskEditRequest{
+						Password: "password",
+						SSHKeys: []*sacloud.DiskEditSSHKey{
+							{
+								PublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4LDQuDiKecOJDPY9InS7EswZ2fPnoRZXc48T1EqyRLyJhgEYGSDWaBiMDs2R/lWgA81Hp37qhrNqZPjFHUkBr93FOXxt9W0m1TNlkNepK0Uyi+14B2n0pdoeqsKEkb3sTevWF0ztxxWrwUd7Mems2hf+wFODITHYye9RlDAKLKPCFRvlQ9xQj4bBWOogQwoaXMSK1znMPjudcm1tRry4KIifLdXmwVKU4qDPGxoXfqs44Dgsikk43UVBStQ7IFoqPgAqcJFSGHLoMS7tPKdTvY9+GME5QidWK84gl69piAkgIdwd+JTMUOc/J+9DXAt220HqZ6l3yhWG5nIgi0x8n",
+							},
+						},
+						DisablePWAuth: true,
+						EnableDHCP:    true,
+						HostName:      "hostname",
+						UserIPAddress: "192.2.0.11",
+						UserSubnet: &sacloud.DiskEditUserSubnet{
+							DefaultRoute:   "192.2.0.1",
+							NetworkMaskLen: 24,
+						},
+					})
+					return nil, err
+				},
+			},
+		},
+		Delete: &CRUDTestDeleteFunc{
+			Func: testDiskDelete,
 		},
 	})
-	require.NoError(t, err)
 
 }

--- a/sacloud/test/dns_op_test.go
+++ b/sacloud/test/dns_op_test.go
@@ -30,11 +30,13 @@ func TestDNSOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testDNSUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateDNSExpected,
-				IgnoreFields: ignoreDNSFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testDNSUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateDNSExpected,
+					IgnoreFields: ignoreDNSFields,
+				},
 			},
 		},
 

--- a/sacloud/test/dns_op_test.go
+++ b/sacloud/test/dns_op_test.go
@@ -16,27 +16,27 @@ func TestDNSOpCRUD(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testDNSCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createDNSExpected,
 				IgnoreFields: ignoreDNSFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testDNSRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createDNSExpected,
 				IgnoreFields: ignoreDNSFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testDNSUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateDNSExpected,
 					IgnoreFields: ignoreDNSFields,
-				},
+				}),
 			},
 		},
 

--- a/sacloud/test/gslb_op_test.go
+++ b/sacloud/test/gslb_op_test.go
@@ -30,11 +30,13 @@ func TestGSLBOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testGSLBUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateGSLBExpected,
-				IgnoreFields: ignoreGSLBFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testGSLBUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateGSLBExpected,
+					IgnoreFields: ignoreGSLBFields,
+				},
 			},
 		},
 

--- a/sacloud/test/gslb_op_test.go
+++ b/sacloud/test/gslb_op_test.go
@@ -16,27 +16,27 @@ func TestGSLBOpCRUD(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testGSLBCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createGSLBExpected,
 				IgnoreFields: ignoreGSLBFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testGSLBRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createGSLBExpected,
 				IgnoreFields: ignoreGSLBFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testGSLBUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateGSLBExpected,
 					IgnoreFields: ignoreGSLBFields,
-				},
+				}),
 			},
 		},
 

--- a/sacloud/test/interface_op_test.go
+++ b/sacloud/test/interface_op_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestInterface_Operations(t *testing.T) {
@@ -28,7 +28,9 @@ func TestInterface_Operations(t *testing.T) {
 				ServerPlanCommitment: types.Commitments.Standard,
 				Name:                 "libsacloud-server-with-interface",
 			})
-			require.NoError(t, err)
+			if !assert.NoError(t, err) {
+				return err
+			}
 
 			testContext.Values["interface/server"] = server.ID
 			createInterfaceParam.ServerID = server.ID
@@ -39,25 +41,25 @@ func TestInterface_Operations(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testInterfaceCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createInterfaceExpected,
 				IgnoreFields: ignoreInterfaceFields,
-			},
+			}),
 		},
 		Read: &CRUDTestFunc{
 			Func: testInterfaceRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createInterfaceExpected,
 				IgnoreFields: ignoreInterfaceFields,
-			},
+			}),
 		},
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testInterfaceUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateInterfaceExpected,
 					IgnoreFields: ignoreInterfaceFields,
-				},
+				}),
 			},
 		},
 		Delete: &CRUDTestDeleteFunc{

--- a/sacloud/test/interface_op_test.go
+++ b/sacloud/test/interface_op_test.go
@@ -51,11 +51,13 @@ func TestInterface_Operations(t *testing.T) {
 				IgnoreFields: ignoreInterfaceFields,
 			},
 		},
-		Update: &CRUDTestFunc{
-			Func: testInterfaceUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateInterfaceExpected,
-				IgnoreFields: ignoreInterfaceFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testInterfaceUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateInterfaceExpected,
+					IgnoreFields: ignoreInterfaceFields,
+				},
 			},
 		},
 		Delete: &CRUDTestDeleteFunc{

--- a/sacloud/test/internet_op_test.go
+++ b/sacloud/test/internet_op_test.go
@@ -30,11 +30,13 @@ func TestInternetOpCRUD(t *testing.T) {
 				IgnoreFields: ignoreInternetFields,
 			},
 		},
-		Update: &CRUDTestFunc{
-			Func: testInternetUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateInternetExpected,
-				IgnoreFields: ignoreInternetFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testInternetUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateInternetExpected,
+					IgnoreFields: ignoreInternetFields,
+				},
 			},
 		},
 		Delete: &CRUDTestDeleteFunc{

--- a/sacloud/test/load_balancer_op_test.go
+++ b/sacloud/test/load_balancer_op_test.go
@@ -30,11 +30,13 @@ func TestLoadBalancerOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testLoadBalancerUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateLoadBalancerExpected,
-				IgnoreFields: ignoreLoadBalancerFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testLoadBalancerUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateLoadBalancerExpected,
+					IgnoreFields: ignoreLoadBalancerFields,
+				},
 			},
 		},
 

--- a/sacloud/test/load_balancer_op_test.go
+++ b/sacloud/test/load_balancer_op_test.go
@@ -16,27 +16,27 @@ func TestLoadBalancerOpCRUD(t *testing.T) {
 		Setup:              setupSwitchFunc("lb", createLoadBalancerParam, createLoadBalancerExpected, updateLoadBalancerExpected),
 		Create: &CRUDTestFunc{
 			Func: testLoadBalancerCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createLoadBalancerExpected,
 				IgnoreFields: ignoreLoadBalancerFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testLoadBalancerRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createLoadBalancerExpected,
 				IgnoreFields: ignoreLoadBalancerFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testLoadBalancerUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateLoadBalancerExpected,
 					IgnoreFields: ignoreLoadBalancerFields,
-				},
+				}),
 			},
 		},
 

--- a/sacloud/test/nfs_op_test.go
+++ b/sacloud/test/nfs_op_test.go
@@ -45,11 +45,13 @@ func TestNFSOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testNFSUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateNFSExpected,
-				IgnoreFields: ignoreNFSFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testNFSUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateNFSExpected,
+					IgnoreFields: ignoreNFSFields,
+				},
 			},
 		},
 

--- a/sacloud/test/nfs_op_test.go
+++ b/sacloud/test/nfs_op_test.go
@@ -31,27 +31,27 @@ func TestNFSOpCRUD(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testNFSCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createNFSExpected,
 				IgnoreFields: ignoreNFSFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testNFSRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createNFSExpected,
 				IgnoreFields: ignoreNFSFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testNFSUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateNFSExpected,
 					IgnoreFields: ignoreNFSFields,
-				},
+				}),
 			},
 		},
 

--- a/sacloud/test/note_op_test.go
+++ b/sacloud/test/note_op_test.go
@@ -28,11 +28,13 @@ func TestNoteOpCRUD(t *testing.T) {
 				IgnoreFields: []string{"ID", "CreatedAt", "ModifiedAt"},
 			},
 		},
-		Update: &CRUDTestFunc{
-			Func: testNoteUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateNoteExpected,
-				IgnoreFields: []string{"ID", "CreatedAt", "ModifiedAt"},
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testNoteUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateNoteExpected,
+					IgnoreFields: []string{"ID", "CreatedAt", "ModifiedAt"},
+				},
 			},
 		},
 		Delete: &CRUDTestDeleteFunc{

--- a/sacloud/test/note_op_test.go
+++ b/sacloud/test/note_op_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNoteOpCRUD(t *testing.T) {
@@ -16,25 +15,25 @@ func TestNoteOpCRUD(t *testing.T) {
 		SetupAPICallerFunc: singletonAPICaller,
 		Create: &CRUDTestFunc{
 			Func: testNoteCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createNoteExpected,
 				IgnoreFields: []string{"ID", "CreatedAt", "ModifiedAt"},
-			},
+			}),
 		},
 		Read: &CRUDTestFunc{
 			Func: testNoteRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createNoteExpected,
 				IgnoreFields: []string{"ID", "CreatedAt", "ModifiedAt"},
-			},
+			}),
 		},
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testNoteUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateNoteExpected,
 					IgnoreFields: []string{"ID", "CreatedAt", "ModifiedAt"},
-				},
+				}),
 			},
 		},
 		Delete: &CRUDTestDeleteFunc{
@@ -92,14 +91,4 @@ func testNoteUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (int
 func testNoteDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewNoteOp(caller)
 	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
-}
-
-func TestNoteOp_Find(t *testing.T) {
-	t.Parallel()
-
-	client := sacloud.NewNoteOp(singletonAPICaller())
-
-	noteFindResult, err := client.Find(context.Background(), sacloud.APIDefaultZone, &sacloud.FindCondition{Count: 1})
-	require.NoError(t, err)
-	require.Len(t, noteFindResult.Notes, 1)
 }

--- a/sacloud/test/packet_filter_op_test.go
+++ b/sacloud/test/packet_filter_op_test.go
@@ -27,11 +27,13 @@ func TestPacketFilterOpCRUD(t *testing.T) {
 				IgnoreFields: packetFilterIgnoreFields,
 			},
 		},
-		Update: &CRUDTestFunc{
-			Func: testPacketFilterUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updatePacketFilterExpected,
-				IgnoreFields: packetFilterIgnoreFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testPacketFilterUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updatePacketFilterExpected,
+					IgnoreFields: packetFilterIgnoreFields,
+				},
 			},
 		},
 		Delete: &CRUDTestDeleteFunc{

--- a/sacloud/test/packet_filter_op_test.go
+++ b/sacloud/test/packet_filter_op_test.go
@@ -15,25 +15,25 @@ func TestPacketFilterOpCRUD(t *testing.T) {
 		SetupAPICallerFunc: singletonAPICaller,
 		Create: &CRUDTestFunc{
 			Func: testPacketFilterCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createPacketFilterExpected,
 				IgnoreFields: packetFilterIgnoreFields,
-			},
+			}),
 		},
 		Read: &CRUDTestFunc{
 			Func: testPacketFilterRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createPacketFilterExpected,
 				IgnoreFields: packetFilterIgnoreFields,
-			},
+			}),
 		},
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testPacketFilterUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updatePacketFilterExpected,
 					IgnoreFields: packetFilterIgnoreFields,
-				},
+				}),
 			},
 		},
 		Delete: &CRUDTestDeleteFunc{

--- a/sacloud/test/proxylb_op_test.go
+++ b/sacloud/test/proxylb_op_test.go
@@ -40,11 +40,13 @@ func TestProxyLBOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testProxyLBUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateProxyLBExpected,
-				IgnoreFields: ignoreProxyLBFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testProxyLBUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateProxyLBExpected,
+					IgnoreFields: ignoreProxyLBFields,
+				},
 			},
 		},
 

--- a/sacloud/test/proxylb_op_test.go
+++ b/sacloud/test/proxylb_op_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestProxyLBOpCRUD(t *testing.T) {
@@ -26,27 +25,27 @@ func TestProxyLBOpCRUD(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testProxyLBCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createProxyLBExpected,
 				IgnoreFields: ignoreProxyLBFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testProxyLBRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createProxyLBExpected,
 				IgnoreFields: ignoreProxyLBFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testProxyLBUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateProxyLBExpected,
 					IgnoreFields: ignoreProxyLBFields,
-				},
+				}),
 			},
 		},
 
@@ -325,7 +324,9 @@ func TestProxyLBOpLetsEncryptAndHealth(t *testing.T) {
 
 	// create proxyLB
 	proxyLB, err := proxyLBOp.Create(ctx, sacloud.APIDefaultZone, createProxyLBForACMEParam)
-	require.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	defer func() {
 		proxyLBOp.Delete(ctx, sacloud.APIDefaultZone, proxyLB.ID) // nolint - ignore error
 	}()

--- a/sacloud/test/server_op_test.go
+++ b/sacloud/test/server_op_test.go
@@ -31,11 +31,13 @@ func TestServerOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testServerUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateServerExpected,
-				IgnoreFields: ignoreServerFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testServerUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateServerExpected,
+					IgnoreFields: ignoreServerFields,
+				},
 			},
 		},
 

--- a/sacloud/test/simple_monitor_op_test.go
+++ b/sacloud/test/simple_monitor_op_test.go
@@ -32,11 +32,13 @@ func TestSimpleMonitorOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testSimpleMonitorUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateSimpleMonitorExpected,
-				IgnoreFields: ignoreSimpleMonitorFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testSimpleMonitorUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateSimpleMonitorExpected,
+					IgnoreFields: ignoreSimpleMonitorFields,
+				},
 			},
 		},
 

--- a/sacloud/test/simple_monitor_op_test.go
+++ b/sacloud/test/simple_monitor_op_test.go
@@ -2,12 +2,13 @@ package test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSimpleMonitorOpCRUD(t *testing.T) {
@@ -18,27 +19,27 @@ func TestSimpleMonitorOpCRUD(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: testSimpleMonitorCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createSimpleMonitorExpected,
 				IgnoreFields: ignoreSimpleMonitorFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testSimpleMonitorRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createSimpleMonitorExpected,
 				IgnoreFields: ignoreSimpleMonitorFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testSimpleMonitorUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateSimpleMonitorExpected,
 					IgnoreFields: ignoreSimpleMonitorFields,
-				},
+				}),
 			},
 		},
 
@@ -147,31 +148,63 @@ func testSimpleMonitorDelete(testContext *CRUDTestContext, caller sacloud.APICal
 	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
 }
 
-func TestSimpleMonitorOpStatusAndHealth(t *testing.T) {
-	t.Parallel()
-
+func TestSimpleMonitorOp_StatusAndHealth(t *testing.T) {
 	client := sacloud.NewSimpleMonitorOp(singletonAPICaller())
 	ctx := context.Background()
 
-	// create
-	sm, err := client.Create(ctx, sacloud.APIDefaultZone, simpleMonitorStatusAndHealthTargetParam)
-	require.NoError(t, err)
-	defer func() {
-		client.Delete(ctx, sacloud.APIDefaultZone, sm.ID) // nolint - ignore error
-	}()
-	if isAccTest() {
-		time.Sleep(2 * time.Minute) // Statusの戻り値を確認するために数分待つ
-	}
+	Run(t, &CRUDTestCase{
+		Parallel: true,
 
-	// status
-	status, err := client.HealthStatus(ctx, sacloud.APIDefaultZone, sm.ID)
-	require.NoError(t, err)
-	require.NotNil(t, status)
+		SetupAPICallerFunc: singletonAPICaller,
 
-	// monitor
-	monitor, err := client.MonitorResponseTime(ctx, sacloud.APIDefaultZone, sm.ID, &sacloud.MonitorCondition{})
-	require.NoError(t, err)
-	require.NotNil(t, monitor)
+		Create: &CRUDTestFunc{
+			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				sm, err := client.Create(ctx, sacloud.APIDefaultZone, simpleMonitorStatusAndHealthTargetParam)
+				if err != nil {
+					return nil, err
+				}
+				if isAccTest() {
+					time.Sleep(2 * time.Minute) // Statusの戻り値を確認するために数分待つ
+				}
+				return sm, nil
+			},
+		},
+
+		Read: &CRUDTestFunc{
+			Func: testSimpleMonitorRead,
+		},
+
+		Updates: []*CRUDTestFunc{
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					return client.HealthStatus(ctx, sacloud.APIDefaultZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
+					healthStatus := v.(*sacloud.SimpleMonitorHealthStatus)
+					if !assert.NotNil(t, healthStatus) {
+						return errors.New("unexpected state: SimpleMonitorHealthStatus")
+					}
+					return nil
+				},
+			},
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					return client.MonitorResponseTime(ctx, sacloud.APIDefaultZone, testContext.ID, &sacloud.MonitorCondition{})
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
+					monitor := v.(*sacloud.ResponseTimeSecActivity)
+					if !assert.NotNil(t, monitor) {
+						return errors.New("unexpected state: ResponseTimeSecActivity")
+					}
+					return nil
+				},
+			},
+		},
+
+		Delete: &CRUDTestDeleteFunc{
+			Func: testSimpleMonitorDelete,
+		},
+	})
 }
 
 var simpleMonitorStatusAndHealthTargetParam = &sacloud.SimpleMonitorCreateRequest{

--- a/sacloud/test/switch_op_test.go
+++ b/sacloud/test/switch_op_test.go
@@ -28,11 +28,13 @@ func TestSwitchOpCRUD(t *testing.T) {
 				IgnoreFields: ignoreSwitchFields,
 			},
 		},
-		Update: &CRUDTestFunc{
-			Func: testSwitchUpdate,
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateSwitchExpected,
-				IgnoreFields: ignoreSwitchFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testSwitchUpdate,
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateSwitchExpected,
+					IgnoreFields: ignoreSwitchFields,
+				},
 			},
 		},
 		Delete: &CRUDTestDeleteFunc{

--- a/sacloud/test/switch_op_test.go
+++ b/sacloud/test/switch_op_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSwitchOpCRUD(t *testing.T) {
@@ -16,25 +15,25 @@ func TestSwitchOpCRUD(t *testing.T) {
 		SetupAPICallerFunc: singletonAPICaller,
 		Create: &CRUDTestFunc{
 			Func: testSwitchCreate,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createSwitchExpected,
 				IgnoreFields: ignoreSwitchFields,
-			},
+			}),
 		},
 		Read: &CRUDTestFunc{
 			Func: testSwitchRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createSwitchExpected,
 				IgnoreFields: ignoreSwitchFields,
-			},
+			}),
 		},
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testSwitchUpdate,
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateSwitchExpected,
 					IgnoreFields: ignoreSwitchFields,
-				},
+				}),
 			},
 		},
 		Delete: &CRUDTestDeleteFunc{
@@ -103,60 +102,120 @@ func testSwitchDelete(testContext *CRUDTestContext, caller sacloud.APICaller) er
 }
 
 func TestSwitchOp_BridgeConnection(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	caller := singletonAPICaller()
 
 	swOp := sacloud.NewSwitchOp(caller)
 	bridgeOp := sacloud.NewBridgeOp(caller)
 
-	// create switch
-	sw, err := swOp.Create(ctx, testZone, &sacloud.SwitchCreateRequest{
-		Name: "libsacloud-switch-for-bridge",
+	var bridgeID types.ID
+
+	Run(t, &CRUDTestCase{
+		Parallel:           true,
+		SetupAPICallerFunc: singletonAPICaller,
+		Create: &CRUDTestFunc{
+			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (i interface{}, e error) {
+				return swOp.Create(ctx, testZone, &sacloud.SwitchCreateRequest{
+					Name: "libsacloud-switch-for-bridge",
+				})
+			},
+		},
+		Read: &CRUDTestFunc{
+			Func: testSwitchRead,
+		},
+		Updates: []*CRUDTestFunc{
+			// bridge create and connect
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (i interface{}, e error) {
+					bridge, err := bridgeOp.Create(ctx, testZone, &sacloud.BridgeCreateRequest{
+						Name: "libsacloud-bridge",
+					})
+					if err != nil {
+						return nil, err
+					}
+					bridgeID = bridge.ID
+					return bridge, nil
+				},
+				SkipExtractID: true,
+			},
+			// connect
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (i interface{}, e error) {
+					// connect to bridge
+					if err := swOp.ConnectToBridge(ctx, testZone, testContext.ID, bridgeID); err != nil {
+						return nil, err
+					}
+					return nil, nil
+				},
+				SkipExtractID: true,
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					sw, err := swOp.Read(ctx, testZone, testContext.ID)
+					if err != nil {
+						return err
+					}
+					if err := AssertEqual(t, bridgeID, sw.BridgeID, "Switch.BridgeID"); err != nil {
+						return err
+					}
+
+					bridge, err := bridgeOp.Read(ctx, testZone, bridgeID)
+					if err != nil {
+						return err
+					}
+
+					if err := DoAsserts(
+						func() error { return AssertEqual(t, sw.ID, bridge.SwitchInZone.ID, "Bridge.SwitchInZone.ID") },
+						func() error { return AssertLen(t, bridge.BridgeInfo, 0, "Bridge.BridgeInfo") },
+					); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			// disconnect
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (i interface{}, e error) {
+					if err := swOp.DisconnectFromBridge(ctx, testZone, testContext.ID); err != nil {
+						return nil, err
+					}
+					return nil, nil
+				},
+				SkipExtractID: true,
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					sw, err := swOp.Read(ctx, testZone, testContext.ID)
+					if err != nil {
+						return err
+					}
+					if err := AssertTrue(t, sw.BridgeID.IsEmpty(), "Switch.BridgeID"); err != nil {
+						return err
+					}
+
+					bridge, err := bridgeOp.Read(ctx, testZone, bridgeID)
+					if err != nil {
+						return err
+					}
+
+					if err := DoAsserts(
+						func() error { return AssertNil(t, bridge.SwitchInZone, "Bridge.SwitchInZone") },
+						func() error { return AssertLen(t, bridge.BridgeInfo, 0, "Bridge.BridgeInfo") },
+					); err != nil {
+						return err
+					}
+					return nil
+				},
+			},
+			// bridge delete
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					if err := bridgeOp.Delete(ctx, testZone, bridgeID); err != nil {
+						return nil, err
+					}
+					return nil, nil
+				},
+				SkipExtractID: true,
+			},
+		},
+		Delete: &CRUDTestDeleteFunc{
+			Func: testSwitchDelete,
+		},
 	})
-	require.NoError(t, err)
-
-	bridge, err := bridgeOp.Create(ctx, testZone, &sacloud.BridgeCreateRequest{
-		Name: "libsacloud-bridge",
-	})
-	require.NoError(t, err)
-
-	// connect to bridge
-	err = swOp.ConnectToBridge(ctx, testZone, sw.ID, bridge.ID)
-	require.NoError(t, err)
-
-	// confirm
-	sw, err = swOp.Read(ctx, testZone, sw.ID)
-	require.NoError(t, err)
-	require.Equal(t, bridge.ID, sw.BridgeID)
-
-	bridge, err = bridgeOp.Read(ctx, testZone, bridge.ID)
-	require.NoError(t, err)
-
-	require.Equal(t, sw.ID, bridge.SwitchInZone.ID)
-	require.Len(t, bridge.BridgeInfo, 0) // 他ゾーンのスイッチのみ
-
-	// disconnect
-	err = swOp.DisconnectFromBridge(ctx, testZone, sw.ID)
-	require.NoError(t, err)
-
-	// confirm
-	sw, err = swOp.Read(ctx, testZone, sw.ID)
-	require.NoError(t, err)
-
-	require.True(t, sw.BridgeID.IsEmpty())
-
-	bridge, err = bridgeOp.Read(ctx, testZone, bridge.ID)
-	require.NoError(t, err)
-
-	require.Nil(t, bridge.SwitchInZone)
-	require.Len(t, bridge.BridgeInfo, 0)
-
-	// delete
-	err = swOp.Delete(ctx, testZone, sw.ID)
-	require.NoError(t, err)
-
-	err = bridgeOp.Delete(ctx, testZone, bridge.ID)
-	require.NoError(t, err)
 }

--- a/sacloud/test/vpc_router_op_test.go
+++ b/sacloud/test/vpc_router_op_test.go
@@ -29,11 +29,13 @@ func TestVPCRouterOpCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: testVPCRouterUpdate(updateVPCRouterParam),
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateVPCRouterExpected,
-				IgnoreFields: ignoreVPCRouterFields,
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testVPCRouterUpdate(updateVPCRouterParam),
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateVPCRouterExpected,
+					IgnoreFields: ignoreVPCRouterFields,
+				},
 			},
 		},
 
@@ -232,108 +234,110 @@ func TestVPCRouterOpWithRouterCRUD(t *testing.T) {
 			},
 		},
 
-		Update: &CRUDTestFunc{
-			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
-				vpcOp := sacloud.NewVPCRouterOp(caller)
-				ctx := context.Background()
+		Updates: []*CRUDTestFunc{
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					vpcOp := sacloud.NewVPCRouterOp(caller)
+					ctx := context.Background()
 
-				// shutdown
-				if err := vpcOp.Shutdown(ctx, testZone, testContext.ID, nil); err != nil {
-					return nil, err
-				}
-				_, err := sacloud.WaiterForDown(func() (interface{}, error) {
-					return vpcOp.Read(context.Background(), testZone, testContext.ID)
-				}).WaitForState(context.Background())
-				if err != nil {
-					return nil, err
-				}
+					// shutdown
+					if err := vpcOp.Shutdown(ctx, testZone, testContext.ID, nil); err != nil {
+						return nil, err
+					}
+					_, err := sacloud.WaiterForDown(func() (interface{}, error) {
+						return vpcOp.Read(context.Background(), testZone, testContext.ID)
+					}).WaitForState(context.Background())
+					if err != nil {
+						return nil, err
+					}
 
-				swOp := sacloud.NewSwitchOp(caller)
-				sw, err := swOp.Create(ctx, testZone, &sacloud.SwitchCreateRequest{
-					Name: "libsacloud-switch-for-vpc-router",
-				})
-				if err != nil {
-					return nil, err
-				}
-				testContext.Values["vpcrouter/switch"] = sw.ID
+					swOp := sacloud.NewSwitchOp(caller)
+					sw, err := swOp.Create(ctx, testZone, &sacloud.SwitchCreateRequest{
+						Name: "libsacloud-switch-for-vpc-router",
+					})
+					if err != nil {
+						return nil, err
+					}
+					testContext.Values["vpcrouter/switch"] = sw.ID
 
-				// connect to switch
-				if err := vpcOp.ConnectToSwitch(ctx, testZone, testContext.ID, 2, sw.ID); err != nil {
-					return nil, err
-				}
+					// connect to switch
+					if err := vpcOp.ConnectToSwitch(ctx, testZone, testContext.ID, 2, sw.ID); err != nil {
+						return nil, err
+					}
 
-				// setup update param
-				p := withRouterUpdateVPCRouterParam
-				p.Settings = &sacloud.VPCRouterSetting{
-					InternetConnectionEnabled: true,
-					Interfaces: []*sacloud.VPCRouterInterfaceSetting{
-						withRouterCreateVPCRouterParam.Settings.Interfaces[0],
-						{
-							VirtualIPAddress: "192.0.2.1",
-							IPAddress:        []string{"192.0.2.11", "192.0.2.12"},
-							NetworkMaskLen:   24,
-							Index:            2,
+					// setup update param
+					p := withRouterUpdateVPCRouterParam
+					p.Settings = &sacloud.VPCRouterSetting{
+						InternetConnectionEnabled: true,
+						Interfaces: []*sacloud.VPCRouterInterfaceSetting{
+							withRouterCreateVPCRouterParam.Settings.Interfaces[0],
+							{
+								VirtualIPAddress: "192.0.2.1",
+								IPAddress:        []string{"192.0.2.11", "192.0.2.12"},
+								NetworkMaskLen:   24,
+								Index:            2,
+							},
 						},
-					},
-					StaticNAT: []*sacloud.VPCRouterStaticNAT{
-						{
-							GlobalAddress:  withRouterCreateVPCRouterParam.Settings.Interfaces[0].IPAliases[0],
-							PrivateAddress: "192.0.2.1",
+						StaticNAT: []*sacloud.VPCRouterStaticNAT{
+							{
+								GlobalAddress:  withRouterCreateVPCRouterParam.Settings.Interfaces[0].IPAliases[0],
+								PrivateAddress: "192.0.2.1",
+							},
 						},
-					},
-					DHCPServer: []*sacloud.VPCRouterDHCPServer{
-						{
-							Interface:  "eth2",
-							RangeStart: "192.0.2.51",
-							RangeStop:  "192.0.2.60",
+						DHCPServer: []*sacloud.VPCRouterDHCPServer{
+							{
+								Interface:  "eth2",
+								RangeStart: "192.0.2.51",
+								RangeStop:  "192.0.2.60",
+							},
 						},
-					},
-					DHCPStaticMapping: []*sacloud.VPCRouterDHCPStaticMapping{
-						{
-							MACAddress: "aa:bb:cc:dd:ee:ff",
-							IPAddress:  "192.0.2.21",
+						DHCPStaticMapping: []*sacloud.VPCRouterDHCPStaticMapping{
+							{
+								MACAddress: "aa:bb:cc:dd:ee:ff",
+								IPAddress:  "192.0.2.21",
+							},
 						},
-					},
-					PPTPServer: &sacloud.VPCRouterPPTPServer{
-						RangeStart: "192.0.2.61",
-						RangeStop:  "192.0.2.70",
-					},
-					PPTPServerEnabled: true,
-					L2TPIPsecServer: &sacloud.VPCRouterL2TPIPsecServer{
-						RangeStart:      "192.0.2.71",
-						RangeStop:       "192.0.2.80",
-						PreSharedSecret: "presharedsecret",
-					},
-					L2TPIPsecServerEnabled: true,
-					RemoteAccessUsers: []*sacloud.VPCRouterRemoteAccessUser{
-						{
-							UserName: "user1",
-							Password: "password1",
+						PPTPServer: &sacloud.VPCRouterPPTPServer{
+							RangeStart: "192.0.2.61",
+							RangeStop:  "192.0.2.70",
 						},
-					},
-					SiteToSiteIPsecVPN: []*sacloud.VPCRouterSiteToSiteIPsecVPN{
-						{
-							Peer:            "10.0.0.1",
+						PPTPServerEnabled: true,
+						L2TPIPsecServer: &sacloud.VPCRouterL2TPIPsecServer{
+							RangeStart:      "192.0.2.71",
+							RangeStop:       "192.0.2.80",
 							PreSharedSecret: "presharedsecret",
-							RemoteID:        "10.0.0.1",
-							Routes:          []string{"192.0.2.248/28"},
-							LocalPrefix:     []string{"192.0.2.0/24"},
 						},
-					},
-					StaticRoute: []*sacloud.VPCRouterStaticRoute{
-						{
-							Prefix:  "172.16.0.0/16",
-							NextHop: "192.0.2.11",
+						L2TPIPsecServerEnabled: true,
+						RemoteAccessUsers: []*sacloud.VPCRouterRemoteAccessUser{
+							{
+								UserName: "user1",
+								Password: "password1",
+							},
 						},
-					},
-				}
+						SiteToSiteIPsecVPN: []*sacloud.VPCRouterSiteToSiteIPsecVPN{
+							{
+								Peer:            "10.0.0.1",
+								PreSharedSecret: "presharedsecret",
+								RemoteID:        "10.0.0.1",
+								Routes:          []string{"192.0.2.248/28"},
+								LocalPrefix:     []string{"192.0.2.0/24"},
+							},
+						},
+						StaticRoute: []*sacloud.VPCRouterStaticRoute{
+							{
+								Prefix:  "172.16.0.0/16",
+								NextHop: "192.0.2.11",
+							},
+						},
+					}
 
-				withRouterUpdateVPCRouterExpected.Settings = p.Settings
-				return testVPCRouterUpdate(updateVPCRouterParam)(testContext, caller)
-			},
-			Expect: &CRUDTestExpect{
-				ExpectValue:  updateVPCRouterExpected,
-				IgnoreFields: ignoreVPCRouterFields,
+					withRouterUpdateVPCRouterExpected.Settings = p.Settings
+					return testVPCRouterUpdate(updateVPCRouterParam)(testContext, caller)
+				},
+				Expect: &CRUDTestExpect{
+					ExpectValue:  updateVPCRouterExpected,
+					IgnoreFields: ignoreVPCRouterFields,
+				},
 			},
 		},
 

--- a/sacloud/test/vpc_router_op_test.go
+++ b/sacloud/test/vpc_router_op_test.go
@@ -15,27 +15,27 @@ func TestVPCRouterOpCRUD(t *testing.T) {
 		SetupAPICallerFunc: singletonAPICaller,
 		Create: &CRUDTestFunc{
 			Func: testVPCRouterCreate(createVPCRouterParam),
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createVPCRouterExpected,
 				IgnoreFields: ignoreVPCRouterFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testVPCRouterRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createVPCRouterExpected,
 				IgnoreFields: ignoreVPCRouterFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
 			{
 				Func: testVPCRouterUpdate(updateVPCRouterParam),
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateVPCRouterExpected,
 					IgnoreFields: ignoreVPCRouterFields,
-				},
+				}),
 			},
 		},
 
@@ -220,18 +220,18 @@ func TestVPCRouterOpWithRouterCRUD(t *testing.T) {
 		},
 		Create: &CRUDTestFunc{
 			Func: testVPCRouterCreate(createVPCRouterParam),
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createVPCRouterExpected,
 				IgnoreFields: ignoreVPCRouterFields,
-			},
+			}),
 		},
 
 		Read: &CRUDTestFunc{
 			Func: testVPCRouterRead,
-			Expect: &CRUDTestExpect{
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 				ExpectValue:  createVPCRouterExpected,
 				IgnoreFields: ignoreVPCRouterFields,
-			},
+			}),
 		},
 
 		Updates: []*CRUDTestFunc{
@@ -334,10 +334,10 @@ func TestVPCRouterOpWithRouterCRUD(t *testing.T) {
 					withRouterUpdateVPCRouterExpected.Settings = p.Settings
 					return testVPCRouterUpdate(updateVPCRouterParam)(testContext, caller)
 				},
-				Expect: &CRUDTestExpect{
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
 					ExpectValue:  updateVPCRouterExpected,
 					IgnoreFields: ignoreVPCRouterFields,
-				},
+				}),
 			},
 		},
 

--- a/sacloud/test/zone_op_test.go
+++ b/sacloud/test/zone_op_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestZoneOp_Find(t *testing.T) {
@@ -14,6 +14,6 @@ func TestZoneOp_Find(t *testing.T) {
 	client := sacloud.NewZoneOp(singletonAPICaller())
 
 	zoneFindResult, err := client.Find(context.Background(), sacloud.APIDefaultZone, &sacloud.FindCondition{Count: 1})
-	require.NoError(t, err)
-	require.Len(t, zoneFindResult.Zones, 1)
+	assert.NoError(t, err)
+	assert.Len(t, zoneFindResult.Zones, 1)
 }


### PR DESCRIPTION
全てのテストを`test.Run`経由で行うようにする。
(一部移行が面倒なものはそのまま)

- CRUDTestCase.Updatesを複数指定可能に
- CRUDTestFuncにSkipExtractIDフラグの導入
- CRUDTestFuncのExpectを廃止。任意のチェックを行うための`CheckFunc`を追加