### PR TITLE
Mobile Gateway API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Library for SakuraCloud API
 - [x] `IPv6Addr`: IPv6アドレス
 - [x] `License`: ライセンス
 - [x] `LoadBalancer`: ロードバランサ
-- [ ] `MobileGateway`: モバイルゲートウェイ 
+- [x] `MobileGateway`: モバイルゲートウェイ 
 - [ ] `NewsFeed`: ニュースフィード(メンテナンス情報)
 - [x] `NFS`: NFS
 - [x] `Note`: スタートアップスクリプト
@@ -40,7 +40,7 @@ Library for SakuraCloud API
 - [x] `Server`: サーバ
 - [x] `ServiceClass`: 価格表(public/price)
 - [x] `SimpleMonitor`: シンプル監視
-- [ ] `SIM`: SIM
+- [x] `SIM`: SIM
 - [x] `SSHKey`: 公開鍵
 - [x] `Subnet`: サブネット
 - [x] `Switch`: スイッチ

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/huandu/xstrings v1.2.0
 	github.com/leodido/go-urn v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
 	github.com/uber-go/atomic v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/leodido/go-urn v1.1.0 h1:Sm1gr51B1kKyfD2BlRcLSiEkffoG96g6TPv6eRoEiB8=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
+github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
+github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=

--- a/internal/define/apis.go
+++ b/internal/define/apis.go
@@ -39,6 +39,7 @@ func init() {
 	APIs.Define(licenseAPI)         // ライセンス
 	APIs.Define(licenseInfoAPI)     // ライセンスプラン
 	APIs.Define(loadBalancerAPI)    // ロードバランサ
+	APIs.Define(mobileGatewayAPI)   // モバイルゲートウェイ
 	APIs.Define(nfsAPI)             // NFS
 	APIs.Define(noteAPI)            // スタートアップスクリプト
 	APIs.Define(packetFilterAPI)    // パケットフィルタ

--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -874,9 +874,6 @@ func (f *fieldsDef) GSLBDestinationServers() *dsl.FieldDesc {
 				{
 					Name: "Weight",
 					Type: meta.TypeStringNumber,
-					Tags: &dsl.FieldTags{
-						MapConv: ",default=1",
-					},
 				},
 			},
 		},

--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -549,6 +549,16 @@ func (f *fieldsDef) ApplianceSwitchID() *dsl.FieldDesc {
 	}
 }
 
+func (f *fieldsDef) ApplianceSwitchShared() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "SwitchID",
+		Tags: &dsl.FieldTags{
+			MapConv: "Remark.Switch.Scope,default=shared",
+		},
+		Type: meta.TypeString,
+	}
+}
+
 func (f *fieldsDef) ApplianceIPAddress() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "IPAddress",
@@ -710,6 +720,16 @@ func (f *fieldsDef) VPCRouterClass() *dsl.FieldDesc {
 	}
 }
 
+func (f *fieldsDef) MobileGatewayClass() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Class",
+		Type: meta.TypeString,
+		Tags: &dsl.FieldTags{
+			MapConv: ",default=mobilegateway",
+		},
+	}
+}
+
 func (f *fieldsDef) SIMProviderClass() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "Class",
@@ -723,7 +743,7 @@ func (f *fieldsDef) SIMProviderClass() *dsl.FieldDesc {
 func (f *fieldsDef) SIMICCID() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "ICCID",
-		Type: meta.TypeStringNumber,
+		Type: meta.TypeString,
 		Tags: &dsl.FieldTags{
 			MapConv:  "Status.ICCID",
 			Validate: "numeric", // TODO 数値のみ15桁固定
@@ -1507,6 +1527,17 @@ func (f *fieldsDef) VPCRouterInterfaces() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "Interfaces",
 		Type: models.vpcRouterInterfaceModel(),
+		Tags: &dsl.FieldTags{
+			JSON:    ",omitempty",
+			MapConv: "[]Interfaces,recursive,omitempty",
+		},
+	}
+}
+
+func (f *fieldsDef) MobileGatewayInterfaces() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Interfaces",
+		Type: models.mobileGatewayInterfaceModel(),
 		Tags: &dsl.FieldTags{
 			JSON:    ",omitempty",
 			MapConv: "[]Interfaces,recursive,omitempty",

--- a/internal/define/mobile_gateway.go
+++ b/internal/define/mobile_gateway.go
@@ -1,0 +1,480 @@
+package define
+
+import (
+	"net/http"
+
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
+	"github.com/sacloud/libsacloud/v2/internal/define/ops"
+	"github.com/sacloud/libsacloud/v2/internal/dsl"
+	"github.com/sacloud/libsacloud/v2/internal/dsl/meta"
+	"github.com/sacloud/libsacloud/v2/sacloud/naked"
+)
+
+const (
+	mobileGatewayAPIName     = "MobileGateway"
+	mobileGatewayAPIPathName = "appliance"
+)
+
+var mobileGatewayAPI = &dsl.Resource{
+	Name:       mobileGatewayAPIName,
+	PathName:   mobileGatewayAPIPathName,
+	PathSuffix: dsl.CloudAPISuffix,
+	Operations: dsl.Operations{
+		// find
+		ops.FindAppliance(mobileGatewayAPIName, mobileGatewayNakedType, findParameter, mobileGatewayView),
+
+		// create
+		ops.CreateAppliance(mobileGatewayAPIName, mobileGatewayNakedType, mobileGatewayCreateParam, mobileGatewayView),
+
+		// read
+		ops.ReadAppliance(mobileGatewayAPIName, mobileGatewayNakedType, mobileGatewayView),
+
+		// update
+		ops.UpdateAppliance(mobileGatewayAPIName, mobileGatewayNakedType, mobileGatewayUpdateParam, mobileGatewayView),
+
+		// delete
+		ops.Delete(mobileGatewayAPIName),
+
+		// config
+		ops.Config(mobileGatewayAPIName),
+
+		// power management(boot/shutdown/reset)
+		ops.Boot(mobileGatewayAPIName),
+		ops.Shutdown(mobileGatewayAPIName),
+		ops.Reset(mobileGatewayAPIName),
+
+		// connect to switch
+		ops.WithIDAction(
+			mobileGatewayAPIName, "ConnectToSwitch", http.MethodPut, "interface/1/to/switch/{{.switchID}}",
+			&dsl.Argument{
+				Name: "switchID",
+				Type: meta.TypeID,
+			},
+		),
+
+		// disconnect from switch
+		ops.WithIDAction(
+			mobileGatewayAPIName, "DisconnectFromSwitch", http.MethodDelete, "interface/1/to/switch",
+		),
+
+		// DNS
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "GetDNS",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/dnsresolver"),
+			Method:       http.MethodGet,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+			},
+			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
+				Name: "SIMGroup",
+				Type: meta.Static(naked.MobileGatewaySIMGroup{}),
+				Tags: &dsl.FieldTags{
+					JSON: "sim_group",
+				},
+			}),
+			Results: dsl.Results{
+				{
+					SourceField: "SIMGroup",
+					DestField:   "SIMGroup",
+					IsPlural:    false,
+					Model:       mobileGatewayDNSModel,
+				},
+			},
+		},
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "SetDNS",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/dnsresolver"),
+			Method:       http.MethodPut,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+				dsl.MappableArgument("param", mobileGatewayDNSModel, "SIMGroup"),
+			},
+			RequestEnvelope: dsl.RequestEnvelope(&dsl.EnvelopePayloadDesc{
+				Type: meta.Static(naked.MobileGatewaySIMGroup{}),
+				Name: "SIMGroup",
+				Tags: &dsl.FieldTags{
+					JSON: "sim_group",
+				},
+			}),
+		},
+
+		// SIM Route
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "GetSIMRoutes",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/simroutes"),
+			Method:       http.MethodGet,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+			},
+			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
+				Name: "SIMRoutes",
+				Type: meta.Static([]*naked.MobileGatewaySIMRoute{}),
+				Tags: &dsl.FieldTags{
+					JSON: "sim_routes",
+				},
+			}),
+			Results: dsl.Results{
+				{
+					SourceField: "SIMRoutes",
+					DestField:   "SIMRoutes",
+					IsPlural:    true,
+					Model:       mobileGatewaySIMRouteView,
+				},
+			},
+		},
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "SetSIMRoutes",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/simroutes"),
+			Method:       http.MethodPut,
+			RequestEnvelope: dsl.RequestEnvelope(&dsl.EnvelopePayloadDesc{
+				Type: meta.Static([]*naked.MobileGatewaySIMRoute{}),
+				Name: "SIMRoutes",
+				Tags: &dsl.FieldTags{
+					JSON: "sim_routes",
+				},
+			}),
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+				dsl.MappableArgument("param", mobileGatewaySIMRouteParam, "[]SIMRoutes"),
+			},
+		},
+
+		// list SIM
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "ListSIM",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/sims"),
+			Method:       http.MethodGet,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+			},
+			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
+				Name: "SIM",
+				Type: meta.Static([]*naked.SIMInfo{}),
+				Tags: &dsl.FieldTags{
+					JSON: "sim",
+				},
+			}),
+			Results: dsl.Results{
+				{
+					SourceField: "SIM",
+					DestField:   "SIM",
+					IsPlural:    true,
+					Model:       models.simInfoList(),
+				},
+			},
+		},
+		// add SIM
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "AddSIM",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/sims"),
+			Method:       http.MethodPost,
+			RequestEnvelope: dsl.RequestEnvelope(&dsl.EnvelopePayloadDesc{
+				Type: meta.Static(naked.SIMInfo{}),
+				Name: "SIM",
+				Tags: &dsl.FieldTags{
+					JSON: "sim",
+				},
+			}),
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+				dsl.MappableArgument("param", mobileGatewayAddSIMParam, "SIM"),
+			},
+		},
+		// delete SIM
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "DeleteSIM",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/sims/{{.simID}}"),
+			Method:       http.MethodDelete,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+				{
+					Name: "simID",
+					Type: meta.TypeID,
+				},
+			},
+		},
+
+		// session logs
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "Logs",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/sessionlog"),
+			Method:       http.MethodGet,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+			},
+			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
+				Name: "Logs",
+				Type: meta.Static([]*naked.SIMLog{}),
+				Tags: &dsl.FieldTags{
+					JSON: "logs",
+				},
+			}),
+			Results: dsl.Results{
+				{
+					SourceField: "Logs",
+					DestField:   "Logs",
+					IsPlural:    true,
+					Model:       mobileGatewaySIMLogsModel,
+				},
+			},
+		},
+
+		// get traffic config
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "GetTrafficConfig",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/traffic_monitoring"),
+			Method:       http.MethodGet,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+			},
+			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
+				Name: "TrafficMonitoring",
+				Type: meta.Static(naked.TrafficMonitoringConfig{}),
+				Tags: &dsl.FieldTags{
+					JSON: "traffic_monitoring_config",
+				},
+			}),
+			Results: dsl.Results{
+				{
+					SourceField: "TrafficMonitoring",
+					DestField:   "TrafficMonitoring",
+					IsPlural:    false,
+					Model:       mobileGatewayTrafficConfigModel,
+				},
+			},
+		},
+		// set traffic config
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "SetTrafficConfig",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/traffic_monitoring"),
+			Method:       http.MethodPut,
+			RequestEnvelope: dsl.RequestEnvelope(&dsl.EnvelopePayloadDesc{
+				Name: "TrafficMonitoring",
+				Type: meta.Static(naked.TrafficMonitoringConfig{}),
+				Tags: &dsl.FieldTags{
+					JSON: "traffic_monitoring_config",
+				},
+			}),
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+				dsl.MappableArgument("param", mobileGatewayTrafficConfigModel, "TrafficMonitoring"),
+			},
+		},
+		// delete SIM
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "DeleteTrafficConfig",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/traffic_monitoring"),
+			Method:       http.MethodDelete,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+			},
+		},
+
+		// traffic status
+		{
+			ResourceName: mobileGatewayAPIName,
+			Name:         "TrafficStatus",
+			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/traffic_status"),
+			Method:       http.MethodGet,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentZone,
+				dsl.ArgumentID,
+			},
+			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
+				Name: "TrafficStatus",
+				Type: meta.Static(naked.TrafficStatus{}),
+				Tags: &dsl.FieldTags{
+					JSON: "traffic_status",
+				},
+			}),
+			Results: dsl.Results{
+				{
+					SourceField: "TrafficStatus",
+					DestField:   "TrafficStatus",
+					IsPlural:    false,
+					Model:       mobileGatewayTrafficStatusModel,
+				},
+			},
+		},
+
+		// monitor
+		ops.MonitorChildBy(mobileGatewayAPIName, "Interface", "interface",
+			monitorParameter, monitors.interfaceModel()),
+	},
+}
+
+var (
+	mobileGatewayNakedType = meta.Static(naked.MobileGateway{})
+
+	mobileGatewayView = &dsl.Model{
+		Name:      mobileGatewayAPIName,
+		NakedType: mobileGatewayNakedType,
+		Fields: []*dsl.FieldDesc{
+			fields.ID(),
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.Availability(),
+			fields.Class(),
+			fields.IconID(),
+			fields.CreatedAt(),
+			// plan
+			fields.AppliancePlanID(),
+			// instance
+			fields.InstanceHostName(),
+			fields.InstanceHostInfoURL(),
+			fields.InstanceStatus(),
+			fields.InstanceStatusChangedAt(),
+			// interfaces
+			fields.MobileGatewayInterfaces(),
+			// remark
+			fields.RemarkZoneID(),
+			// settings
+			fields.New("Settings", models.mobileGatewaySetting(), mapConvTag(",omitempty,recursive")),
+			fields.SettingsHash(),
+		},
+	}
+
+	mobileGatewayCreateParam = &dsl.Model{
+		Name:      names.CreateParameterName(mobileGatewayAPIName),
+		NakedType: mobileGatewayNakedType,
+		Fields: []*dsl.FieldDesc{
+			fields.MobileGatewayClass(),
+			fields.ApplianceSwitchShared(),
+			fields.AppliancePlanID(),
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.IconID(),
+			{
+				Name: "Settings",
+				Type: models.mobileGatewaySettingCreate(),
+				Tags: &dsl.FieldTags{
+					JSON:    ",omitempty",
+					MapConv: ",omitempty,recursive",
+				},
+			},
+		},
+	}
+
+	mobileGatewayUpdateParam = &dsl.Model{
+		Name:      names.UpdateParameterName(mobileGatewayAPIName),
+		NakedType: mobileGatewayNakedType,
+		Fields: []*dsl.FieldDesc{
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.IconID(),
+			{
+				Name: "Settings",
+				Type: models.mobileGatewaySetting(),
+				Tags: &dsl.FieldTags{
+					JSON:    ",omitempty",
+					MapConv: ",omitempty,recursive",
+				},
+			},
+		},
+	}
+
+	mobileGatewayDNSModel = &dsl.Model{
+		Name:      "MobileGatewayDNSSetting",
+		NakedType: meta.Static(naked.MobileGatewaySIMGroup{}),
+		Fields: []*dsl.FieldDesc{
+			fields.New("DNS1", meta.TypeString),
+			fields.New("DNS2", meta.TypeString),
+		},
+	}
+
+	mobileGatewaySIMRouteParam = &dsl.Model{
+		Name:      "MobileGatewaySIMRouteParam",
+		NakedType: meta.Static(naked.MobileGatewaySIMRoute{}),
+		IsArray:   true,
+		Fields: []*dsl.FieldDesc{
+			fields.New("ResourceID", meta.TypeString),
+			fields.New("Prefix", meta.TypeString),
+		},
+	}
+	mobileGatewaySIMRouteView = &dsl.Model{
+		Name:      "MobileGatewaySIMRoute",
+		NakedType: meta.Static(naked.MobileGatewaySIMRoute{}),
+		IsArray:   true,
+		Fields: []*dsl.FieldDesc{
+			fields.New("ResourceID", meta.TypeString),
+			fields.New("Prefix", meta.TypeString),
+			fields.New("ICCID", meta.TypeString),
+		},
+	}
+
+	mobileGatewayAddSIMParam = &dsl.Model{
+		Name:      mobileGatewayAPIName + "AddSIMRequest",
+		NakedType: meta.Static(naked.SIMInfo{}),
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "SIMID",
+				Type: meta.TypeString,
+				Tags: &dsl.FieldTags{
+					MapConv: "ResourceID",
+					JSON:    "resource_id",
+				},
+			},
+		},
+	}
+
+	mobileGatewaySIMLogsModel = &dsl.Model{
+		Name:      mobileGatewayAPIName + "SIMLogs",
+		NakedType: meta.Static(naked.SIMLog{}),
+		IsArray:   true,
+		Fields: []*dsl.FieldDesc{
+			fields.New("Date", meta.TypeTime),
+			fields.New("SessionStatus", meta.TypeString),
+			fields.New("ResourceID", meta.TypeString),
+			fields.New("IMEI", meta.TypeString),
+			fields.New("IMSI", meta.TypeString),
+		},
+	}
+
+	mobileGatewayTrafficConfigModel = &dsl.Model{
+		Name:      mobileGatewayAPIName + "TrafficControl",
+		NakedType: meta.Static(naked.TrafficMonitoringConfig{}),
+		Fields: []*dsl.FieldDesc{
+			fields.New("TrafficQuotaInMB", meta.TypeInt),
+			fields.New("BandWidthLimitInKbps", meta.TypeInt),
+			fields.New("EmailNotifyEnabled", meta.TypeFlag, mapConvTag("EMailConfig.Enabled")),
+			fields.New("SlackNotifyEnabled", meta.TypeFlag, mapConvTag("SlackConfig.Enabled")),
+			fields.New("SlackNotifyWebhooksURL", meta.TypeString, mapConvTag("SlackConfig.IncomingWebhooksURL")),
+			fields.New("AutoTrafficShaping", meta.TypeFlag),
+		},
+	}
+
+	mobileGatewayTrafficStatusModel = &dsl.Model{
+		Name:      mobileGatewayAPIName + "TrafficStatus",
+		NakedType: meta.Static(naked.TrafficStatus{}),
+		Fields: []*dsl.FieldDesc{
+			fields.New("UplinkBytes", meta.TypeStringNumber),
+			fields.New("DownlinkBytes", meta.TypeStringNumber),
+			fields.New("TrafficShaping", meta.TypeFlag),
+		},
+	}
+)

--- a/internal/define/models.go
+++ b/internal/define/models.go
@@ -322,6 +322,19 @@ func (m *modelsDef) vpcRouterInterfaceModel() *dsl.Model {
 	return ifModel
 }
 
+func (m *modelsDef) mobileGatewayInterfaceModel() *dsl.Model {
+	ifModel := m.interfaceModel()
+	ifModel.Name = "MobileGatewayInterface"
+	ifModel.Fields = append(ifModel.Fields, &dsl.FieldDesc{
+		Name: "Index",
+		Type: meta.TypeInt,
+		Tags: &dsl.FieldTags{
+			MapConv: ",omitempty",
+		},
+	})
+	return ifModel
+}
+
 func (m *modelsDef) bundleInfoModel() *dsl.Model {
 	return &dsl.Model{
 		Name:      "BundleInfo",
@@ -715,6 +728,10 @@ func (m *modelsDef) switchSubnet() *dsl.Model {
 	}
 	return subnet
 }
+
+//******************************************************************************
+// VPCRouter
+//******************************************************************************
 
 func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 	return &dsl.Model{
@@ -1126,5 +1143,157 @@ func (m *modelsDef) vpcRouterStaticRoute() *dsl.Model {
 				Type: meta.TypeString,
 			},
 		},
+	}
+}
+
+//******************************************************************************
+// Mobile Gateway
+//******************************************************************************
+
+func (m *modelsDef) mobileGatewaySetting() *dsl.Model {
+	return &dsl.Model{
+		Name:      "MobileGatewaySetting",
+		NakedType: meta.Static(naked.MobileGatewaySettings{}),
+		Fields: []*dsl.FieldDesc{
+
+			{
+				Name: "Interfaces",
+				Type: m.mobileGatewayInterface(),
+				Tags: &dsl.FieldTags{
+					JSON:    ",omitempty",
+					MapConv: "MobileGateway.[]Interfaces,omitempty,recursive",
+				},
+			},
+			{
+				Name: "StaticRoute",
+				Type: m.mobileGatewayStaticRoute(),
+				Tags: &dsl.FieldTags{
+					JSON:    ",omitempty",
+					MapConv: "MobileGateway.[]StaticRoutes,omitempty,recursive",
+				},
+			},
+			{
+				Name: "InternetConnectionEnabled",
+				Type: meta.TypeStringFlag,
+				Tags: &dsl.FieldTags{
+					MapConv: "MobileGateway.InternetConnection.Enabled",
+				},
+			},
+			{
+				Name: "InterDeviceCommunicationEnabled",
+				Type: meta.TypeStringFlag,
+				Tags: &dsl.FieldTags{
+					MapConv: "MobileGateway.InterDeviceCommunication.Enabled",
+				},
+			},
+		},
+	}
+}
+
+func (m *modelsDef) mobileGatewaySettingCreate() *dsl.Model {
+	return &dsl.Model{
+		Name:      "MobileGatewaySettingCreate",
+		NakedType: meta.Static(naked.MobileGatewaySettings{}),
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "StaticRoute",
+				Type: m.mobileGatewayStaticRoute(),
+				Tags: &dsl.FieldTags{
+					JSON:    ",omitempty",
+					MapConv: "MobileGateway.[]StaticRoutes,omitempty,recursive",
+				},
+			},
+			{
+				Name: "InternetConnectionEnabled",
+				Type: meta.TypeStringFlag,
+				Tags: &dsl.FieldTags{
+					MapConv: "MobileGateway.InternetConnection.Enabled",
+				},
+			},
+			{
+				Name: "InterDeviceCommunicationEnabled",
+				Type: meta.TypeStringFlag,
+				Tags: &dsl.FieldTags{
+					MapConv: "MobileGateway.InterDeviceCommunication.Enabled",
+				},
+			},
+		},
+	}
+}
+
+func (m *modelsDef) mobileGatewayInterface() *dsl.Model {
+	return &dsl.Model{
+		Name:      "MobileGatewayInterfaceSetting",
+		NakedType: meta.Static(naked.MobileGatewayInterface{}),
+		IsArray:   true,
+		Fields: []*dsl.FieldDesc{
+			fields.New("IPAddress", meta.TypeStringSlice),
+			fields.New("NetworkMaskLen", meta.TypeInt),
+			fields.New("Index", meta.TypeInt),
+		},
+	}
+}
+
+func (m *modelsDef) mobileGatewayStaticRoute() *dsl.Model {
+	return &dsl.Model{
+		Name:      "MobileGatewayStaticRoute",
+		NakedType: meta.Static(naked.MobileGatewayStaticRoute{}),
+		IsArray:   true,
+		Fields: []*dsl.FieldDesc{
+			fields.New("Prefix", meta.TypeString),
+			fields.New("NextHop", meta.TypeString),
+		},
+	}
+}
+
+//******************************************************************************
+// SIM
+//******************************************************************************
+
+func (m *modelsDef) simInfo() *dsl.Model {
+	return &dsl.Model{
+		Name:      "SIMInfo",
+		NakedType: meta.Static(naked.SIMInfo{}),
+		Fields:    m.simInfoFields(),
+	}
+}
+
+func (m *modelsDef) simInfoList() *dsl.Model {
+	return &dsl.Model{
+		Name:      "MobileGatewaySIMInfo",
+		NakedType: meta.Static(naked.SIMInfo{}),
+		IsArray:   true,
+		Fields:    m.simInfoFields(),
+	}
+}
+
+func (m *modelsDef) simInfoFields() []*dsl.FieldDesc {
+	return []*dsl.FieldDesc{
+		fields.New("ICCID", meta.TypeString),
+		fields.New("IMSI", meta.TypeStringSlice),
+		fields.New("IP", meta.TypeString),
+		fields.New("SessionStatus", meta.TypeString),
+		fields.New("IMEILock", meta.TypeFlag),
+		fields.New("Registered", meta.TypeFlag),
+		fields.New("Activated", meta.TypeFlag),
+		fields.New("ResourceID", meta.TypeString),
+		fields.New("RegisteredDate", meta.TypeTime),
+		fields.New("ActivatedDate", meta.TypeTime),
+		fields.New("DeactivatedDate", meta.TypeTime),
+		fields.New("SIMGroupID", meta.TypeString),
+		{
+			Name: "TrafficBytesOfCurrentMonth",
+			Type: &dsl.Model{
+				Name: "SIMTrafficBytes",
+				Fields: []*dsl.FieldDesc{
+					fields.New("UplinkBytes", meta.TypeInt64),
+					fields.New("DownlinkBytes", meta.TypeInt64),
+				},
+			},
+			Tags: &dsl.FieldTags{
+				MapConv: ",recursive",
+			},
+		},
+		fields.New("ConnectedIMEI", meta.TypeString),
 	}
 }

--- a/pkg/mapconv/mapconv.go
+++ b/pkg/mapconv/mapconv.go
@@ -1,12 +1,12 @@
 package mapconv
 
 import (
-	"encoding/json"
 	"errors"
 	"reflect"
 	"strings"
 
 	"github.com/fatih/structs"
+	"github.com/mitchellh/mapstructure"
 )
 
 // ConvertTo converts struct which input by mapconv to plain models
@@ -72,11 +72,7 @@ func ConvertTo(source interface{}, dest interface{}) error {
 		}
 	}
 
-	data, err := json.Marshal(destMap)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(data, dest)
+	return mapstructure.Decode(destMap.Map(), dest)
 }
 
 // ConvertFrom converts struct which input by mapconv from plain models
@@ -149,12 +145,7 @@ func ConvertFrom(source interface{}, dest interface{}) error {
 		}
 
 	}
-
-	data, err := json.Marshal(destMap)
-	if err != nil {
-		return err
-	}
-	return json.Unmarshal(data, dest)
+	return mapstructure.Decode(destMap.Map(), dest)
 }
 
 type mapConv string

--- a/sacloud/customize_envelope.go
+++ b/sacloud/customize_envelope.go
@@ -42,3 +42,16 @@ func (b *billDetailsCSVResponseEnvelope) UnmarshalJSON(data []byte) error {
 	*b = billDetailsCSVResponseEnvelope(tmp)
 	return nil
 }
+
+func (m *mobileGatewaySetSIMRoutesRequestEnvelope) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		SIMRoutes []*naked.MobileGatewaySIMRoute `json:"sim_routes"`
+	}
+	tmp := &alias{
+		SIMRoutes: m.SIMRoutes,
+	}
+	if len(tmp.SIMRoutes) == 0 {
+		tmp.SIMRoutes = make([]*naked.MobileGatewaySIMRoute, 0)
+	}
+	return json.Marshal(tmp)
+}

--- a/sacloud/fake/ops_gslb.go
+++ b/sacloud/fake/ops_gslb.go
@@ -33,12 +33,6 @@ func (o *GSLBOp) Create(ctx context.Context, zone string, param *sacloud.GSLBCre
 
 	result.FQDN = fmt.Sprintf("site-%d.gslb7.example.ne.jp", result.ID)
 	result.SettingsHash = "settingshash"
-	// TODO mapconvで設定しているデフォルト値をどう扱うか?
-	for _, server := range result.DestinationServers {
-		if server.Weight.Int() == 0 {
-			server.Weight = types.StringNumber(1)
-		}
-	}
 
 	s.setGSLB(sacloud.APIDefaultZone, result)
 	return result, nil

--- a/sacloud/fake/ops_mobile_gateway.go
+++ b/sacloud/fake/ops_mobile_gateway.go
@@ -1,0 +1,440 @@
+package fake
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// Find is fake implementation
+func (o *MobileGatewayOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.MobileGatewayFindResult, error) {
+	results, _ := find(o.key, zone, conditions)
+	var values []*sacloud.MobileGateway
+	for _, res := range results {
+		dest := &sacloud.MobileGateway{}
+		copySameNameField(res, dest)
+		values = append(values, dest)
+	}
+	return &sacloud.MobileGatewayFindResult{
+		Total:          len(results),
+		Count:          len(results),
+		From:           0,
+		MobileGateways: values,
+	}, nil
+}
+
+// Create is fake implementation
+func (o *MobileGatewayOp) Create(ctx context.Context, zone string, param *sacloud.MobileGatewayCreateRequest) (*sacloud.MobileGateway, error) {
+	result := &sacloud.MobileGateway{}
+	copySameNameField(param, result)
+	fill(result, fillID, fillCreatedAt)
+
+	result.Availability = types.Availabilities.Available
+	result.Class = "mobilegateway"
+	result.ZoneID = zoneIDs[zone]
+	result.SettingsHash = ""
+
+	s.setMobileGateway(zone, result)
+	return result, nil
+}
+
+// Read is fake implementation
+func (o *MobileGatewayOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGateway, error) {
+	value := s.getMobileGatewayByID(zone, id)
+	if value == nil {
+		return nil, newErrorNotFound(o.key, id)
+	}
+	dest := &sacloud.MobileGateway{}
+	copySameNameField(value, dest)
+	return dest, nil
+}
+
+// Update is fake implementation
+func (o *MobileGatewayOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayUpdateRequest) (*sacloud.MobileGateway, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	return value, nil
+}
+
+// Delete is fake implementation
+func (o *MobileGatewayOp) Delete(ctx context.Context, zone string, id types.ID) error {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	s.delete(o.key, zone, id)
+	return nil
+}
+
+// Config is fake implementation
+func (o *MobileGatewayOp) Config(ctx context.Context, zone string, id types.ID) error {
+	_, err := o.Read(ctx, zone, id)
+	return err
+}
+
+// Boot is fake implementation
+func (o *MobileGatewayOp) Boot(ctx context.Context, zone string, id types.ID) error {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	if value.InstanceStatus.IsUp() {
+		return newErrorConflict(o.key, id, "Boot is failed")
+	}
+
+	startPowerOn(o.key, zone, func() (interface{}, error) {
+		return o.Read(context.Background(), zone, id)
+	})
+
+	return err
+}
+
+// Shutdown is fake implementation
+func (o *MobileGatewayOp) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	if !value.InstanceStatus.IsUp() {
+		return newErrorConflict(o.key, id, "Shutdown is failed")
+	}
+
+	startPowerOff(o.key, zone, func() (interface{}, error) {
+		return o.Read(context.Background(), zone, id)
+	})
+
+	return err
+}
+
+// Reset is fake implementation
+func (o *MobileGatewayOp) Reset(ctx context.Context, zone string, id types.ID) error {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	if !value.InstanceStatus.IsUp() {
+		return newErrorConflict(o.key, id, "Reset is failed")
+	}
+
+	startPowerOn(o.key, zone, func() (interface{}, error) {
+		return o.Read(context.Background(), zone, id)
+	})
+
+	return nil
+}
+
+// ConnectToSwitch is fake implementation
+func (o *MobileGatewayOp) ConnectToSwitch(ctx context.Context, zone string, id types.ID, switchID types.ID) error {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	for _, nic := range value.Interfaces {
+		if nic.Index == 1 {
+			return newErrorBadRequest(o.key, id, fmt.Sprintf("nic[%d] already connected to switch", 1))
+		}
+	}
+
+	// find switch
+	swOp := NewSwitchOp()
+	_, err = swOp.Read(ctx, zone, switchID)
+	if err != nil {
+		return fmt.Errorf("ConnectToSwitch is failed: %s", err)
+	}
+
+	// create interface
+	ifOp := NewInterfaceOp()
+	iface, err := ifOp.Create(ctx, zone, &sacloud.InterfaceCreateRequest{ServerID: id})
+	if err != nil {
+		return newErrorConflict(o.key, types.ID(0), err.Error())
+	}
+
+	if err := ifOp.ConnectToSwitch(ctx, zone, iface.ID, switchID); err != nil {
+		return newErrorConflict(o.key, types.ID(0), err.Error())
+	}
+
+	iface, err = ifOp.Read(ctx, zone, iface.ID)
+	if err != nil {
+		return newErrorConflict(o.key, types.ID(0), err.Error())
+	}
+
+	mobileGatewayInterface := &sacloud.MobileGatewayInterface{}
+	copySameNameField(iface, mobileGatewayInterface)
+	value.Interfaces = append(value.Interfaces, mobileGatewayInterface)
+
+	s.setMobileGateway(zone, value)
+	return nil
+}
+
+// DisconnectFromSwitch is fake implementation
+func (o *MobileGatewayOp) DisconnectFromSwitch(ctx context.Context, zone string, id types.ID) error {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	var exists bool
+	var nicID types.ID
+	var interfaces []*sacloud.MobileGatewayInterface
+
+	for _, nic := range value.Interfaces {
+		if nic.Index == 1 {
+			exists = true
+			nicID = nic.ID
+		} else {
+			interfaces = append(interfaces, nic)
+		}
+	}
+	if !exists {
+		return newErrorBadRequest(o.key, id, fmt.Sprintf("nic[%d] is not exists", 1))
+	}
+
+	ifOp := NewInterfaceOp()
+	if err := ifOp.DisconnectFromSwitch(ctx, zone, nicID); err != nil {
+		return newErrorConflict(o.key, types.ID(0), err.Error())
+	}
+
+	value.Interfaces = interfaces
+	s.setMobileGateway(zone, value)
+	return nil
+}
+
+// GetDNS is fake implementation
+func (o *MobileGatewayOp) GetDNS(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayDNSSetting, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	dns := s.getByID(o.dnsStoreKey(), zone, id)
+	if dns == nil {
+		return &sacloud.MobileGatewayDNSSetting{
+			DNS1: "133.242.0.1",
+			DNS2: "133.242.0.2",
+		}, nil
+	}
+	return dns.(*sacloud.MobileGatewayDNSSetting), nil
+}
+
+// SetDNS is fake implementation
+func (o *MobileGatewayOp) SetDNS(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayDNSSetting) error {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	s.setWithID(o.dnsStoreKey(), zone, param, id)
+	return nil
+}
+
+// GetSIMRoutes is fake implementation
+func (o *MobileGatewayOp) GetSIMRoutes(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMRoute, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	routes := s.getByID(o.simRoutesStoreKey(), zone, id)
+	if routes == nil {
+		return nil, nil
+	}
+	return routes.([]*sacloud.MobileGatewaySIMRoute), nil
+}
+
+// SetSIMRoutes is fake implementation
+func (o *MobileGatewayOp) SetSIMRoutes(ctx context.Context, zone string, id types.ID, param []*sacloud.MobileGatewaySIMRouteParam) error {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	s.setWithID(o.simRoutesStoreKey(), zone, param, id)
+	return nil
+}
+
+// ListSIM is fake implementation
+func (o *MobileGatewayOp) ListSIM(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMInfo, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	sims := s.getByID(o.simsStoreKey(), zone, id)
+	if sims == nil {
+		return nil, nil
+	}
+	return sims.([]*sacloud.MobileGatewaySIMInfo), nil
+}
+
+// AddSIM is fake implementation
+func (o *MobileGatewayOp) AddSIM(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayAddSIMRequest) error {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	var sims []*sacloud.MobileGatewaySIMInfo
+	rawSIMs := s.getByID(o.simsStoreKey(), zone, id)
+	if rawSIMs != nil {
+		sims = rawSIMs.([]*sacloud.MobileGatewaySIMInfo)
+		for _, sim := range sims {
+			if sim.ResourceID == param.SIMID {
+				return newErrorBadRequest(o.key, id, fmt.Sprintf("SIM %s already exists", param.SIMID))
+			}
+		}
+	}
+
+	simOp := NewSIMOp()
+	simInfo, err := simOp.Status(context.Background(), sacloud.APIDefaultZone, types.StringID(param.SIMID))
+	if err != nil {
+		return err
+	}
+	sim := &sacloud.MobileGatewaySIMInfo{}
+	copySameNameField(simInfo, sim)
+
+	sims = append(sims, sim)
+
+	s.setWithID(o.simsStoreKey(), zone, sims, id)
+	return nil
+}
+
+// DeleteSIM is fake implementation
+func (o *MobileGatewayOp) DeleteSIM(ctx context.Context, zone string, id types.ID, simID types.ID) error {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	var sims, updSIMs []*sacloud.MobileGatewaySIMInfo
+	rawSIMs := s.getByID(o.simsStoreKey(), zone, id)
+	if rawSIMs != nil {
+		sims = rawSIMs.([]*sacloud.MobileGatewaySIMInfo)
+		for _, sim := range sims {
+			if sim.ResourceID != simID.String() {
+				updSIMs = append(updSIMs, sim)
+			}
+		}
+		if len(sims) != len(updSIMs) {
+			s.setWithID(o.simsStoreKey(), zone, updSIMs, id)
+			return nil
+		}
+	}
+	return newErrorBadRequest(o.key, id, fmt.Sprintf("SIM %d is not exists", simID))
+}
+
+// Logs is fake implementation
+func (o *MobileGatewayOp) Logs(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMLogs, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*sacloud.MobileGatewaySIMLogs{
+		{
+			Date:          time.Now(),
+			SessionStatus: "UP",
+			ResourceID:    types.ID(1).String(),
+		},
+	}, nil
+}
+
+// GetTrafficConfig is fake implementation
+func (o *MobileGatewayOp) GetTrafficConfig(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayTrafficControl, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	config := s.getByID(o.trafficConfigStoreKey(), zone, id)
+	if config == nil {
+		return nil, nil
+	}
+	return config.(*sacloud.MobileGatewayTrafficControl), nil
+}
+
+// SetTrafficConfig is fake implementation
+func (o *MobileGatewayOp) SetTrafficConfig(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayTrafficControl) error {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	s.setWithID(o.trafficConfigStoreKey(), zone, param, id)
+	return nil
+}
+
+// DeleteTrafficConfig is fake implementation
+func (o *MobileGatewayOp) DeleteTrafficConfig(ctx context.Context, zone string, id types.ID) error {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+
+	s.delete(o.trafficConfigStoreKey(), zone, id)
+	return nil
+}
+
+// TrafficStatus is fake implementation
+func (o *MobileGatewayOp) TrafficStatus(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayTrafficStatus, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sacloud.MobileGatewayTrafficStatus{
+		UplinkBytes:    100,
+		DownlinkBytes:  100,
+		TrafficShaping: true,
+	}, nil
+}
+
+// MonitorInterface is fake implementation
+func (o *MobileGatewayOp) MonitorInterface(ctx context.Context, zone string, id types.ID, index int, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().Truncate(time.Second)
+	m := now.Minute() % 5
+	if m != 0 {
+		now.Add(time.Duration(m) * time.Minute)
+	}
+
+	res := &sacloud.InterfaceActivity{}
+	for i := 0; i < 5; i++ {
+		res.Values = append(res.Values, &sacloud.MonitorInterfaceValue{
+			Time:    now.Add(time.Duration(i*-5) * time.Minute),
+			Send:    float64(random(1000)),
+			Receive: float64(random(1000)),
+		})
+	}
+
+	return res, nil
+}
+
+func (o *MobileGatewayOp) dnsStoreKey() string {
+	return o.key + "DNS"
+}
+
+func (o *MobileGatewayOp) simRoutesStoreKey() string {
+	return o.key + "SIMRoutes"
+}
+
+func (o *MobileGatewayOp) simsStoreKey() string {
+	return o.key + "SIMRoutes"
+}
+
+func (o *MobileGatewayOp) trafficConfigStoreKey() string {
+	return o.key + "TrafficConfig"
+}

--- a/sacloud/fake/ops_sim.go
+++ b/sacloud/fake/ops_sim.go
@@ -3,6 +3,8 @@ package fake
 import (
 	"context"
 	"errors"
+	"strings"
+	"time"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -29,9 +31,13 @@ func (o *SIMOp) Find(ctx context.Context, zone string, conditions *sacloud.FindC
 func (o *SIMOp) Create(ctx context.Context, zone string, param *sacloud.SIMCreateRequest) (*sacloud.SIM, error) {
 	result := &sacloud.SIM{}
 	copySameNameField(param, result)
-	fill(result, fillID, fillCreatedAt)
+	fill(result, fillID, fillCreatedAt, fillModifiedAt)
 
-	// TODO core logic is not implemented
+	result.Class = "sim"
+	result.Availability = types.Availabilities.Available
+	result.Info = &sacloud.SIMInfo{
+		ICCID: param.ICCID,
+	}
 
 	s.setSIM(zone, result)
 	return result, nil
@@ -57,7 +63,6 @@ func (o *SIMOp) Update(ctx context.Context, zone string, id types.ID, param *sac
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
 
-	// TODO core logic is not implemented
 	return value, nil
 }
 
@@ -68,78 +73,170 @@ func (o *SIMOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		return err
 	}
 
-	// TODO core logic is not implemented
-
 	s.delete(o.key, zone, id)
 	return nil
 }
 
 // Activate is fake implementation
 func (o *SIMOp) Activate(ctx context.Context, zone string, id types.ID) error {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return err
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	if value.Info.Activated {
+		return errors.New("SIM[%d] is already activated")
+	}
+	value.Info.Activated = true
+	value.Info.ActivatedDate = time.Now()
+	value.Info.DeactivatedDate = time.Time{}
+	return nil
 }
 
 // Deactivate is fake implementation
 func (o *SIMOp) Deactivate(ctx context.Context, zone string, id types.ID) error {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return err
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	if !value.Info.Activated {
+		return errors.New("SIM[%d] is already deactivated")
+	}
+	value.Info.Activated = false
+	value.Info.ActivatedDate = time.Time{}
+	value.Info.DeactivatedDate = time.Now()
+	return nil
 }
 
 // AssignIP is fake implementation
 func (o *SIMOp) AssignIP(ctx context.Context, zone string, id types.ID, param *sacloud.SIMAssignIPRequest) error {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return err
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	if value.Info.IP != "" {
+		return errors.New("SIM[%d] already has IPAddress")
+	}
+	value.Info.IP = param.IP
+	return nil
 }
 
 // ClearIP is fake implementation
 func (o *SIMOp) ClearIP(ctx context.Context, zone string, id types.ID) error {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return err
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	if value.Info.IP == "" {
+		return errors.New("SIM[%d] doesn't have IPAddress")
+	}
+	value.Info.IP = ""
+	return nil
 }
 
 // IMEILock is fake implementation
 func (o *SIMOp) IMEILock(ctx context.Context, zone string, id types.ID, param *sacloud.SIMIMEILockRequest) error {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return err
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	if value.Info.IMEILock {
+		return errors.New("SIM[%d] is already locked with IMEI")
+	}
+	value.Info.IMEILock = true
+	value.Info.ConnectedIMEI = param.IMEI
+	return nil
 }
 
 // IMEIUnlock is fake implementation
 func (o *SIMOp) IMEIUnlock(ctx context.Context, zone string, id types.ID) error {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return err
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	if !value.Info.IMEILock {
+		return errors.New("SIM[%d] is not locked with IMEI")
+	}
+	value.Info.IMEILock = false
+	value.Info.ConnectedIMEI = ""
+	return nil
 }
 
 // Logs is fake implementation
 func (o *SIMOp) Logs(ctx context.Context, zone string, id types.ID) (*sacloud.SIMLogsResult, error) {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return nil, err
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sacloud.SIMLogsResult{
+		Total: 1,
+		From:  0,
+		Count: 1,
+		Logs: []*sacloud.SIMLog{
+			{
+				Date:          time.Now(),
+				SessionStatus: "up",
+				ResourceID:    value.ID.String(),
+				IMEI:          value.Info.ConnectedIMEI,
+				IMSI:          strings.Join(value.Info.IMSI, " "),
+			},
+		},
+	}, nil
 }
 
 // GetNetworkOperator is fake implementation
-func (o *SIMOp) GetNetworkOperator(ctx context.Context, zone string, id types.ID) (*sacloud.SIMGetNetworkOperatorResult, error) {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return nil, err
+func (o *SIMOp) GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*sacloud.SIMNetworkOperatorConfig, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	return []*sacloud.SIMNetworkOperatorConfig{
+		{
+			Allow:       true,
+			CountryCode: "XX",
+			Name:        "name",
+		},
+	}, nil
 }
 
 // SetNetworkOperator is fake implementation
-func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs *sacloud.SIMNetworkOperatorConfigs) error {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return err
+func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*sacloud.SIMNetworkOperatorConfig) error {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // MonitorSIM is fake implementation
 func (o *SIMOp) MonitorSIM(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LinkActivity, error) {
-	// TODO not implemented
-	err := errors.New("not implements")
-	return nil, err
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().Truncate(time.Second)
+	m := now.Minute() % 5
+	if m != 0 {
+		now.Add(time.Duration(m) * time.Minute)
+	}
+
+	res := &sacloud.LinkActivity{}
+	for i := 0; i < 5; i++ {
+		res.Values = append(res.Values, &sacloud.MonitorLinkValue{
+			Time:        now.Add(time.Duration(i*-5) * time.Minute),
+			UplinkBPS:   float64(random(1000)),
+			DownlinkBPS: float64(random(1000)),
+		})
+	}
+
+	return res, nil
+}
+
+// Status is fake implementation
+func (o *SIMOp) Status(ctx context.Context, zone string, id types.ID) (*sacloud.SIMInfo, error) {
+	v, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	return v.Info, nil
 }

--- a/sacloud/fake/zz_api_ops.go
+++ b/sacloud/fake/zz_api_ops.go
@@ -74,6 +74,9 @@ func SwitchFactoryFuncToFake() {
 	sacloud.SetClientFactoryFunc(ResourceLoadBalancer, func(caller sacloud.APICaller) interface{} {
 		return NewLoadBalancerOp()
 	})
+	sacloud.SetClientFactoryFunc(ResourceMobileGateway, func(caller sacloud.APICaller) interface{} {
+		return NewMobileGatewayOp()
+	})
 	sacloud.SetClientFactoryFunc(ResourceNFS, func(caller sacloud.APICaller) interface{} {
 		return NewNFSOp()
 	})
@@ -476,6 +479,22 @@ type LoadBalancerOp struct {
 func NewLoadBalancerOp() sacloud.LoadBalancerAPI {
 	return &LoadBalancerOp{
 		key: ResourceLoadBalancer,
+	}
+}
+
+/*************************************************
+* MobileGatewayOp
+*************************************************/
+
+// MobileGatewayOp is fake implementation of MobileGatewayAPI interface
+type MobileGatewayOp struct {
+	key string
+}
+
+// NewMobileGatewayOp creates new MobileGatewayOp instance
+func NewMobileGatewayOp() sacloud.MobileGatewayAPI {
+	return &MobileGatewayOp{
+		key: ResourceMobileGateway,
 	}
 }
 

--- a/sacloud/fake/zz_api_ops_test.go
+++ b/sacloud/fake/zz_api_ops_test.go
@@ -98,6 +98,10 @@ func TestResourceOps(t *testing.T) {
 		t.Fatalf("%s is not sacloud.LoadBalancer", op)
 	}
 
+	if op, ok := NewMobileGatewayOp().(sacloud.MobileGatewayAPI); !ok {
+		t.Fatalf("%s is not sacloud.MobileGateway", op)
+	}
+
 	if op, ok := NewNFSOp().(sacloud.NFSAPI); !ok {
 		t.Fatalf("%s is not sacloud.NFS", op)
 	}

--- a/sacloud/fake/zz_resources.go
+++ b/sacloud/fake/zz_resources.go
@@ -47,6 +47,8 @@ const (
 	ResourceLicenseInfo = "LicenseInfo"
 	// ResourceLoadBalancer is resource key of fake store
 	ResourceLoadBalancer = "LoadBalancer"
+	// ResourceMobileGateway is resource key of fake store
+	ResourceMobileGateway = "MobileGateway"
 	// ResourceNFS is resource key of fake store
 	ResourceNFS = "NFS"
 	// ResourceNote is resource key of fake store

--- a/sacloud/fake/zz_store.go
+++ b/sacloud/fake/zz_store.go
@@ -513,6 +513,29 @@ func (s *store) setLoadBalancer(zone string, value *sacloud.LoadBalancer) {
 	s.set(ResourceLoadBalancer, zone, value)
 }
 
+func (s *store) getMobileGateway(zone string) []*sacloud.MobileGateway {
+	values := s.get(ResourceMobileGateway, zone)
+	var ret []*sacloud.MobileGateway
+	for _, v := range values {
+		if v, ok := v.(*sacloud.MobileGateway); ok {
+			ret = append(ret, v)
+		}
+	}
+	return ret
+}
+
+func (s *store) getMobileGatewayByID(zone string, id types.ID) *sacloud.MobileGateway {
+	v := s.getByID(ResourceMobileGateway, zone, id)
+	if v, ok := v.(*sacloud.MobileGateway); ok {
+		return v
+	}
+	return nil
+}
+
+func (s *store) setMobileGateway(zone string, value *sacloud.MobileGateway) {
+	s.set(ResourceMobileGateway, zone, value)
+}
+
 func (s *store) getNFS(zone string) []*sacloud.NFS {
 	values := s.get(ResourceNFS, zone)
 	var ret []*sacloud.NFS

--- a/sacloud/naked/interface.go
+++ b/sacloud/naked/interface.go
@@ -20,7 +20,7 @@ type Interface struct {
 	// Index 仮想フィールド、VPCルータなどでInterfaces(実体は[]*Interface)を扱う場合にUnmarshalJSONの中で設定される
 	//
 	// Findした際のAPIからの応答にも同名のフィールドが含まれるが無関係。
-	Index int `json:"-" yaml:"-" structs:"-"`
+	Index int
 }
 
 // Interfaces Interface配列
@@ -39,7 +39,9 @@ func (i *Interfaces) UnmarshalJSON(b []byte) error {
 	var dest []*Interface
 	for i, v := range a {
 		if v != nil {
-			v.Index = i
+			if v.Index == 0 {
+				v.Index = i
+			}
 			dest = append(dest, v)
 		}
 	}
@@ -49,18 +51,44 @@ func (i *Interfaces) UnmarshalJSON(b []byte) error {
 }
 
 // MarshalJSON 配列中にnullが入る場合(VPCルータなど)への対応
-func (i *Interfaces) MarshalJSON() ([]byte, error) {
+func (i Interfaces) MarshalJSON() ([]byte, error) {
 	max := 0
-	for _, iface := range *i {
+	for _, iface := range i {
 		if max < iface.Index {
 			max = iface.Index
 		}
 	}
 
-	var dest = make([]*Interface, max)
-	for _, iface := range *i {
+	var dest = make([]*Interface, max+1)
+	for _, iface := range i {
 		dest[iface.Index] = iface
 	}
 
 	return json.Marshal(dest)
+}
+
+// MarshalJSON JSON
+func (i *Interface) MarshalJSON() ([]byte, error) {
+	type alias struct {
+		ID            types.ID          `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
+		MACAddress    string            `json:",omitempty" yaml:"mac_address,omitempty" structs:",omitempty"`
+		IPAddress     string            `json:",omitempty" yaml:"ip_address,omitempty" structs:",omitempty"`
+		UserIPAddress string            `json:",omitempty" yaml:"user_ip_address,omitempty" structs:",omitempty"`
+		HostName      string            `json:",omitempty" yaml:"host_name,omitempty" structs:",omitempty"`
+		Switch        *Switch           `json:",omitempty" yaml:"switch,omitempty" structs:",omitempty"`
+		PacketFilter  *PacketFilterInfo `json:",omitempty" yaml:"packet_filter,omitempty" structs:",omitempty"`
+		Server        *Server           `json:",omitempty" yaml:"server,omitempty" structs:",omitempty"`
+	}
+
+	tmp := alias{
+		ID:            i.ID,
+		MACAddress:    i.MACAddress,
+		IPAddress:     i.IPAddress,
+		UserIPAddress: i.UserIPAddress,
+		HostName:      i.HostName,
+		Switch:        i.Switch,
+		PacketFilter:  i.PacketFilter,
+		Server:        i.Server,
+	}
+	return json.Marshal(tmp)
 }

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -2258,6 +2258,366 @@ func (s *LoadBalancerStub) Status(ctx context.Context, zone string, id types.ID)
 }
 
 /*************************************************
+* MobileGatewayStub
+*************************************************/
+
+// MobileGatewayFindStubResult is expected values of the Find operation
+type MobileGatewayFindStubResult struct {
+	Values *sacloud.MobileGatewayFindResult
+	Err    error
+}
+
+// MobileGatewayCreateStubResult is expected values of the Create operation
+type MobileGatewayCreateStubResult struct {
+	MobileGateway *sacloud.MobileGateway
+	Err           error
+}
+
+// MobileGatewayReadStubResult is expected values of the Read operation
+type MobileGatewayReadStubResult struct {
+	MobileGateway *sacloud.MobileGateway
+	Err           error
+}
+
+// MobileGatewayUpdateStubResult is expected values of the Update operation
+type MobileGatewayUpdateStubResult struct {
+	MobileGateway *sacloud.MobileGateway
+	Err           error
+}
+
+// MobileGatewayDeleteStubResult is expected values of the Delete operation
+type MobileGatewayDeleteStubResult struct {
+	Err error
+}
+
+// MobileGatewayConfigStubResult is expected values of the Config operation
+type MobileGatewayConfigStubResult struct {
+	Err error
+}
+
+// MobileGatewayBootStubResult is expected values of the Boot operation
+type MobileGatewayBootStubResult struct {
+	Err error
+}
+
+// MobileGatewayShutdownStubResult is expected values of the Shutdown operation
+type MobileGatewayShutdownStubResult struct {
+	Err error
+}
+
+// MobileGatewayResetStubResult is expected values of the Reset operation
+type MobileGatewayResetStubResult struct {
+	Err error
+}
+
+// MobileGatewayConnectToSwitchStubResult is expected values of the ConnectToSwitch operation
+type MobileGatewayConnectToSwitchStubResult struct {
+	Err error
+}
+
+// MobileGatewayDisconnectFromSwitchStubResult is expected values of the DisconnectFromSwitch operation
+type MobileGatewayDisconnectFromSwitchStubResult struct {
+	Err error
+}
+
+// MobileGatewayGetDNSStubResult is expected values of the GetDNS operation
+type MobileGatewayGetDNSStubResult struct {
+	SIMGroup *sacloud.MobileGatewayDNSSetting
+	Err      error
+}
+
+// MobileGatewaySetDNSStubResult is expected values of the SetDNS operation
+type MobileGatewaySetDNSStubResult struct {
+	Err error
+}
+
+// MobileGatewayGetSIMRoutesStubResult is expected values of the GetSIMRoutes operation
+type MobileGatewayGetSIMRoutesStubResult struct {
+	SIMRoutes []*sacloud.MobileGatewaySIMRoute
+	Err       error
+}
+
+// MobileGatewaySetSIMRoutesStubResult is expected values of the SetSIMRoutes operation
+type MobileGatewaySetSIMRoutesStubResult struct {
+	Err error
+}
+
+// MobileGatewayListSIMStubResult is expected values of the ListSIM operation
+type MobileGatewayListSIMStubResult struct {
+	SIM []*sacloud.MobileGatewaySIMInfo
+	Err error
+}
+
+// MobileGatewayAddSIMStubResult is expected values of the AddSIM operation
+type MobileGatewayAddSIMStubResult struct {
+	Err error
+}
+
+// MobileGatewayDeleteSIMStubResult is expected values of the DeleteSIM operation
+type MobileGatewayDeleteSIMStubResult struct {
+	Err error
+}
+
+// MobileGatewayLogsStubResult is expected values of the Logs operation
+type MobileGatewayLogsStubResult struct {
+	Logs []*sacloud.MobileGatewaySIMLogs
+	Err  error
+}
+
+// MobileGatewayGetTrafficConfigStubResult is expected values of the GetTrafficConfig operation
+type MobileGatewayGetTrafficConfigStubResult struct {
+	TrafficMonitoring *sacloud.MobileGatewayTrafficControl
+	Err               error
+}
+
+// MobileGatewaySetTrafficConfigStubResult is expected values of the SetTrafficConfig operation
+type MobileGatewaySetTrafficConfigStubResult struct {
+	Err error
+}
+
+// MobileGatewayDeleteTrafficConfigStubResult is expected values of the DeleteTrafficConfig operation
+type MobileGatewayDeleteTrafficConfigStubResult struct {
+	Err error
+}
+
+// MobileGatewayTrafficStatusStubResult is expected values of the TrafficStatus operation
+type MobileGatewayTrafficStatusStubResult struct {
+	TrafficStatus *sacloud.MobileGatewayTrafficStatus
+	Err           error
+}
+
+// MobileGatewayMonitorInterfaceStubResult is expected values of the MonitorInterface operation
+type MobileGatewayMonitorInterfaceStubResult struct {
+	InterfaceActivity *sacloud.InterfaceActivity
+	Err               error
+}
+
+// MobileGatewayStub is for trace MobileGatewayOp operations
+type MobileGatewayStub struct {
+	FindStubResult                 *MobileGatewayFindStubResult
+	CreateStubResult               *MobileGatewayCreateStubResult
+	ReadStubResult                 *MobileGatewayReadStubResult
+	UpdateStubResult               *MobileGatewayUpdateStubResult
+	DeleteStubResult               *MobileGatewayDeleteStubResult
+	ConfigStubResult               *MobileGatewayConfigStubResult
+	BootStubResult                 *MobileGatewayBootStubResult
+	ShutdownStubResult             *MobileGatewayShutdownStubResult
+	ResetStubResult                *MobileGatewayResetStubResult
+	ConnectToSwitchStubResult      *MobileGatewayConnectToSwitchStubResult
+	DisconnectFromSwitchStubResult *MobileGatewayDisconnectFromSwitchStubResult
+	GetDNSStubResult               *MobileGatewayGetDNSStubResult
+	SetDNSStubResult               *MobileGatewaySetDNSStubResult
+	GetSIMRoutesStubResult         *MobileGatewayGetSIMRoutesStubResult
+	SetSIMRoutesStubResult         *MobileGatewaySetSIMRoutesStubResult
+	ListSIMStubResult              *MobileGatewayListSIMStubResult
+	AddSIMStubResult               *MobileGatewayAddSIMStubResult
+	DeleteSIMStubResult            *MobileGatewayDeleteSIMStubResult
+	LogsStubResult                 *MobileGatewayLogsStubResult
+	GetTrafficConfigStubResult     *MobileGatewayGetTrafficConfigStubResult
+	SetTrafficConfigStubResult     *MobileGatewaySetTrafficConfigStubResult
+	DeleteTrafficConfigStubResult  *MobileGatewayDeleteTrafficConfigStubResult
+	TrafficStatusStubResult        *MobileGatewayTrafficStatusStubResult
+	MonitorInterfaceStubResult     *MobileGatewayMonitorInterfaceStubResult
+}
+
+// NewMobileGatewayStub creates new MobileGatewayStub instance
+func NewMobileGatewayStub(caller sacloud.APICaller) sacloud.MobileGatewayAPI {
+	return &MobileGatewayStub{}
+}
+
+// Find is API call with trace log
+func (s *MobileGatewayStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.MobileGatewayFindResult, error) {
+	if s.FindStubResult == nil {
+		log.Fatal("MobileGatewayStub.FindStubResult is not set")
+	}
+	return s.FindStubResult.Values, s.FindStubResult.Err
+}
+
+// Create is API call with trace log
+func (s *MobileGatewayStub) Create(ctx context.Context, zone string, param *sacloud.MobileGatewayCreateRequest) (*sacloud.MobileGateway, error) {
+	if s.CreateStubResult == nil {
+		log.Fatal("MobileGatewayStub.CreateStubResult is not set")
+	}
+	return s.CreateStubResult.MobileGateway, s.CreateStubResult.Err
+}
+
+// Read is API call with trace log
+func (s *MobileGatewayStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGateway, error) {
+	if s.ReadStubResult == nil {
+		log.Fatal("MobileGatewayStub.ReadStubResult is not set")
+	}
+	return s.ReadStubResult.MobileGateway, s.ReadStubResult.Err
+}
+
+// Update is API call with trace log
+func (s *MobileGatewayStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayUpdateRequest) (*sacloud.MobileGateway, error) {
+	if s.UpdateStubResult == nil {
+		log.Fatal("MobileGatewayStub.UpdateStubResult is not set")
+	}
+	return s.UpdateStubResult.MobileGateway, s.UpdateStubResult.Err
+}
+
+// Delete is API call with trace log
+func (s *MobileGatewayStub) Delete(ctx context.Context, zone string, id types.ID) error {
+	if s.DeleteStubResult == nil {
+		log.Fatal("MobileGatewayStub.DeleteStubResult is not set")
+	}
+	return s.DeleteStubResult.Err
+}
+
+// Config is API call with trace log
+func (s *MobileGatewayStub) Config(ctx context.Context, zone string, id types.ID) error {
+	if s.ConfigStubResult == nil {
+		log.Fatal("MobileGatewayStub.ConfigStubResult is not set")
+	}
+	return s.ConfigStubResult.Err
+}
+
+// Boot is API call with trace log
+func (s *MobileGatewayStub) Boot(ctx context.Context, zone string, id types.ID) error {
+	if s.BootStubResult == nil {
+		log.Fatal("MobileGatewayStub.BootStubResult is not set")
+	}
+	return s.BootStubResult.Err
+}
+
+// Shutdown is API call with trace log
+func (s *MobileGatewayStub) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
+	if s.ShutdownStubResult == nil {
+		log.Fatal("MobileGatewayStub.ShutdownStubResult is not set")
+	}
+	return s.ShutdownStubResult.Err
+}
+
+// Reset is API call with trace log
+func (s *MobileGatewayStub) Reset(ctx context.Context, zone string, id types.ID) error {
+	if s.ResetStubResult == nil {
+		log.Fatal("MobileGatewayStub.ResetStubResult is not set")
+	}
+	return s.ResetStubResult.Err
+}
+
+// ConnectToSwitch is API call with trace log
+func (s *MobileGatewayStub) ConnectToSwitch(ctx context.Context, zone string, id types.ID, switchID types.ID) error {
+	if s.ConnectToSwitchStubResult == nil {
+		log.Fatal("MobileGatewayStub.ConnectToSwitchStubResult is not set")
+	}
+	return s.ConnectToSwitchStubResult.Err
+}
+
+// DisconnectFromSwitch is API call with trace log
+func (s *MobileGatewayStub) DisconnectFromSwitch(ctx context.Context, zone string, id types.ID) error {
+	if s.DisconnectFromSwitchStubResult == nil {
+		log.Fatal("MobileGatewayStub.DisconnectFromSwitchStubResult is not set")
+	}
+	return s.DisconnectFromSwitchStubResult.Err
+}
+
+// GetDNS is API call with trace log
+func (s *MobileGatewayStub) GetDNS(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayDNSSetting, error) {
+	if s.GetDNSStubResult == nil {
+		log.Fatal("MobileGatewayStub.GetDNSStubResult is not set")
+	}
+	return s.GetDNSStubResult.SIMGroup, s.GetDNSStubResult.Err
+}
+
+// SetDNS is API call with trace log
+func (s *MobileGatewayStub) SetDNS(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayDNSSetting) error {
+	if s.SetDNSStubResult == nil {
+		log.Fatal("MobileGatewayStub.SetDNSStubResult is not set")
+	}
+	return s.SetDNSStubResult.Err
+}
+
+// GetSIMRoutes is API call with trace log
+func (s *MobileGatewayStub) GetSIMRoutes(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMRoute, error) {
+	if s.GetSIMRoutesStubResult == nil {
+		log.Fatal("MobileGatewayStub.GetSIMRoutesStubResult is not set")
+	}
+	return s.GetSIMRoutesStubResult.SIMRoutes, s.GetSIMRoutesStubResult.Err
+}
+
+// SetSIMRoutes is API call with trace log
+func (s *MobileGatewayStub) SetSIMRoutes(ctx context.Context, zone string, id types.ID, param []*sacloud.MobileGatewaySIMRouteParam) error {
+	if s.SetSIMRoutesStubResult == nil {
+		log.Fatal("MobileGatewayStub.SetSIMRoutesStubResult is not set")
+	}
+	return s.SetSIMRoutesStubResult.Err
+}
+
+// ListSIM is API call with trace log
+func (s *MobileGatewayStub) ListSIM(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMInfo, error) {
+	if s.ListSIMStubResult == nil {
+		log.Fatal("MobileGatewayStub.ListSIMStubResult is not set")
+	}
+	return s.ListSIMStubResult.SIM, s.ListSIMStubResult.Err
+}
+
+// AddSIM is API call with trace log
+func (s *MobileGatewayStub) AddSIM(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayAddSIMRequest) error {
+	if s.AddSIMStubResult == nil {
+		log.Fatal("MobileGatewayStub.AddSIMStubResult is not set")
+	}
+	return s.AddSIMStubResult.Err
+}
+
+// DeleteSIM is API call with trace log
+func (s *MobileGatewayStub) DeleteSIM(ctx context.Context, zone string, id types.ID, simID types.ID) error {
+	if s.DeleteSIMStubResult == nil {
+		log.Fatal("MobileGatewayStub.DeleteSIMStubResult is not set")
+	}
+	return s.DeleteSIMStubResult.Err
+}
+
+// Logs is API call with trace log
+func (s *MobileGatewayStub) Logs(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMLogs, error) {
+	if s.LogsStubResult == nil {
+		log.Fatal("MobileGatewayStub.LogsStubResult is not set")
+	}
+	return s.LogsStubResult.Logs, s.LogsStubResult.Err
+}
+
+// GetTrafficConfig is API call with trace log
+func (s *MobileGatewayStub) GetTrafficConfig(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayTrafficControl, error) {
+	if s.GetTrafficConfigStubResult == nil {
+		log.Fatal("MobileGatewayStub.GetTrafficConfigStubResult is not set")
+	}
+	return s.GetTrafficConfigStubResult.TrafficMonitoring, s.GetTrafficConfigStubResult.Err
+}
+
+// SetTrafficConfig is API call with trace log
+func (s *MobileGatewayStub) SetTrafficConfig(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayTrafficControl) error {
+	if s.SetTrafficConfigStubResult == nil {
+		log.Fatal("MobileGatewayStub.SetTrafficConfigStubResult is not set")
+	}
+	return s.SetTrafficConfigStubResult.Err
+}
+
+// DeleteTrafficConfig is API call with trace log
+func (s *MobileGatewayStub) DeleteTrafficConfig(ctx context.Context, zone string, id types.ID) error {
+	if s.DeleteTrafficConfigStubResult == nil {
+		log.Fatal("MobileGatewayStub.DeleteTrafficConfigStubResult is not set")
+	}
+	return s.DeleteTrafficConfigStubResult.Err
+}
+
+// TrafficStatus is API call with trace log
+func (s *MobileGatewayStub) TrafficStatus(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayTrafficStatus, error) {
+	if s.TrafficStatusStubResult == nil {
+		log.Fatal("MobileGatewayStub.TrafficStatusStubResult is not set")
+	}
+	return s.TrafficStatusStubResult.TrafficStatus, s.TrafficStatusStubResult.Err
+}
+
+// MonitorInterface is API call with trace log
+func (s *MobileGatewayStub) MonitorInterface(ctx context.Context, zone string, id types.ID, index int, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
+	if s.MonitorInterfaceStubResult == nil {
+		log.Fatal("MobileGatewayStub.MonitorInterfaceStubResult is not set")
+	}
+	return s.MonitorInterfaceStubResult.InterfaceActivity, s.MonitorInterfaceStubResult.Err
+}
+
+/*************************************************
 * NFSStub
 *************************************************/
 
@@ -3267,8 +3627,8 @@ type SIMLogsStubResult struct {
 
 // SIMGetNetworkOperatorStubResult is expected values of the GetNetworkOperator operation
 type SIMGetNetworkOperatorStubResult struct {
-	Values *sacloud.SIMGetNetworkOperatorResult
-	Err    error
+	Configs []*sacloud.SIMNetworkOperatorConfig
+	Err     error
 }
 
 // SIMSetNetworkOperatorStubResult is expected values of the SetNetworkOperator operation
@@ -3280,6 +3640,12 @@ type SIMSetNetworkOperatorStubResult struct {
 type SIMMonitorSIMStubResult struct {
 	LinkActivity *sacloud.LinkActivity
 	Err          error
+}
+
+// SIMStatusStubResult is expected values of the Status operation
+type SIMStatusStubResult struct {
+	SIM *sacloud.SIMInfo
+	Err error
 }
 
 // SIMStub is for trace SIMOp operations
@@ -3299,6 +3665,7 @@ type SIMStub struct {
 	GetNetworkOperatorStubResult *SIMGetNetworkOperatorStubResult
 	SetNetworkOperatorStubResult *SIMSetNetworkOperatorStubResult
 	MonitorSIMStubResult         *SIMMonitorSIMStubResult
+	StatusStubResult             *SIMStatusStubResult
 }
 
 // NewSIMStub creates new SIMStub instance
@@ -3403,15 +3770,15 @@ func (s *SIMStub) Logs(ctx context.Context, zone string, id types.ID) (*sacloud.
 }
 
 // GetNetworkOperator is API call with trace log
-func (s *SIMStub) GetNetworkOperator(ctx context.Context, zone string, id types.ID) (*sacloud.SIMGetNetworkOperatorResult, error) {
+func (s *SIMStub) GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*sacloud.SIMNetworkOperatorConfig, error) {
 	if s.GetNetworkOperatorStubResult == nil {
 		log.Fatal("SIMStub.GetNetworkOperatorStubResult is not set")
 	}
-	return s.GetNetworkOperatorStubResult.Values, s.GetNetworkOperatorStubResult.Err
+	return s.GetNetworkOperatorStubResult.Configs, s.GetNetworkOperatorStubResult.Err
 }
 
 // SetNetworkOperator is API call with trace log
-func (s *SIMStub) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs *sacloud.SIMNetworkOperatorConfigs) error {
+func (s *SIMStub) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*sacloud.SIMNetworkOperatorConfig) error {
 	if s.SetNetworkOperatorStubResult == nil {
 		log.Fatal("SIMStub.SetNetworkOperatorStubResult is not set")
 	}
@@ -3424,6 +3791,14 @@ func (s *SIMStub) MonitorSIM(ctx context.Context, zone string, id types.ID, cond
 		log.Fatal("SIMStub.MonitorSIMStubResult is not set")
 	}
 	return s.MonitorSIMStubResult.LinkActivity, s.MonitorSIMStubResult.Err
+}
+
+// Status is API call with trace log
+func (s *SIMStub) Status(ctx context.Context, zone string, id types.ID) (*sacloud.SIMInfo, error) {
+	if s.StatusStubResult == nil {
+		log.Fatal("SIMStub.StatusStubResult is not set")
+	}
+	return s.StatusStubResult.SIM, s.StatusStubResult.Err
 }
 
 /*************************************************

--- a/sacloud/test/gslb_op_test.go
+++ b/sacloud/test/gslb_op_test.go
@@ -94,12 +94,10 @@ var (
 		DestinationServers: []*sacloud.GSLBServer{
 			{
 				IPAddress: "192.2.0.1",
-				Weight:    types.StringNumber(1),
 				Enabled:   types.StringTrue,
 			},
 			{
 				IPAddress: "192.2.0.2",
-				Weight:    types.StringNumber(1),
 				Enabled:   types.StringTrue,
 			},
 		},

--- a/sacloud/test/mobile_gateway_op_test.go
+++ b/sacloud/test/mobile_gateway_op_test.go
@@ -1,0 +1,464 @@
+package test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+func TestMobileGatewayOpCRUD(t *testing.T) {
+
+	PreCheckEnvsFunc("SAKURACLOUD_SIM_ICCID", "SAKURACLOUD_SIM_PASSCODE")(t)
+
+	initMobileGatewayVariables()
+
+	Run(t, &CRUDTestCase{
+		Parallel: true,
+
+		SetupAPICallerFunc: singletonAPICaller,
+
+		Create: &CRUDTestFunc{
+			Func: testMobileGatewayCreate,
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
+				ExpectValue:  createMobileGatewayExpected,
+				IgnoreFields: ignoreMobileGatewayFields,
+			}),
+		},
+
+		Read: &CRUDTestFunc{
+			Func: testMobileGatewayRead,
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
+				ExpectValue:  createMobileGatewayExpected,
+				IgnoreFields: ignoreMobileGatewayFields,
+			}),
+		},
+
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testMobileGatewayUpdate,
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
+					ExpectValue:  updateMobileGatewayExpected,
+					IgnoreFields: ignoreMobileGatewayFields,
+				}),
+			},
+			// shutdown(no check)
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					// shutdown
+					if err := mgwOp.Shutdown(context.Background(), testZone, testContext.ID, &sacloud.ShutdownOption{Force: true}); err != nil {
+						return nil, err
+					}
+
+					waiter := sacloud.WaiterForDown(func() (interface{}, error) {
+						return mgwOp.Read(context.Background(), testZone, testContext.ID)
+					})
+
+					return waiter.WaitForState(context.Background())
+				},
+				SkipExtractID: true,
+			},
+			// connect to switch
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					// prepare switch
+					swOp := sacloud.NewSwitchOp(caller)
+					sw, err := swOp.Create(context.Background(), testZone, &sacloud.SwitchCreateRequest{
+						Name: "libsacloud-test-mobile-gateway",
+					})
+					if err != nil {
+						return nil, err
+					}
+
+					// connect
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					if err := mgwOp.ConnectToSwitch(context.Background(), testZone, testContext.ID, sw.ID); err != nil {
+						return nil, err
+					}
+
+					return mgwOp.Read(context.Background(), testZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					mgw := i.(*sacloud.MobileGateway)
+					return DoAsserts(
+						AssertLenFunc(t, mgw.Interfaces, 2, "len(MobileGateway.Interfaces)"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// set IPAddress to eth1
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					return mgwOp.Update(context.Background(), testZone, testContext.ID, &sacloud.MobileGatewayUpdateRequest{
+						Settings: &sacloud.MobileGatewaySetting{
+							Interfaces: []*sacloud.MobileGatewayInterfaceSetting{
+								{
+									IPAddress:      []string{"192.168.2.11"},
+									NetworkMaskLen: 24,
+									Index:          1,
+								},
+							},
+						},
+					})
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					mgw := i.(*sacloud.MobileGateway)
+					return DoAsserts(
+						AssertNotNilFunc(t, mgw.Settings.Interfaces, "MobileGateway.Settings.Interfaces"),
+						AssertEqualFunc(t, 1, mgw.Settings.Interfaces[0].Index, "MobileGateway.Settings.Interfaces.Index"),
+						AssertEqualFunc(t, "192.168.2.11", mgw.Settings.Interfaces[0].IPAddress[0], "MobileGateway.Settings.Interfaces.IPAddress"),
+						AssertEqualFunc(t, 24, mgw.Settings.Interfaces[0].NetworkMaskLen, "MobileGateway.Settings.Interfaces.NetworkMaskLen"),
+					)
+				},
+				SkipExtractID: true,
+			},
+
+			// Get/Set DNS
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					if err := mgwOp.SetDNS(context.Background(), testZone, testContext.ID, &sacloud.MobileGatewayDNSSetting{
+						DNS1: "8.8.8.8",
+						DNS2: "8.8.4.4",
+					}); err != nil {
+						return nil, err
+					}
+					return mgwOp.GetDNS(context.Background(), testZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					dns := i.(*sacloud.MobileGatewayDNSSetting)
+					return DoAsserts(
+						AssertEqualFunc(t, "8.8.8.8", dns.DNS1, "DNS1"),
+						AssertEqualFunc(t, "8.8.4.4", dns.DNS2, "DNS2"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// Add/List SIM
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					simOp := sacloud.NewSIMOp(caller)
+					sim, err := simOp.Create(context.Background(), sacloud.APIDefaultZone, &sacloud.SIMCreateRequest{
+						Name:     "libsacloud-test-mobile-gateway",
+						ICCID:    iccid,
+						PassCode: passcode,
+					})
+					if err != nil {
+						return nil, err
+					}
+
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					if err := mgwOp.AddSIM(context.Background(), testZone, testContext.ID, &sacloud.MobileGatewayAddSIMRequest{
+						SIMID: sim.ID.String(),
+					}); err != nil {
+						return nil, err
+					}
+
+					testContext.Values["mobile-gateway/sim"] = sim.ID
+					return mgwOp.ListSIM(context.Background(), testZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					sims := i.([]*sacloud.MobileGatewaySIMInfo)
+					return DoAsserts(
+						AssertLenFunc(t, sims, 1, "len(SIM)"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// SIMOp: Assign IP
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					client := sacloud.NewSIMOp(caller)
+					simID := testContext.Values["mobile-gateway/sim"].(types.ID)
+					if err := client.AssignIP(context.Background(), sacloud.APIDefaultZone, simID, &sacloud.SIMAssignIPRequest{
+						IP: "192.168.2.1",
+					}); err != nil {
+						return nil, err
+					}
+					return client.Status(context.Background(), sacloud.APIDefaultZone, simID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
+					simInfo := v.(*sacloud.SIMInfo)
+					return DoAsserts(
+						AssertEqualFunc(t, "192.168.2.1", simInfo.IP, "SIMInfo.IP"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// SIMOp: clear IP
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					client := sacloud.NewSIMOp(caller)
+					simID := testContext.Values["mobile-gateway/sim"].(types.ID)
+					if err := client.ClearIP(context.Background(), sacloud.APIDefaultZone, simID); err != nil {
+						return nil, err
+					}
+					return client.Status(context.Background(), sacloud.APIDefaultZone, simID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
+					simInfo := v.(*sacloud.SIMInfo)
+					return DoAsserts(
+						AssertEmptyFunc(t, simInfo.IP, "SIMInfo.IP"),
+					)
+				},
+				SkipExtractID: true,
+			},
+
+			// Get/Set SIMRoutes
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					if err := mgwOp.SetSIMRoutes(context.Background(), testZone, testContext.ID, []*sacloud.MobileGatewaySIMRouteParam{
+						{
+							ResourceID: testContext.Values["mobile-gateway/sim"].(types.ID).String(),
+							Prefix:     "192.168.3.0/24",
+						},
+					}); err != nil {
+						return nil, err
+					}
+					return mgwOp.GetSIMRoutes(context.Background(), testZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					routes := i.([]*sacloud.MobileGatewaySIMRoute)
+					simID := testContext.Values["mobile-gateway/sim"].(types.ID)
+					return DoAsserts(
+						AssertLenFunc(t, routes, 1, "len(SIMRoutes)"),
+						AssertEqualFunc(t, "192.168.3.0/24", routes[0].Prefix, "SIMRoute.Prefix"),
+						AssertEqualFunc(t, simID.String(), routes[0].ResourceID, "SIMRoute.ResourceID"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// Delete SIMRoutes
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					if err := mgwOp.SetSIMRoutes(context.Background(), testZone, testContext.ID, []*sacloud.MobileGatewaySIMRouteParam{}); err != nil {
+						return nil, err
+					}
+					return mgwOp.GetSIMRoutes(context.Background(), testZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					routes := i.([]*sacloud.MobileGatewaySIMRoute)
+					return DoAsserts(
+						AssertLenFunc(t, routes, 0, "len(SIMRoutes)"),
+					)
+				},
+				SkipExtractID: true,
+			},
+
+			// Get/Set TrafficConfig
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					if err := mgwOp.SetTrafficConfig(context.Background(), testZone, testContext.ID, &sacloud.MobileGatewayTrafficControl{
+						TrafficQuotaInMB:       10,
+						BandWidthLimitInKbps:   20,
+						EmailNotifyEnabled:     true,
+						SlackNotifyEnabled:     true,
+						SlackNotifyWebhooksURL: "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX",
+						AutoTrafficShaping:     true,
+					}); err != nil {
+						return nil, err
+					}
+					return mgwOp.GetTrafficConfig(context.Background(), testZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					slackURL := "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX"
+					config := i.(*sacloud.MobileGatewayTrafficControl)
+					return DoAsserts(
+						AssertEqualFunc(t, 10, config.TrafficQuotaInMB, "TrafficConfig.TrafficQuotaInMB"),
+						AssertEqualFunc(t, 20, config.BandWidthLimitInKbps, "TrafficConfig.BandWidthLimitInKbps"),
+						AssertEqualFunc(t, true, config.EmailNotifyEnabled, "TrafficConfig.EmailNotifyEnabled"),
+						AssertEqualFunc(t, true, config.SlackNotifyEnabled, "TrafficConfig.SlackNotifyEnabled"),
+						AssertEqualFunc(t, slackURL, config.SlackNotifyWebhooksURL, "TrafficConfig.SlackNotifyWebhooksURL"),
+						AssertEqualFunc(t, true, config.AutoTrafficShaping, "TrafficConfig.AutoTrafficShaping"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// Delete TrafficConfig(no check)
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					return nil, mgwOp.DeleteTrafficConfig(context.Background(), testZone, testContext.ID)
+				},
+				SkipExtractID: true,
+			},
+
+			// Get TrafficStatus
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					return mgwOp.TrafficStatus(context.Background(), testZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					status := i.(*sacloud.MobileGatewayTrafficStatus)
+					return DoAsserts(
+						AssertNotNilFunc(t, status, "TrafficStatus"),
+						AssertEqualFunc(t, types.StringNumber(0), status.UplinkBytes, "TrafficStatus.UplinkBytes"),
+						AssertEqualFunc(t, types.StringNumber(0), status.DownlinkBytes, "TrafficStatus.DownlinkBytes"),
+					)
+				},
+				SkipExtractID: true,
+			},
+
+			// Delete SIM
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					simID := testContext.Values["mobile-gateway/sim"].(types.ID)
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					if err := mgwOp.DeleteSIM(context.Background(), testZone, testContext.ID, simID); err != nil {
+						return nil, err
+					}
+
+					simOp := sacloud.NewSIMOp(caller)
+					if err := simOp.Delete(context.Background(), testZone, simID); err != nil {
+						return nil, err
+					}
+
+					return mgwOp.ListSIM(context.Background(), testZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					sims := i.([]*sacloud.MobileGatewaySIMInfo)
+					return DoAsserts(
+						AssertLenFunc(t, sims, 0, "len(SIM)"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// disconnect from switch
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					mgwOp := sacloud.NewMobileGatewayOp(caller)
+					if err := mgwOp.DisconnectFromSwitch(context.Background(), testZone, testContext.ID); err != nil {
+						return nil, err
+					}
+					return mgwOp.Read(context.Background(), testZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, i interface{}) error {
+					mgw := i.(*sacloud.MobileGateway)
+					return DoAsserts(
+						AssertLenFunc(t, mgw.Interfaces, 1, "len(MobileGateway.Interfaces)"),
+					)
+				},
+				SkipExtractID: true,
+			},
+		},
+		Shutdown: func(testContext *CRUDTestContext, caller sacloud.APICaller) error {
+			client := sacloud.NewMobileGatewayOp(caller)
+			return client.Shutdown(context.Background(), testZone, testContext.ID, &sacloud.ShutdownOption{Force: true})
+		},
+		Delete: &CRUDTestDeleteFunc{
+			Func: testMobileGatewayDelete,
+		},
+	})
+}
+
+func initMobileGatewayVariables() {
+
+	iccid = os.Getenv("SAKURACLOUD_SIM_ICCID")
+	passcode = os.Getenv("SAKURACLOUD_SIM_PASSCODE")
+
+	createMobileGatewayParam = &sacloud.MobileGatewayCreateRequest{
+		Name:        "libsacloud-mobile-gateway",
+		Description: "desc",
+		Tags:        []string{"tag1", "tag2"},
+		PlanID:      types.ID(1),
+		Settings: &sacloud.MobileGatewaySettingCreate{
+			InternetConnectionEnabled:       true,
+			InterDeviceCommunicationEnabled: true,
+		},
+	}
+	createMobileGatewayExpected = &sacloud.MobileGateway{
+		Name:         createMobileGatewayParam.Name,
+		Description:  createMobileGatewayParam.Description,
+		Tags:         createMobileGatewayParam.Tags,
+		Availability: types.Availabilities.Available,
+		PlanID:       createMobileGatewayParam.PlanID,
+		Settings: &sacloud.MobileGatewaySetting{
+			InternetConnectionEnabled:       true,
+			InterDeviceCommunicationEnabled: true,
+		},
+	}
+	updateMobileGatewayParam = &sacloud.MobileGatewayUpdateRequest{
+		Name:        "libsacloud-mobile-gateway-upd",
+		Description: "desc-upd",
+		Tags:        []string{"tag1-upd", "tag2-upd"},
+		Settings: &sacloud.MobileGatewaySetting{
+			InternetConnectionEnabled:       false,
+			InterDeviceCommunicationEnabled: false,
+		},
+	}
+	updateMobileGatewayExpected = &sacloud.MobileGateway{
+		Name:         updateMobileGatewayParam.Name,
+		Description:  updateMobileGatewayParam.Description,
+		Tags:         updateMobileGatewayParam.Tags,
+		Availability: types.Availabilities.Available,
+		PlanID:       createMobileGatewayParam.PlanID,
+		Settings: &sacloud.MobileGatewaySetting{
+			InternetConnectionEnabled:       false,
+			InterDeviceCommunicationEnabled: false,
+		},
+	}
+}
+
+var (
+	ignoreMobileGatewayFields = []string{
+		"ID",
+		"Class",
+		"IconID",
+		"CreatedAt",
+		"Availability",
+		"InstanceHostName",
+		"InstanceHostInfoURL",
+		"InstanceStatus",
+		"InstanceStatusChangedAt",
+		"Interfaces",
+		"ZoneID",
+		"SettingsHash",
+	}
+	iccid                       string
+	passcode                    string
+	createMobileGatewayParam    *sacloud.MobileGatewayCreateRequest
+	createMobileGatewayExpected *sacloud.MobileGateway
+	updateMobileGatewayParam    *sacloud.MobileGatewayUpdateRequest
+	updateMobileGatewayExpected *sacloud.MobileGateway
+)
+
+func testMobileGatewayCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewMobileGatewayOp(caller)
+	v, err := client.Create(context.Background(), testZone, createMobileGatewayParam)
+	if err != nil {
+		return nil, err
+	}
+	value, err := sacloud.WaiterForReady(func() (interface{}, error) {
+		return client.Read(context.Background(), testZone, v.ID)
+	}).WaitForState(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	if err := client.Boot(context.Background(), testZone, v.ID); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func testMobileGatewayRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewMobileGatewayOp(caller)
+	return client.Read(context.Background(), testZone, testContext.ID)
+}
+
+func testMobileGatewayUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewMobileGatewayOp(caller)
+	return client.Update(context.Background(), testZone, testContext.ID, updateMobileGatewayParam)
+}
+
+func testMobileGatewayDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
+	client := sacloud.NewMobileGatewayOp(caller)
+	return client.Delete(context.Background(), testZone, testContext.ID)
+}

--- a/sacloud/test/mobile_gateway_op_test.go
+++ b/sacloud/test/mobile_gateway_op_test.go
@@ -143,7 +143,7 @@ func TestMobileGatewayOpCRUD(t *testing.T) {
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					simOp := sacloud.NewSIMOp(caller)
 					sim, err := simOp.Create(context.Background(), sacloud.APIDefaultZone, &sacloud.SIMCreateRequest{
-						Name:     "libsacloud-test-mobile-gateway",
+						Name:     "libsacloud-switch-for-mobile-gateway",
 						ICCID:    iccid,
 						PassCode: passcode,
 					})

--- a/sacloud/test/sim_op_test.go
+++ b/sacloud/test/sim_op_test.go
@@ -1,0 +1,232 @@
+package test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSIMOpCRUD(t *testing.T) {
+
+	PreCheckEnvsFunc("SAKURACLOUD_SIM_ICCID", "SAKURACLOUD_SIM_PASSCODE")(t)
+
+	initSIMVariables()
+
+	Run(t, &CRUDTestCase{
+		Parallel:          true,
+		IgnoreStartupWait: true,
+
+		SetupAPICallerFunc: singletonAPICaller,
+
+		Create: &CRUDTestFunc{
+			Func: testSIMCreate,
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
+				ExpectValue:  createSIMExpected,
+				IgnoreFields: ignoreSIMFields,
+			}),
+		},
+
+		Read: &CRUDTestFunc{
+			Func: testSIMRead,
+			CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
+				ExpectValue:  createSIMExpected,
+				IgnoreFields: ignoreSIMFields,
+			}),
+		},
+
+		Updates: []*CRUDTestFunc{
+			{
+				Func: testSIMUpdate,
+				CheckFunc: AssertEqualWithExpected(&CRUDTestExpect{
+					ExpectValue:  updateSIMExpected,
+					IgnoreFields: ignoreSIMFields,
+				}),
+			},
+			// activate
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					client := sacloud.NewSIMOp(caller)
+					if err := client.Activate(context.Background(), sacloud.APIDefaultZone, testContext.ID); err != nil {
+						return nil, err
+					}
+					return client.Status(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
+					simInfo := v.(*sacloud.SIMInfo)
+					return DoAsserts(
+						AssertNotNilFunc(t, simInfo, "SIMInfo"),
+						AssertTrueFunc(t, simInfo.Activated, "SIMInfo.Activated"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// deactivate
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					client := sacloud.NewSIMOp(caller)
+					if err := client.Deactivate(context.Background(), sacloud.APIDefaultZone, testContext.ID); err != nil {
+						return nil, err
+					}
+					return client.Status(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
+					simInfo := v.(*sacloud.SIMInfo)
+					return DoAsserts(
+						AssertNotNilFunc(t, simInfo, "SIMInfo"),
+						AssertFalseFunc(t, simInfo.Activated, "SIMInfo.Activated"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// IMEI lock
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					client := sacloud.NewSIMOp(caller)
+					if err := client.IMEILock(context.Background(), sacloud.APIDefaultZone, testContext.ID, &sacloud.SIMIMEILockRequest{
+						IMEI: "123456789012345",
+					}); err != nil {
+						return nil, err
+					}
+					return client.Status(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
+					simInfo := v.(*sacloud.SIMInfo)
+					return DoAsserts(
+						AssertTrueFunc(t, simInfo.IMEILock, "SIMInfo.IMEILock"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// IMEI unlock
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					client := sacloud.NewSIMOp(caller)
+					if err := client.IMEIUnlock(context.Background(), sacloud.APIDefaultZone, testContext.ID); err != nil {
+						return nil, err
+					}
+					return client.Status(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
+					simInfo := v.(*sacloud.SIMInfo)
+					return DoAsserts(
+						AssertFalseFunc(t, simInfo.IMEILock, "SIMInfo.IMEILock"),
+					)
+				},
+				SkipExtractID: true,
+			},
+			// network operator
+			{
+				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					client := sacloud.NewSIMOp(caller)
+					configs := []*sacloud.SIMNetworkOperatorConfig{
+						{
+							Name:  "SoftBank",
+							Allow: true,
+						},
+					}
+					if err := client.SetNetworkOperator(context.Background(), sacloud.APIDefaultZone, testContext.ID, configs); err != nil {
+						return nil, err
+					}
+					return client.GetNetworkOperator(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+				},
+				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
+					config := v.([]*sacloud.SIMNetworkOperatorConfig)
+					return DoAsserts(
+						AssertNotEmptyFunc(t, config, "NetworkOperatorConfig"),
+					)
+				},
+				SkipExtractID: true,
+			},
+		},
+
+		Delete: &CRUDTestDeleteFunc{
+			Func: testSIMDelete,
+		},
+	})
+}
+
+func TestSIMOp_Logs(t *testing.T) {
+	if !isAccTest() {
+		t.Skip("TestSIMOp_Logs only exec at Acceptance Test")
+	}
+	PreCheckEnvsFunc("SAKURACLOUD_SIM_ID")(t)
+	id := types.StringID(os.Getenv("SAKURACLOUD_SIM_ID"))
+
+	client := sacloud.NewSIMOp(singletonAPICaller())
+	logs, err := client.Logs(context.Background(), sacloud.APIDefaultZone, id)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, logs)
+
+}
+
+func initSIMVariables() {
+
+	iccid := os.Getenv("SAKURACLOUD_SIM_ICCID")
+	passcode := os.Getenv("SAKURACLOUD_SIM_PASSCODE")
+
+	createSIMParam = &sacloud.SIMCreateRequest{
+		Name:        "libsacloud-sim",
+		Description: "desc",
+		Tags:        []string{"tag1", "tag2"},
+		ICCID:       iccid,
+		PassCode:    passcode,
+	}
+	createSIMExpected = &sacloud.SIM{
+		Name:         createSIMParam.Name,
+		Description:  createSIMParam.Description,
+		Tags:         createSIMParam.Tags,
+		Availability: types.Availabilities.Available,
+		ICCID:        createSIMParam.ICCID,
+	}
+	updateSIMParam = &sacloud.SIMUpdateRequest{
+		Name:        "libsacloud-sim-upd",
+		Description: "desc-upd",
+		Tags:        []string{"tag1-upd", "tag2-upd"},
+	}
+	updateSIMExpected = &sacloud.SIM{
+		Name:         updateSIMParam.Name,
+		Description:  updateSIMParam.Description,
+		Tags:         updateSIMParam.Tags,
+		Availability: types.Availabilities.Available,
+		ICCID:        createSIMParam.ICCID,
+	}
+}
+
+var (
+	ignoreSIMFields = []string{
+		"ID",
+		"Class",
+		"IconID",
+		"Info",
+		"CreatedAt",
+		"ModifiedAt",
+	}
+	createSIMParam    *sacloud.SIMCreateRequest
+	createSIMExpected *sacloud.SIM
+	updateSIMParam    *sacloud.SIMUpdateRequest
+	updateSIMExpected *sacloud.SIM
+)
+
+func testSIMCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewSIMOp(caller)
+	return client.Create(context.Background(), sacloud.APIDefaultZone, createSIMParam)
+}
+
+func testSIMRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewSIMOp(caller)
+	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+}
+
+func testSIMUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewSIMOp(caller)
+	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateSIMParam)
+}
+
+func testSIMDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
+	client := sacloud.NewSIMOp(caller)
+	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+}

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -79,6 +79,9 @@ func AddClientFactoryHooks() {
 	sacloud.AddClientFacotyHookFunc("LoadBalancer", func(in interface{}) interface{} {
 		return NewLoadBalancerTracer(in.(sacloud.LoadBalancerAPI))
 	})
+	sacloud.AddClientFacotyHookFunc("MobileGateway", func(in interface{}) interface{} {
+		return NewMobileGatewayTracer(in.(sacloud.MobileGatewayAPI))
+	})
 	sacloud.AddClientFacotyHookFunc("NFS", func(in interface{}) interface{} {
 		return NewNFSTracer(in.(sacloud.NFSAPI))
 	})
@@ -4902,6 +4905,808 @@ func (t *LoadBalancerTracer) Status(ctx context.Context, zone string, id types.I
 }
 
 /*************************************************
+* MobileGatewayTracer
+*************************************************/
+
+// MobileGatewayTracer is for trace MobileGatewayOp operations
+type MobileGatewayTracer struct {
+	Internal sacloud.MobileGatewayAPI
+}
+
+// NewMobileGatewayTracer creates new MobileGatewayTracer instance
+func NewMobileGatewayTracer(in sacloud.MobileGatewayAPI) sacloud.MobileGatewayAPI {
+	return &MobileGatewayTracer{
+		Internal: in,
+	}
+}
+
+// Find is API call with trace log
+func (t *MobileGatewayTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.MobileGatewayFindResult, error) {
+	log.Println("[TRACE] MobileGatewayAPI.Find start")
+	targetArguments := struct {
+		Argzone       string                 `json:"zone"`
+		Argconditions *sacloud.FindCondition `json:"conditions"`
+	}{
+		Argzone:       zone,
+		Argconditions: conditions,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Find end")
+	}()
+
+	result, err := t.Internal.Find(ctx, zone, conditions)
+	targetResults := struct {
+		Result *sacloud.MobileGatewayFindResult
+		Error  error
+	}{
+		Result: result,
+		Error:  err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return result, err
+}
+
+// Create is API call with trace log
+func (t *MobileGatewayTracer) Create(ctx context.Context, zone string, param *sacloud.MobileGatewayCreateRequest) (*sacloud.MobileGateway, error) {
+	log.Println("[TRACE] MobileGatewayAPI.Create start")
+	targetArguments := struct {
+		Argzone  string                              `json:"zone"`
+		Argparam *sacloud.MobileGatewayCreateRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Create end")
+	}()
+
+	resultMobileGateway, err := t.Internal.Create(ctx, zone, param)
+	targetResults := struct {
+		MobileGateway *sacloud.MobileGateway
+		Error         error
+	}{
+		MobileGateway: resultMobileGateway,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultMobileGateway, err
+}
+
+// Read is API call with trace log
+func (t *MobileGatewayTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGateway, error) {
+	log.Println("[TRACE] MobileGatewayAPI.Read start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Read end")
+	}()
+
+	resultMobileGateway, err := t.Internal.Read(ctx, zone, id)
+	targetResults := struct {
+		MobileGateway *sacloud.MobileGateway
+		Error         error
+	}{
+		MobileGateway: resultMobileGateway,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultMobileGateway, err
+}
+
+// Update is API call with trace log
+func (t *MobileGatewayTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayUpdateRequest) (*sacloud.MobileGateway, error) {
+	log.Println("[TRACE] MobileGatewayAPI.Update start")
+	targetArguments := struct {
+		Argzone  string                              `json:"zone"`
+		Argid    types.ID                            `json:"id"`
+		Argparam *sacloud.MobileGatewayUpdateRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Update end")
+	}()
+
+	resultMobileGateway, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		MobileGateway *sacloud.MobileGateway
+		Error         error
+	}{
+		MobileGateway: resultMobileGateway,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultMobileGateway, err
+}
+
+// Delete is API call with trace log
+func (t *MobileGatewayTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+	log.Println("[TRACE] MobileGatewayAPI.Delete start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Delete end")
+	}()
+
+	err := t.Internal.Delete(ctx, zone, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// Config is API call with trace log
+func (t *MobileGatewayTracer) Config(ctx context.Context, zone string, id types.ID) error {
+	log.Println("[TRACE] MobileGatewayAPI.Config start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Config end")
+	}()
+
+	err := t.Internal.Config(ctx, zone, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// Boot is API call with trace log
+func (t *MobileGatewayTracer) Boot(ctx context.Context, zone string, id types.ID) error {
+	log.Println("[TRACE] MobileGatewayAPI.Boot start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Boot end")
+	}()
+
+	err := t.Internal.Boot(ctx, zone, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// Shutdown is API call with trace log
+func (t *MobileGatewayTracer) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
+	log.Println("[TRACE] MobileGatewayAPI.Shutdown start")
+	targetArguments := struct {
+		Argzone           string                  `json:"zone"`
+		Argid             types.ID                `json:"id"`
+		ArgshutdownOption *sacloud.ShutdownOption `json:"shutdownOption"`
+	}{
+		Argzone:           zone,
+		Argid:             id,
+		ArgshutdownOption: shutdownOption,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Shutdown end")
+	}()
+
+	err := t.Internal.Shutdown(ctx, zone, id, shutdownOption)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// Reset is API call with trace log
+func (t *MobileGatewayTracer) Reset(ctx context.Context, zone string, id types.ID) error {
+	log.Println("[TRACE] MobileGatewayAPI.Reset start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Reset end")
+	}()
+
+	err := t.Internal.Reset(ctx, zone, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// ConnectToSwitch is API call with trace log
+func (t *MobileGatewayTracer) ConnectToSwitch(ctx context.Context, zone string, id types.ID, switchID types.ID) error {
+	log.Println("[TRACE] MobileGatewayAPI.ConnectToSwitch start")
+	targetArguments := struct {
+		Argzone     string   `json:"zone"`
+		Argid       types.ID `json:"id"`
+		ArgswitchID types.ID `json:"switchID"`
+	}{
+		Argzone:     zone,
+		Argid:       id,
+		ArgswitchID: switchID,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.ConnectToSwitch end")
+	}()
+
+	err := t.Internal.ConnectToSwitch(ctx, zone, id, switchID)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// DisconnectFromSwitch is API call with trace log
+func (t *MobileGatewayTracer) DisconnectFromSwitch(ctx context.Context, zone string, id types.ID) error {
+	log.Println("[TRACE] MobileGatewayAPI.DisconnectFromSwitch start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.DisconnectFromSwitch end")
+	}()
+
+	err := t.Internal.DisconnectFromSwitch(ctx, zone, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// GetDNS is API call with trace log
+func (t *MobileGatewayTracer) GetDNS(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayDNSSetting, error) {
+	log.Println("[TRACE] MobileGatewayAPI.GetDNS start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.GetDNS end")
+	}()
+
+	resultSIMGroup, err := t.Internal.GetDNS(ctx, zone, id)
+	targetResults := struct {
+		SIMGroup *sacloud.MobileGatewayDNSSetting
+		Error    error
+	}{
+		SIMGroup: resultSIMGroup,
+		Error:    err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSIMGroup, err
+}
+
+// SetDNS is API call with trace log
+func (t *MobileGatewayTracer) SetDNS(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayDNSSetting) error {
+	log.Println("[TRACE] MobileGatewayAPI.SetDNS start")
+	targetArguments := struct {
+		Argzone  string                           `json:"zone"`
+		Argid    types.ID                         `json:"id"`
+		Argparam *sacloud.MobileGatewayDNSSetting `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.SetDNS end")
+	}()
+
+	err := t.Internal.SetDNS(ctx, zone, id, param)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// GetSIMRoutes is API call with trace log
+func (t *MobileGatewayTracer) GetSIMRoutes(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMRoute, error) {
+	log.Println("[TRACE] MobileGatewayAPI.GetSIMRoutes start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.GetSIMRoutes end")
+	}()
+
+	resultSIMRoutes, err := t.Internal.GetSIMRoutes(ctx, zone, id)
+	targetResults := struct {
+		SIMRoutes []*sacloud.MobileGatewaySIMRoute
+		Error     error
+	}{
+		SIMRoutes: resultSIMRoutes,
+		Error:     err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSIMRoutes, err
+}
+
+// SetSIMRoutes is API call with trace log
+func (t *MobileGatewayTracer) SetSIMRoutes(ctx context.Context, zone string, id types.ID, param []*sacloud.MobileGatewaySIMRouteParam) error {
+	log.Println("[TRACE] MobileGatewayAPI.SetSIMRoutes start")
+	targetArguments := struct {
+		Argzone  string                                `json:"zone"`
+		Argid    types.ID                              `json:"id"`
+		Argparam []*sacloud.MobileGatewaySIMRouteParam `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.SetSIMRoutes end")
+	}()
+
+	err := t.Internal.SetSIMRoutes(ctx, zone, id, param)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// ListSIM is API call with trace log
+func (t *MobileGatewayTracer) ListSIM(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMInfo, error) {
+	log.Println("[TRACE] MobileGatewayAPI.ListSIM start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.ListSIM end")
+	}()
+
+	resultSIM, err := t.Internal.ListSIM(ctx, zone, id)
+	targetResults := struct {
+		SIM   []*sacloud.MobileGatewaySIMInfo
+		Error error
+	}{
+		SIM:   resultSIM,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSIM, err
+}
+
+// AddSIM is API call with trace log
+func (t *MobileGatewayTracer) AddSIM(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayAddSIMRequest) error {
+	log.Println("[TRACE] MobileGatewayAPI.AddSIM start")
+	targetArguments := struct {
+		Argzone  string                              `json:"zone"`
+		Argid    types.ID                            `json:"id"`
+		Argparam *sacloud.MobileGatewayAddSIMRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.AddSIM end")
+	}()
+
+	err := t.Internal.AddSIM(ctx, zone, id, param)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// DeleteSIM is API call with trace log
+func (t *MobileGatewayTracer) DeleteSIM(ctx context.Context, zone string, id types.ID, simID types.ID) error {
+	log.Println("[TRACE] MobileGatewayAPI.DeleteSIM start")
+	targetArguments := struct {
+		Argzone  string   `json:"zone"`
+		Argid    types.ID `json:"id"`
+		ArgsimID types.ID `json:"simID"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		ArgsimID: simID,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.DeleteSIM end")
+	}()
+
+	err := t.Internal.DeleteSIM(ctx, zone, id, simID)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// Logs is API call with trace log
+func (t *MobileGatewayTracer) Logs(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMLogs, error) {
+	log.Println("[TRACE] MobileGatewayAPI.Logs start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Logs end")
+	}()
+
+	resultLogs, err := t.Internal.Logs(ctx, zone, id)
+	targetResults := struct {
+		Logs  []*sacloud.MobileGatewaySIMLogs
+		Error error
+	}{
+		Logs:  resultLogs,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLogs, err
+}
+
+// GetTrafficConfig is API call with trace log
+func (t *MobileGatewayTracer) GetTrafficConfig(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayTrafficControl, error) {
+	log.Println("[TRACE] MobileGatewayAPI.GetTrafficConfig start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.GetTrafficConfig end")
+	}()
+
+	resultTrafficMonitoring, err := t.Internal.GetTrafficConfig(ctx, zone, id)
+	targetResults := struct {
+		TrafficMonitoring *sacloud.MobileGatewayTrafficControl
+		Error             error
+	}{
+		TrafficMonitoring: resultTrafficMonitoring,
+		Error:             err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultTrafficMonitoring, err
+}
+
+// SetTrafficConfig is API call with trace log
+func (t *MobileGatewayTracer) SetTrafficConfig(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayTrafficControl) error {
+	log.Println("[TRACE] MobileGatewayAPI.SetTrafficConfig start")
+	targetArguments := struct {
+		Argzone  string                               `json:"zone"`
+		Argid    types.ID                             `json:"id"`
+		Argparam *sacloud.MobileGatewayTrafficControl `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.SetTrafficConfig end")
+	}()
+
+	err := t.Internal.SetTrafficConfig(ctx, zone, id, param)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// DeleteTrafficConfig is API call with trace log
+func (t *MobileGatewayTracer) DeleteTrafficConfig(ctx context.Context, zone string, id types.ID) error {
+	log.Println("[TRACE] MobileGatewayAPI.DeleteTrafficConfig start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.DeleteTrafficConfig end")
+	}()
+
+	err := t.Internal.DeleteTrafficConfig(ctx, zone, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// TrafficStatus is API call with trace log
+func (t *MobileGatewayTracer) TrafficStatus(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayTrafficStatus, error) {
+	log.Println("[TRACE] MobileGatewayAPI.TrafficStatus start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.TrafficStatus end")
+	}()
+
+	resultTrafficStatus, err := t.Internal.TrafficStatus(ctx, zone, id)
+	targetResults := struct {
+		TrafficStatus *sacloud.MobileGatewayTrafficStatus
+		Error         error
+	}{
+		TrafficStatus: resultTrafficStatus,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultTrafficStatus, err
+}
+
+// MonitorInterface is API call with trace log
+func (t *MobileGatewayTracer) MonitorInterface(ctx context.Context, zone string, id types.ID, index int, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
+	log.Println("[TRACE] MobileGatewayAPI.MonitorInterface start")
+	targetArguments := struct {
+		Argzone      string                    `json:"zone"`
+		Argid        types.ID                  `json:"id"`
+		Argindex     int                       `json:"index"`
+		Argcondition *sacloud.MonitorCondition `json:"condition"`
+	}{
+		Argzone:      zone,
+		Argid:        id,
+		Argindex:     index,
+		Argcondition: condition,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.MonitorInterface end")
+	}()
+
+	resultInterfaceActivity, err := t.Internal.MonitorInterface(ctx, zone, id, index, condition)
+	targetResults := struct {
+		InterfaceActivity *sacloud.InterfaceActivity
+		Error             error
+	}{
+		InterfaceActivity: resultInterfaceActivity,
+		Error:             err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultInterfaceActivity, err
+}
+
+/*************************************************
 * NFSTracer
 *************************************************/
 
@@ -7281,7 +8086,7 @@ func (t *SIMTracer) Logs(ctx context.Context, zone string, id types.ID) (*saclou
 }
 
 // GetNetworkOperator is API call with trace log
-func (t *SIMTracer) GetNetworkOperator(ctx context.Context, zone string, id types.ID) (*sacloud.SIMGetNetworkOperatorResult, error) {
+func (t *SIMTracer) GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*sacloud.SIMNetworkOperatorConfig, error) {
 	log.Println("[TRACE] SIMAPI.GetNetworkOperator start")
 	targetArguments := struct {
 		Argzone string   `json:"zone"`
@@ -7298,28 +8103,28 @@ func (t *SIMTracer) GetNetworkOperator(ctx context.Context, zone string, id type
 		log.Println("[TRACE] SIMAPI.GetNetworkOperator end")
 	}()
 
-	result, err := t.Internal.GetNetworkOperator(ctx, zone, id)
+	resultConfigs, err := t.Internal.GetNetworkOperator(ctx, zone, id)
 	targetResults := struct {
-		Result *sacloud.SIMGetNetworkOperatorResult
-		Error  error
+		Configs []*sacloud.SIMNetworkOperatorConfig
+		Error   error
 	}{
-		Result: result,
-		Error:  err,
+		Configs: resultConfigs,
+		Error:   err,
 	}
 	if d, err := json.Marshal(targetResults); err == nil {
 		log.Printf("[TRACE] \tresults: %s\n", string(d))
 	}
 
-	return result, err
+	return resultConfigs, err
 }
 
 // SetNetworkOperator is API call with trace log
-func (t *SIMTracer) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs *sacloud.SIMNetworkOperatorConfigs) error {
+func (t *SIMTracer) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*sacloud.SIMNetworkOperatorConfig) error {
 	log.Println("[TRACE] SIMAPI.SetNetworkOperator start")
 	targetArguments := struct {
-		Argzone    string                             `json:"zone"`
-		Argid      types.ID                           `json:"id"`
-		Argconfigs *sacloud.SIMNetworkOperatorConfigs `json:"configs"`
+		Argzone    string                              `json:"zone"`
+		Argid      types.ID                            `json:"id"`
+		Argconfigs []*sacloud.SIMNetworkOperatorConfig `json:"configs"`
 	}{
 		Argzone:    zone,
 		Argid:      id,
@@ -7379,6 +8184,39 @@ func (t *SIMTracer) MonitorSIM(ctx context.Context, zone string, id types.ID, co
 	}
 
 	return resultLinkActivity, err
+}
+
+// Status is API call with trace log
+func (t *SIMTracer) Status(ctx context.Context, zone string, id types.ID) (*sacloud.SIMInfo, error) {
+	log.Println("[TRACE] SIMAPI.Status start")
+	targetArguments := struct {
+		Argzone string   `json:"zone"`
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] SIMAPI.Status end")
+	}()
+
+	resultSIM, err := t.Internal.Status(ctx, zone, id)
+	targetResults := struct {
+		SIM   *sacloud.SIMInfo
+		Error error
+	}{
+		SIM:   resultSIM,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSIM, err
 }
 
 /*************************************************

--- a/sacloud/types/string_number.go
+++ b/sacloud/types/string_number.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 )
 
 // StringNumber 数値型を文字列で表す型
@@ -51,4 +52,14 @@ func (n StringNumber) Int() int {
 // Int64 returns the number as an int64.
 func (n StringNumber) Int64() int64 {
 	return int64(n)
+}
+
+// ParseStringNumber 文字列からStringNumberへの変換
+func ParseStringNumber(s string) (StringNumber, error) {
+	n, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return StringNumber(0), err
+	}
+	return StringNumber(n), nil
+
 }

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -188,6 +188,14 @@ func init() {
 		}
 	})
 
+	SetClientFactoryFunc("MobileGateway", func(caller APICaller) interface{} {
+		return &MobileGatewayOp{
+			Client:     caller,
+			PathSuffix: "api/cloud/1.1",
+			PathName:   "appliance",
+		}
+	})
+
 	SetClientFactoryFunc("NFS", func(caller APICaller) interface{} {
 		return &NFSOp{
 			Client:     caller,
@@ -6289,6 +6297,906 @@ func (o *LoadBalancerOp) Status(ctx context.Context, zone string, id types.ID) (
 }
 
 /*************************************************
+* MobileGatewayOp
+*************************************************/
+
+// MobileGatewayOp implements MobileGatewayAPI interface
+type MobileGatewayOp struct {
+	// Client APICaller
+	Client APICaller
+	// PathSuffix is used when building URL
+	PathSuffix string
+	// PathName is used when building URL
+	PathName string
+}
+
+// NewMobileGatewayOp creates new MobileGatewayOp instance
+func NewMobileGatewayOp(caller APICaller) MobileGatewayAPI {
+	return GetClientFactoryFunc("MobileGateway")(caller).(MobileGatewayAPI)
+}
+
+// Find is API call
+func (o *MobileGatewayOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*MobileGatewayFindResult, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"conditions": conditions,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	if zone == "" {
+		zone = ""
+	}
+	if conditions == nil {
+		conditions = &FindCondition{}
+	}
+	args := &struct {
+		Argzone       string
+		Argconditions *FindCondition `mapconv:",squash"`
+	}{
+		Argzone:       zone,
+		Argconditions: conditions,
+	}
+
+	v := &mobileGatewayFindRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	body = v
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayFindResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &MobileGatewayFindResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, err
+}
+
+// Create is API call
+func (o *MobileGatewayOp) Create(ctx context.Context, zone string, param *MobileGatewayCreateRequest) (*MobileGateway, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	if zone == "" {
+		zone = ""
+	}
+	if param == nil {
+		param = &MobileGatewayCreateRequest{}
+	}
+	args := &struct {
+		Argzone  string
+		Argparam *MobileGatewayCreateRequest `mapconv:"Appliance,recursive"`
+	}{
+		Argzone:  zone,
+		Argparam: param,
+	}
+
+	v := &mobileGatewayCreateRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	body = v
+
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayCreateResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayCreateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.MobileGateway, nil
+}
+
+// Read is API call
+func (o *MobileGatewayOp) Read(ctx context.Context, zone string, id types.ID) (*MobileGateway, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayReadResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayReadResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.MobileGateway, nil
+}
+
+// Update is API call
+func (o *MobileGatewayOp) Update(ctx context.Context, zone string, id types.ID, param *MobileGatewayUpdateRequest) (*MobileGateway, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	if zone == "" {
+		zone = ""
+	}
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	if param == nil {
+		param = &MobileGatewayUpdateRequest{}
+	}
+	args := &struct {
+		Argzone  string
+		Argid    types.ID
+		Argparam *MobileGatewayUpdateRequest `mapconv:"Appliance,recursive"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+
+	v := &mobileGatewayUpdateRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	body = v
+
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayUpdateResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.MobileGateway, nil
+}
+
+// Delete is API call
+func (o *MobileGatewayOp) Delete(ctx context.Context, zone string, id types.ID) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	_, err = o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Config is API call
+func (o *MobileGatewayOp) Config(ctx context.Context, zone string, id types.ID) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/config", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	_, err = o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Boot is API call
+func (o *MobileGatewayOp) Boot(ctx context.Context, zone string, id types.ID) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/power", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	_, err = o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Shutdown is API call
+func (o *MobileGatewayOp) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *ShutdownOption) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/power", map[string]interface{}{
+		"rootURL":        SakuraCloudAPIRoot,
+		"pathSuffix":     o.PathSuffix,
+		"pathName":       o.PathName,
+		"zone":           zone,
+		"id":             id,
+		"shutdownOption": shutdownOption,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	if zone == "" {
+		zone = ""
+	}
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	if shutdownOption == nil {
+		shutdownOption = &ShutdownOption{}
+	}
+	args := &struct {
+		Argzone           string
+		Argid             types.ID
+		ArgshutdownOption *ShutdownOption `mapconv:",squash"`
+	}{
+		Argzone:           zone,
+		Argid:             id,
+		ArgshutdownOption: shutdownOption,
+	}
+
+	v := &mobileGatewayShutdownRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return err
+	}
+	body = v
+
+	_, err = o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Reset is API call
+func (o *MobileGatewayOp) Reset(ctx context.Context, zone string, id types.ID) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/reset", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	_, err = o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ConnectToSwitch is API call
+func (o *MobileGatewayOp) ConnectToSwitch(ctx context.Context, zone string, id types.ID, switchID types.ID) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/interface/1/to/switch/{{.switchID}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"switchID":   switchID,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	_, err = o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DisconnectFromSwitch is API call
+func (o *MobileGatewayOp) DisconnectFromSwitch(ctx context.Context, zone string, id types.ID) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/interface/1/to/switch", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	_, err = o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetDNS is API call
+func (o *MobileGatewayOp) GetDNS(ctx context.Context, zone string, id types.ID) (*MobileGatewayDNSSetting, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/dnsresolver", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayGetDNSResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayGetDNSResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.SIMGroup, nil
+}
+
+// SetDNS is API call
+func (o *MobileGatewayOp) SetDNS(ctx context.Context, zone string, id types.ID, param *MobileGatewayDNSSetting) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/dnsresolver", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	if zone == "" {
+		zone = ""
+	}
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	if param == nil {
+		param = &MobileGatewayDNSSetting{}
+	}
+	args := &struct {
+		Argzone  string
+		Argid    types.ID
+		Argparam *MobileGatewayDNSSetting `mapconv:"SIMGroup,recursive"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+
+	v := &mobileGatewaySetDNSRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return err
+	}
+	body = v
+
+	_, err = o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetSIMRoutes is API call
+func (o *MobileGatewayOp) GetSIMRoutes(ctx context.Context, zone string, id types.ID) ([]*MobileGatewaySIMRoute, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/simroutes", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayGetSIMRoutesResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayGetSIMRoutesResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.SIMRoutes, nil
+}
+
+// SetSIMRoutes is API call
+func (o *MobileGatewayOp) SetSIMRoutes(ctx context.Context, zone string, id types.ID, param []*MobileGatewaySIMRouteParam) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/simroutes", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	if zone == "" {
+		zone = ""
+	}
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	if param == nil {
+		param = []*MobileGatewaySIMRouteParam{}
+	}
+	args := &struct {
+		Argzone  string
+		Argid    types.ID
+		Argparam []*MobileGatewaySIMRouteParam `mapconv:"[]SIMRoutes,recursive"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+
+	v := &mobileGatewaySetSIMRoutesRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return err
+	}
+	body = v
+
+	_, err = o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ListSIM is API call
+func (o *MobileGatewayOp) ListSIM(ctx context.Context, zone string, id types.ID) ([]*MobileGatewaySIMInfo, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/sims", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayListSIMResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayListSIMResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.SIM, nil
+}
+
+// AddSIM is API call
+func (o *MobileGatewayOp) AddSIM(ctx context.Context, zone string, id types.ID, param *MobileGatewayAddSIMRequest) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/sims", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	if zone == "" {
+		zone = ""
+	}
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	if param == nil {
+		param = &MobileGatewayAddSIMRequest{}
+	}
+	args := &struct {
+		Argzone  string
+		Argid    types.ID
+		Argparam *MobileGatewayAddSIMRequest `mapconv:"SIM,recursive"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+
+	v := &mobileGatewayAddSIMRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return err
+	}
+	body = v
+
+	_, err = o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteSIM is API call
+func (o *MobileGatewayOp) DeleteSIM(ctx context.Context, zone string, id types.ID, simID types.ID) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/sims/{{.simID}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"simID":      simID,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	_, err = o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Logs is API call
+func (o *MobileGatewayOp) Logs(ctx context.Context, zone string, id types.ID) ([]*MobileGatewaySIMLogs, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/sessionlog", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayLogsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayLogsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.Logs, nil
+}
+
+// GetTrafficConfig is API call
+func (o *MobileGatewayOp) GetTrafficConfig(ctx context.Context, zone string, id types.ID) (*MobileGatewayTrafficControl, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/traffic_monitoring", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayGetTrafficConfigResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayGetTrafficConfigResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.TrafficMonitoring, nil
+}
+
+// SetTrafficConfig is API call
+func (o *MobileGatewayOp) SetTrafficConfig(ctx context.Context, zone string, id types.ID, param *MobileGatewayTrafficControl) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/traffic_monitoring", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	if zone == "" {
+		zone = ""
+	}
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	if param == nil {
+		param = &MobileGatewayTrafficControl{}
+	}
+	args := &struct {
+		Argzone  string
+		Argid    types.ID
+		Argparam *MobileGatewayTrafficControl `mapconv:"TrafficMonitoring,recursive"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+
+	v := &mobileGatewaySetTrafficConfigRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return err
+	}
+	body = v
+
+	_, err = o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteTrafficConfig is API call
+func (o *MobileGatewayOp) DeleteTrafficConfig(ctx context.Context, zone string, id types.ID) error {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/traffic_monitoring", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return err
+	}
+
+	var body interface{}
+
+	_, err = o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// TrafficStatus is API call
+func (o *MobileGatewayOp) TrafficStatus(ctx context.Context, zone string, id types.ID) (*MobileGatewayTrafficStatus, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/mobilegateway/traffic_status", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayTrafficStatusResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayTrafficStatusResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.TrafficStatus, nil
+}
+
+// MonitorInterface is API call
+func (o *MobileGatewayOp) MonitorInterface(ctx context.Context, zone string, id types.ID, index int, condition *MonitorCondition) (*InterfaceActivity, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/interface/{{if eq .index 0}}{{.index}}{{end}}/monitor", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"index":      index,
+		"condition":  condition,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	if zone == "" {
+		zone = ""
+	}
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	if index == 0 {
+		index = 0
+	}
+	if condition == nil {
+		condition = &MonitorCondition{}
+	}
+	args := &struct {
+		Argzone      string
+		Argid        types.ID
+		Argindex     int
+		Argcondition *MonitorCondition `mapconv:",squash"`
+	}{
+		Argzone:      zone,
+		Argid:        id,
+		Argindex:     index,
+		Argcondition: condition,
+	}
+
+	v := &mobileGatewayMonitorInterfaceRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	body = v
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &mobileGatewayMonitorInterfaceResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayMonitorInterfaceResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.InterfaceActivity, nil
+}
+
+/*************************************************
 * NFSOp
 *************************************************/
 
@@ -9289,7 +10197,7 @@ func (o *SIMOp) Logs(ctx context.Context, zone string, id types.ID) (*SIMLogsRes
 }
 
 // GetNetworkOperator is API call
-func (o *SIMOp) GetNetworkOperator(ctx context.Context, zone string, id types.ID) (*SIMGetNetworkOperatorResult, error) {
+func (o *SIMOp) GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*SIMNetworkOperatorConfig, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/network_operator_config", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
@@ -9313,15 +10221,15 @@ func (o *SIMOp) GetNetworkOperator(ctx context.Context, zone string, id types.ID
 		return nil, err
 	}
 
-	results := &SIMGetNetworkOperatorResult{}
+	results := &sIMGetNetworkOperatorResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
-	return results, err
+	return results.Configs, nil
 }
 
 // SetNetworkOperator is API call
-func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs *SIMNetworkOperatorConfigs) error {
+func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*SIMNetworkOperatorConfig) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/network_operator_config", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
@@ -9343,12 +10251,12 @@ func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID
 		id = types.ID(int64(0))
 	}
 	if configs == nil {
-		configs = &SIMNetworkOperatorConfigs{}
+		configs = []*SIMNetworkOperatorConfig{}
 	}
 	args := &struct {
 		Argzone    string
 		Argid      types.ID
-		Argconfigs *SIMNetworkOperatorConfigs `mapconv:",squash"`
+		Argconfigs []*SIMNetworkOperatorConfig `mapconv:"[]NetworkOperatorConfigs,recursive"`
 	}{
 		Argzone:    zone,
 		Argid:      id,
@@ -9425,6 +10333,38 @@ func (o *SIMOp) MonitorSIM(ctx context.Context, zone string, id types.ID, condit
 		return nil, err
 	}
 	return results.LinkActivity, nil
+}
+
+// Status is API call
+func (o *SIMOp) Status(ctx context.Context, zone string, id types.ID) (*SIMInfo, error) {
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/status", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var body interface{}
+
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	nakedResponse := &sIMStatusResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &sIMStatusResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results.SIM, nil
 }
 
 /*************************************************

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -318,6 +318,38 @@ type LoadBalancerAPI interface {
 }
 
 /*************************************************
+* MobileGatewayAPI
+*************************************************/
+
+// MobileGatewayAPI is interface for operate MobileGateway resource
+type MobileGatewayAPI interface {
+	Find(ctx context.Context, zone string, conditions *FindCondition) (*MobileGatewayFindResult, error)
+	Create(ctx context.Context, zone string, param *MobileGatewayCreateRequest) (*MobileGateway, error)
+	Read(ctx context.Context, zone string, id types.ID) (*MobileGateway, error)
+	Update(ctx context.Context, zone string, id types.ID, param *MobileGatewayUpdateRequest) (*MobileGateway, error)
+	Delete(ctx context.Context, zone string, id types.ID) error
+	Config(ctx context.Context, zone string, id types.ID) error
+	Boot(ctx context.Context, zone string, id types.ID) error
+	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *ShutdownOption) error
+	Reset(ctx context.Context, zone string, id types.ID) error
+	ConnectToSwitch(ctx context.Context, zone string, id types.ID, switchID types.ID) error
+	DisconnectFromSwitch(ctx context.Context, zone string, id types.ID) error
+	GetDNS(ctx context.Context, zone string, id types.ID) (*MobileGatewayDNSSetting, error)
+	SetDNS(ctx context.Context, zone string, id types.ID, param *MobileGatewayDNSSetting) error
+	GetSIMRoutes(ctx context.Context, zone string, id types.ID) ([]*MobileGatewaySIMRoute, error)
+	SetSIMRoutes(ctx context.Context, zone string, id types.ID, param []*MobileGatewaySIMRouteParam) error
+	ListSIM(ctx context.Context, zone string, id types.ID) ([]*MobileGatewaySIMInfo, error)
+	AddSIM(ctx context.Context, zone string, id types.ID, param *MobileGatewayAddSIMRequest) error
+	DeleteSIM(ctx context.Context, zone string, id types.ID, simID types.ID) error
+	Logs(ctx context.Context, zone string, id types.ID) ([]*MobileGatewaySIMLogs, error)
+	GetTrafficConfig(ctx context.Context, zone string, id types.ID) (*MobileGatewayTrafficControl, error)
+	SetTrafficConfig(ctx context.Context, zone string, id types.ID, param *MobileGatewayTrafficControl) error
+	DeleteTrafficConfig(ctx context.Context, zone string, id types.ID) error
+	TrafficStatus(ctx context.Context, zone string, id types.ID) (*MobileGatewayTrafficStatus, error)
+	MonitorInterface(ctx context.Context, zone string, id types.ID, index int, condition *MonitorCondition) (*InterfaceActivity, error)
+}
+
+/*************************************************
 * NFSAPI
 *************************************************/
 
@@ -470,9 +502,10 @@ type SIMAPI interface {
 	IMEILock(ctx context.Context, zone string, id types.ID, param *SIMIMEILockRequest) error
 	IMEIUnlock(ctx context.Context, zone string, id types.ID) error
 	Logs(ctx context.Context, zone string, id types.ID) (*SIMLogsResult, error)
-	GetNetworkOperator(ctx context.Context, zone string, id types.ID) (*SIMGetNetworkOperatorResult, error)
-	SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs *SIMNetworkOperatorConfigs) error
+	GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*SIMNetworkOperatorConfig, error)
+	SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*SIMNetworkOperatorConfig) error
 	MonitorSIM(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*LinkActivity, error)
+	Status(ctx context.Context, zone string, id types.ID) (*SIMInfo, error)
 }
 
 /*************************************************

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -1263,6 +1263,146 @@ type loadBalancerStatusResponseEnvelope struct {
 	LoadBalancer []*naked.LoadBalancerStatus `json:",omitempty"`
 }
 
+// mobileGatewayFindRequestEnvelope is envelop of API request
+type mobileGatewayFindRequestEnvelope struct {
+	Count   int                    `json:",omitempty"`
+	From    int                    `json:",omitempty"`
+	Sort    []string               `json:",omitempty"`
+	Filter  map[string]interface{} `json:",omitempty"`
+	Include []string               `json:",omitempty"`
+	Exclude []string               `json:",omitempty"`
+}
+
+// mobileGatewayFindResponseEnvelope is envelop of API response
+type mobileGatewayFindResponseEnvelope struct {
+	Total int `json:",omitempty"` // トータル件数
+	From  int `json:",omitempty"` // ページング開始ページ
+	Count int `json:",omitempty"` // 件数
+
+	Appliances []*naked.MobileGateway `json:",omitempty"`
+}
+
+// mobileGatewayCreateRequestEnvelope is envelop of API request
+type mobileGatewayCreateRequestEnvelope struct {
+	Appliance *naked.MobileGateway `json:",omitempty"`
+}
+
+// mobileGatewayCreateResponseEnvelope is envelop of API response
+type mobileGatewayCreateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.MobileGateway `json:",omitempty"`
+}
+
+// mobileGatewayReadResponseEnvelope is envelop of API response
+type mobileGatewayReadResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.MobileGateway `json:",omitempty"`
+}
+
+// mobileGatewayUpdateRequestEnvelope is envelop of API request
+type mobileGatewayUpdateRequestEnvelope struct {
+	Appliance *naked.MobileGateway `json:",omitempty"`
+}
+
+// mobileGatewayUpdateResponseEnvelope is envelop of API response
+type mobileGatewayUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.MobileGateway `json:",omitempty"`
+}
+
+// mobileGatewayShutdownRequestEnvelope is envelop of API request
+type mobileGatewayShutdownRequestEnvelope struct {
+	Force bool `json:",omitempty"`
+}
+
+// mobileGatewayGetDNSResponseEnvelope is envelop of API response
+type mobileGatewayGetDNSResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	SIMGroup *naked.MobileGatewaySIMGroup `json:"sim_group"`
+}
+
+// mobileGatewaySetDNSRequestEnvelope is envelop of API request
+type mobileGatewaySetDNSRequestEnvelope struct {
+	SIMGroup *naked.MobileGatewaySIMGroup `json:"sim_group"`
+}
+
+// mobileGatewayGetSIMRoutesResponseEnvelope is envelop of API response
+type mobileGatewayGetSIMRoutesResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	SIMRoutes []*naked.MobileGatewaySIMRoute `json:"sim_routes"`
+}
+
+// mobileGatewaySetSIMRoutesRequestEnvelope is envelop of API request
+type mobileGatewaySetSIMRoutesRequestEnvelope struct {
+	SIMRoutes []*naked.MobileGatewaySIMRoute `json:"sim_routes"`
+}
+
+// mobileGatewayListSIMResponseEnvelope is envelop of API response
+type mobileGatewayListSIMResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	SIM []*naked.SIMInfo `json:"sim"`
+}
+
+// mobileGatewayAddSIMRequestEnvelope is envelop of API request
+type mobileGatewayAddSIMRequestEnvelope struct {
+	SIM *naked.SIMInfo `json:"sim"`
+}
+
+// mobileGatewayLogsResponseEnvelope is envelop of API response
+type mobileGatewayLogsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Logs []*naked.SIMLog `json:"logs"`
+}
+
+// mobileGatewayGetTrafficConfigResponseEnvelope is envelop of API response
+type mobileGatewayGetTrafficConfigResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	TrafficMonitoring *naked.TrafficMonitoringConfig `json:"traffic_monitoring_config"`
+}
+
+// mobileGatewaySetTrafficConfigRequestEnvelope is envelop of API request
+type mobileGatewaySetTrafficConfigRequestEnvelope struct {
+	TrafficMonitoring *naked.TrafficMonitoringConfig `json:"traffic_monitoring_config"`
+}
+
+// mobileGatewayTrafficStatusResponseEnvelope is envelop of API response
+type mobileGatewayTrafficStatusResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	TrafficStatus *naked.TrafficStatus `json:"traffic_status"`
+}
+
+// mobileGatewayMonitorInterfaceRequestEnvelope is envelop of API request
+type mobileGatewayMonitorInterfaceRequestEnvelope struct {
+	Start time.Time `json:",omitempty"`
+	End   time.Time `json:",omitempty"`
+}
+
+// mobileGatewayMonitorInterfaceResponseEnvelope is envelop of API response
+type mobileGatewayMonitorInterfaceResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Data *naked.MonitorValues `json:",omitempty"`
+}
+
 // nFSFindRequestEnvelope is envelop of API request
 type nFSFindRequestEnvelope struct {
 	Count   int                    `json:",omitempty"`
@@ -1870,21 +2010,20 @@ type sIMLogsResponseEnvelope struct {
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
 
-	Logs []*naked.SIMLog `json:",omitempty"`
+	Logs []*naked.SIMLog `json:"logs"`
 }
 
 // sIMGetNetworkOperatorResponseEnvelope is envelop of API response
 type sIMGetNetworkOperatorResponseEnvelope struct {
-	Total int `json:",omitempty"` // トータル件数
-	From  int `json:",omitempty"` // ページング開始ページ
-	Count int `json:",omitempty"` // 件数
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
 
-	NetworkOperationConfigs []*naked.SIMNetworkOperatorConfig `json:",omitempty"`
+	NetworkOperationConfigs []*naked.SIMNetworkOperatorConfig `json:"network_operator_config"`
 }
 
 // sIMSetNetworkOperatorRequestEnvelope is envelop of API request
 type sIMSetNetworkOperatorRequestEnvelope struct {
-	NetworkOperatorConfigs []*SIMNetworkOperatorConfig `json:",omitempty"`
+	NetworkOperatorConfigs []*naked.SIMNetworkOperatorConfig `json:"network_operator_config"`
 }
 
 // sIMMonitorSIMRequestEnvelope is envelop of API request
@@ -1899,6 +2038,14 @@ type sIMMonitorSIMResponseEnvelope struct {
 	Success types.APIResult `json:",omitempty"`      // success項目
 
 	Data *naked.MonitorValues `json:",omitempty"`
+}
+
+// sIMStatusResponseEnvelope is envelop of API response
+type sIMStatusResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	SIM *naked.SIMInfo `json:"sim"`
 }
 
 // simpleMonitorFindRequestEnvelope is envelop of API request

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -8893,6 +8893,1345 @@ func (o *LoadBalancerServerStatus) SetCPS(v types.StringNumber) {
 }
 
 /*************************************************
+* MobileGateway
+*************************************************/
+
+// MobileGateway represents API parameter/response structure
+type MobileGateway struct {
+	ID                      types.ID
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	Tags                    []string
+	Availability            types.EAvailability
+	Class                   string
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	CreatedAt               time.Time
+	PlanID                  types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
+	InstanceHostName        string                      `mapconv:"Instance.Host.Name"`
+	InstanceHostInfoURL     string                      `mapconv:"Instance.Host.InfoURL"`
+	InstanceStatus          types.EServerInstanceStatus `mapconv:"Instance.Status"`
+	InstanceStatusChangedAt time.Time                   `mapconv:"Instance.StatusChangedAt"`
+	Interfaces              []*MobileGatewayInterface   `json:",omitempty" mapconv:"[]Interfaces,recursive,omitempty"`
+	ZoneID                  types.ID                    `mapconv:"Remark.Zone.ID"`
+	Settings                *MobileGatewaySetting       `mapconv:",omitempty,recursive"`
+	SettingsHash            string
+}
+
+// Validate validates by field tags
+func (o *MobileGateway) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetID returns value of ID
+func (o *MobileGateway) GetID() types.ID {
+	return o.ID
+}
+
+// SetID sets value to ID
+func (o *MobileGateway) SetID(v types.ID) {
+	o.ID = v
+}
+
+// GetStringID gets value to StringID
+func (o *MobileGateway) GetStringID() string {
+	return accessor.GetStringID(o)
+}
+
+// SetStringID sets value to StringID
+func (o *MobileGateway) SetStringID(v string) {
+	accessor.SetStringID(o, v)
+}
+
+// GetInt64ID gets value to Int64ID
+func (o *MobileGateway) GetInt64ID() int64 {
+	return accessor.GetInt64ID(o)
+}
+
+// SetInt64ID sets value to Int64ID
+func (o *MobileGateway) SetInt64ID(v int64) {
+	accessor.SetInt64ID(o, v)
+}
+
+// GetName returns value of Name
+func (o *MobileGateway) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *MobileGateway) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *MobileGateway) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *MobileGateway) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *MobileGateway) GetTags() []string {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *MobileGateway) SetTags(v []string) {
+	o.Tags = v
+}
+
+// GetAvailability returns value of Availability
+func (o *MobileGateway) GetAvailability() types.EAvailability {
+	return o.Availability
+}
+
+// SetAvailability sets value to Availability
+func (o *MobileGateway) SetAvailability(v types.EAvailability) {
+	o.Availability = v
+}
+
+// GetClass returns value of Class
+func (o *MobileGateway) GetClass() string {
+	return o.Class
+}
+
+// SetClass sets value to Class
+func (o *MobileGateway) SetClass(v string) {
+	o.Class = v
+}
+
+// GetIconID returns value of IconID
+func (o *MobileGateway) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *MobileGateway) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetCreatedAt returns value of CreatedAt
+func (o *MobileGateway) GetCreatedAt() time.Time {
+	return o.CreatedAt
+}
+
+// SetCreatedAt sets value to CreatedAt
+func (o *MobileGateway) SetCreatedAt(v time.Time) {
+	o.CreatedAt = v
+}
+
+// GetPlanID returns value of PlanID
+func (o *MobileGateway) GetPlanID() types.ID {
+	return o.PlanID
+}
+
+// SetPlanID sets value to PlanID
+func (o *MobileGateway) SetPlanID(v types.ID) {
+	o.PlanID = v
+}
+
+// GetInstanceHostName returns value of InstanceHostName
+func (o *MobileGateway) GetInstanceHostName() string {
+	return o.InstanceHostName
+}
+
+// SetInstanceHostName sets value to InstanceHostName
+func (o *MobileGateway) SetInstanceHostName(v string) {
+	o.InstanceHostName = v
+}
+
+// GetInstanceHostInfoURL returns value of InstanceHostInfoURL
+func (o *MobileGateway) GetInstanceHostInfoURL() string {
+	return o.InstanceHostInfoURL
+}
+
+// SetInstanceHostInfoURL sets value to InstanceHostInfoURL
+func (o *MobileGateway) SetInstanceHostInfoURL(v string) {
+	o.InstanceHostInfoURL = v
+}
+
+// GetInstanceStatus returns value of InstanceStatus
+func (o *MobileGateway) GetInstanceStatus() types.EServerInstanceStatus {
+	return o.InstanceStatus
+}
+
+// SetInstanceStatus sets value to InstanceStatus
+func (o *MobileGateway) SetInstanceStatus(v types.EServerInstanceStatus) {
+	o.InstanceStatus = v
+}
+
+// GetInstanceStatusChangedAt returns value of InstanceStatusChangedAt
+func (o *MobileGateway) GetInstanceStatusChangedAt() time.Time {
+	return o.InstanceStatusChangedAt
+}
+
+// SetInstanceStatusChangedAt sets value to InstanceStatusChangedAt
+func (o *MobileGateway) SetInstanceStatusChangedAt(v time.Time) {
+	o.InstanceStatusChangedAt = v
+}
+
+// GetInterfaces returns value of Interfaces
+func (o *MobileGateway) GetInterfaces() []*MobileGatewayInterface {
+	return o.Interfaces
+}
+
+// SetInterfaces sets value to Interfaces
+func (o *MobileGateway) SetInterfaces(v []*MobileGatewayInterface) {
+	o.Interfaces = v
+}
+
+// GetZoneID returns value of ZoneID
+func (o *MobileGateway) GetZoneID() types.ID {
+	return o.ZoneID
+}
+
+// SetZoneID sets value to ZoneID
+func (o *MobileGateway) SetZoneID(v types.ID) {
+	o.ZoneID = v
+}
+
+// GetSettings returns value of Settings
+func (o *MobileGateway) GetSettings() *MobileGatewaySetting {
+	return o.Settings
+}
+
+// SetSettings sets value to Settings
+func (o *MobileGateway) SetSettings(v *MobileGatewaySetting) {
+	o.Settings = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *MobileGateway) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *MobileGateway) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* MobileGatewayInterface
+*************************************************/
+
+// MobileGatewayInterface represents API parameter/response structure
+type MobileGatewayInterface struct {
+	ID                              types.ID
+	MACAddress                      string
+	IPAddress                       string
+	UserIPAddress                   string
+	HostName                        string
+	SwitchID                        types.ID           `mapconv:"Switch.ID"`
+	SwitchName                      string             `mapconv:"Switch.Name"`
+	SwitchScope                     types.EScope       `mapconv:"Switch.Scope"`
+	UserSubnetDefaultRoute          string             `mapconv:"Switch.UserSubnet.DefaultRoute"`
+	UserSubnetNetworkMaskLen        int                `mapconv:"Switch.UserSubnet.NetworkMaskLen"`
+	SubnetDefaultRoute              string             `mapconv:"Switch.Subnet.DefaultRoute"`
+	SubnetNetworkMaskLen            int                `mapconv:"Switch.Subnet.NetworkMaskLen"`
+	SubnetNetworkAddress            string             `mapconv:"Switch.Subnet.NetworkAddress"`
+	SubnetBandWidthMbps             int                `mapconv:"Switch.Subnet.Internet.BandWidthMbps"`
+	PacketFilterID                  string             `mapconv:"PacketFilter.ID"`
+	PacketFilterName                string             `mapconv:"PacketFilter.Name"`
+	PacketFilterRequiredHostVersion types.StringNumber `mapconv:"PacketFilter.RequiredHostVersionn"`
+	Index                           int                `mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayInterface) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetID returns value of ID
+func (o *MobileGatewayInterface) GetID() types.ID {
+	return o.ID
+}
+
+// SetID sets value to ID
+func (o *MobileGatewayInterface) SetID(v types.ID) {
+	o.ID = v
+}
+
+// GetStringID gets value to StringID
+func (o *MobileGatewayInterface) GetStringID() string {
+	return accessor.GetStringID(o)
+}
+
+// SetStringID sets value to StringID
+func (o *MobileGatewayInterface) SetStringID(v string) {
+	accessor.SetStringID(o, v)
+}
+
+// GetInt64ID gets value to Int64ID
+func (o *MobileGatewayInterface) GetInt64ID() int64 {
+	return accessor.GetInt64ID(o)
+}
+
+// SetInt64ID sets value to Int64ID
+func (o *MobileGatewayInterface) SetInt64ID(v int64) {
+	accessor.SetInt64ID(o, v)
+}
+
+// GetMACAddress returns value of MACAddress
+func (o *MobileGatewayInterface) GetMACAddress() string {
+	return o.MACAddress
+}
+
+// SetMACAddress sets value to MACAddress
+func (o *MobileGatewayInterface) SetMACAddress(v string) {
+	o.MACAddress = v
+}
+
+// GetIPAddress returns value of IPAddress
+func (o *MobileGatewayInterface) GetIPAddress() string {
+	return o.IPAddress
+}
+
+// SetIPAddress sets value to IPAddress
+func (o *MobileGatewayInterface) SetIPAddress(v string) {
+	o.IPAddress = v
+}
+
+// GetUserIPAddress returns value of UserIPAddress
+func (o *MobileGatewayInterface) GetUserIPAddress() string {
+	return o.UserIPAddress
+}
+
+// SetUserIPAddress sets value to UserIPAddress
+func (o *MobileGatewayInterface) SetUserIPAddress(v string) {
+	o.UserIPAddress = v
+}
+
+// GetHostName returns value of HostName
+func (o *MobileGatewayInterface) GetHostName() string {
+	return o.HostName
+}
+
+// SetHostName sets value to HostName
+func (o *MobileGatewayInterface) SetHostName(v string) {
+	o.HostName = v
+}
+
+// GetSwitchID returns value of SwitchID
+func (o *MobileGatewayInterface) GetSwitchID() types.ID {
+	return o.SwitchID
+}
+
+// SetSwitchID sets value to SwitchID
+func (o *MobileGatewayInterface) SetSwitchID(v types.ID) {
+	o.SwitchID = v
+}
+
+// GetSwitchName returns value of SwitchName
+func (o *MobileGatewayInterface) GetSwitchName() string {
+	return o.SwitchName
+}
+
+// SetSwitchName sets value to SwitchName
+func (o *MobileGatewayInterface) SetSwitchName(v string) {
+	o.SwitchName = v
+}
+
+// GetSwitchScope returns value of SwitchScope
+func (o *MobileGatewayInterface) GetSwitchScope() types.EScope {
+	return o.SwitchScope
+}
+
+// SetSwitchScope sets value to SwitchScope
+func (o *MobileGatewayInterface) SetSwitchScope(v types.EScope) {
+	o.SwitchScope = v
+}
+
+// GetUserSubnetDefaultRoute returns value of UserSubnetDefaultRoute
+func (o *MobileGatewayInterface) GetUserSubnetDefaultRoute() string {
+	return o.UserSubnetDefaultRoute
+}
+
+// SetUserSubnetDefaultRoute sets value to UserSubnetDefaultRoute
+func (o *MobileGatewayInterface) SetUserSubnetDefaultRoute(v string) {
+	o.UserSubnetDefaultRoute = v
+}
+
+// GetUserSubnetNetworkMaskLen returns value of UserSubnetNetworkMaskLen
+func (o *MobileGatewayInterface) GetUserSubnetNetworkMaskLen() int {
+	return o.UserSubnetNetworkMaskLen
+}
+
+// SetUserSubnetNetworkMaskLen sets value to UserSubnetNetworkMaskLen
+func (o *MobileGatewayInterface) SetUserSubnetNetworkMaskLen(v int) {
+	o.UserSubnetNetworkMaskLen = v
+}
+
+// GetSubnetDefaultRoute returns value of SubnetDefaultRoute
+func (o *MobileGatewayInterface) GetSubnetDefaultRoute() string {
+	return o.SubnetDefaultRoute
+}
+
+// SetSubnetDefaultRoute sets value to SubnetDefaultRoute
+func (o *MobileGatewayInterface) SetSubnetDefaultRoute(v string) {
+	o.SubnetDefaultRoute = v
+}
+
+// GetSubnetNetworkMaskLen returns value of SubnetNetworkMaskLen
+func (o *MobileGatewayInterface) GetSubnetNetworkMaskLen() int {
+	return o.SubnetNetworkMaskLen
+}
+
+// SetSubnetNetworkMaskLen sets value to SubnetNetworkMaskLen
+func (o *MobileGatewayInterface) SetSubnetNetworkMaskLen(v int) {
+	o.SubnetNetworkMaskLen = v
+}
+
+// GetSubnetNetworkAddress returns value of SubnetNetworkAddress
+func (o *MobileGatewayInterface) GetSubnetNetworkAddress() string {
+	return o.SubnetNetworkAddress
+}
+
+// SetSubnetNetworkAddress sets value to SubnetNetworkAddress
+func (o *MobileGatewayInterface) SetSubnetNetworkAddress(v string) {
+	o.SubnetNetworkAddress = v
+}
+
+// GetSubnetBandWidthMbps returns value of SubnetBandWidthMbps
+func (o *MobileGatewayInterface) GetSubnetBandWidthMbps() int {
+	return o.SubnetBandWidthMbps
+}
+
+// SetSubnetBandWidthMbps sets value to SubnetBandWidthMbps
+func (o *MobileGatewayInterface) SetSubnetBandWidthMbps(v int) {
+	o.SubnetBandWidthMbps = v
+}
+
+// GetPacketFilterID returns value of PacketFilterID
+func (o *MobileGatewayInterface) GetPacketFilterID() string {
+	return o.PacketFilterID
+}
+
+// SetPacketFilterID sets value to PacketFilterID
+func (o *MobileGatewayInterface) SetPacketFilterID(v string) {
+	o.PacketFilterID = v
+}
+
+// GetPacketFilterName returns value of PacketFilterName
+func (o *MobileGatewayInterface) GetPacketFilterName() string {
+	return o.PacketFilterName
+}
+
+// SetPacketFilterName sets value to PacketFilterName
+func (o *MobileGatewayInterface) SetPacketFilterName(v string) {
+	o.PacketFilterName = v
+}
+
+// GetPacketFilterRequiredHostVersion returns value of PacketFilterRequiredHostVersion
+func (o *MobileGatewayInterface) GetPacketFilterRequiredHostVersion() types.StringNumber {
+	return o.PacketFilterRequiredHostVersion
+}
+
+// SetPacketFilterRequiredHostVersion sets value to PacketFilterRequiredHostVersion
+func (o *MobileGatewayInterface) SetPacketFilterRequiredHostVersion(v types.StringNumber) {
+	o.PacketFilterRequiredHostVersion = v
+}
+
+// GetIndex returns value of Index
+func (o *MobileGatewayInterface) GetIndex() int {
+	return o.Index
+}
+
+// SetIndex sets value to Index
+func (o *MobileGatewayInterface) SetIndex(v int) {
+	o.Index = v
+}
+
+/*************************************************
+* MobileGatewaySetting
+*************************************************/
+
+// MobileGatewaySetting represents API parameter/response structure
+type MobileGatewaySetting struct {
+	Interfaces                      []*MobileGatewayInterfaceSetting `json:",omitempty" mapconv:"MobileGateway.[]Interfaces,omitempty,recursive"`
+	StaticRoute                     []*MobileGatewayStaticRoute      `json:",omitempty" mapconv:"MobileGateway.[]StaticRoutes,omitempty,recursive"`
+	InternetConnectionEnabled       types.StringFlag                 `mapconv:"MobileGateway.InternetConnection.Enabled"`
+	InterDeviceCommunicationEnabled types.StringFlag                 `mapconv:"MobileGateway.InterDeviceCommunication.Enabled"`
+}
+
+// Validate validates by field tags
+func (o *MobileGatewaySetting) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetInterfaces returns value of Interfaces
+func (o *MobileGatewaySetting) GetInterfaces() []*MobileGatewayInterfaceSetting {
+	return o.Interfaces
+}
+
+// SetInterfaces sets value to Interfaces
+func (o *MobileGatewaySetting) SetInterfaces(v []*MobileGatewayInterfaceSetting) {
+	o.Interfaces = v
+}
+
+// GetStaticRoute returns value of StaticRoute
+func (o *MobileGatewaySetting) GetStaticRoute() []*MobileGatewayStaticRoute {
+	return o.StaticRoute
+}
+
+// SetStaticRoute sets value to StaticRoute
+func (o *MobileGatewaySetting) SetStaticRoute(v []*MobileGatewayStaticRoute) {
+	o.StaticRoute = v
+}
+
+// GetInternetConnectionEnabled returns value of InternetConnectionEnabled
+func (o *MobileGatewaySetting) GetInternetConnectionEnabled() types.StringFlag {
+	return o.InternetConnectionEnabled
+}
+
+// SetInternetConnectionEnabled sets value to InternetConnectionEnabled
+func (o *MobileGatewaySetting) SetInternetConnectionEnabled(v types.StringFlag) {
+	o.InternetConnectionEnabled = v
+}
+
+// GetInterDeviceCommunicationEnabled returns value of InterDeviceCommunicationEnabled
+func (o *MobileGatewaySetting) GetInterDeviceCommunicationEnabled() types.StringFlag {
+	return o.InterDeviceCommunicationEnabled
+}
+
+// SetInterDeviceCommunicationEnabled sets value to InterDeviceCommunicationEnabled
+func (o *MobileGatewaySetting) SetInterDeviceCommunicationEnabled(v types.StringFlag) {
+	o.InterDeviceCommunicationEnabled = v
+}
+
+/*************************************************
+* MobileGatewayInterfaceSetting
+*************************************************/
+
+// MobileGatewayInterfaceSetting represents API parameter/response structure
+type MobileGatewayInterfaceSetting struct {
+	IPAddress      []string
+	NetworkMaskLen int
+	Index          int
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayInterfaceSetting) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetIPAddress returns value of IPAddress
+func (o *MobileGatewayInterfaceSetting) GetIPAddress() []string {
+	return o.IPAddress
+}
+
+// SetIPAddress sets value to IPAddress
+func (o *MobileGatewayInterfaceSetting) SetIPAddress(v []string) {
+	o.IPAddress = v
+}
+
+// GetNetworkMaskLen returns value of NetworkMaskLen
+func (o *MobileGatewayInterfaceSetting) GetNetworkMaskLen() int {
+	return o.NetworkMaskLen
+}
+
+// SetNetworkMaskLen sets value to NetworkMaskLen
+func (o *MobileGatewayInterfaceSetting) SetNetworkMaskLen(v int) {
+	o.NetworkMaskLen = v
+}
+
+// GetIndex returns value of Index
+func (o *MobileGatewayInterfaceSetting) GetIndex() int {
+	return o.Index
+}
+
+// SetIndex sets value to Index
+func (o *MobileGatewayInterfaceSetting) SetIndex(v int) {
+	o.Index = v
+}
+
+/*************************************************
+* MobileGatewayStaticRoute
+*************************************************/
+
+// MobileGatewayStaticRoute represents API parameter/response structure
+type MobileGatewayStaticRoute struct {
+	Prefix  string
+	NextHop string
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayStaticRoute) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetPrefix returns value of Prefix
+func (o *MobileGatewayStaticRoute) GetPrefix() string {
+	return o.Prefix
+}
+
+// SetPrefix sets value to Prefix
+func (o *MobileGatewayStaticRoute) SetPrefix(v string) {
+	o.Prefix = v
+}
+
+// GetNextHop returns value of NextHop
+func (o *MobileGatewayStaticRoute) GetNextHop() string {
+	return o.NextHop
+}
+
+// SetNextHop sets value to NextHop
+func (o *MobileGatewayStaticRoute) SetNextHop(v string) {
+	o.NextHop = v
+}
+
+/*************************************************
+* MobileGatewayCreateRequest
+*************************************************/
+
+// MobileGatewayCreateRequest represents API parameter/response structure
+type MobileGatewayCreateRequest struct {
+	Class       string   `mapconv:",default=mobilegateway"`
+	SwitchID    string   `mapconv:"Remark.Switch.Scope,default=shared"`
+	PlanID      types.ID `mapconv:"Remark.Plan.ID/Plan.ID"`
+	Name        string   `validate:"required"`
+	Description string   `validate:"min=0,max=512"`
+	Tags        []string
+	IconID      types.ID                    `mapconv:"Icon.ID"`
+	Settings    *MobileGatewaySettingCreate `json:",omitempty" mapconv:",omitempty,recursive"`
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayCreateRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetClass returns value of Class
+func (o *MobileGatewayCreateRequest) GetClass() string {
+	return o.Class
+}
+
+// SetClass sets value to Class
+func (o *MobileGatewayCreateRequest) SetClass(v string) {
+	o.Class = v
+}
+
+// GetSwitchID returns value of SwitchID
+func (o *MobileGatewayCreateRequest) GetSwitchID() string {
+	return o.SwitchID
+}
+
+// SetSwitchID sets value to SwitchID
+func (o *MobileGatewayCreateRequest) SetSwitchID(v string) {
+	o.SwitchID = v
+}
+
+// GetPlanID returns value of PlanID
+func (o *MobileGatewayCreateRequest) GetPlanID() types.ID {
+	return o.PlanID
+}
+
+// SetPlanID sets value to PlanID
+func (o *MobileGatewayCreateRequest) SetPlanID(v types.ID) {
+	o.PlanID = v
+}
+
+// GetName returns value of Name
+func (o *MobileGatewayCreateRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *MobileGatewayCreateRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *MobileGatewayCreateRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *MobileGatewayCreateRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *MobileGatewayCreateRequest) GetTags() []string {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *MobileGatewayCreateRequest) SetTags(v []string) {
+	o.Tags = v
+}
+
+// GetIconID returns value of IconID
+func (o *MobileGatewayCreateRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *MobileGatewayCreateRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetSettings returns value of Settings
+func (o *MobileGatewayCreateRequest) GetSettings() *MobileGatewaySettingCreate {
+	return o.Settings
+}
+
+// SetSettings sets value to Settings
+func (o *MobileGatewayCreateRequest) SetSettings(v *MobileGatewaySettingCreate) {
+	o.Settings = v
+}
+
+/*************************************************
+* MobileGatewaySettingCreate
+*************************************************/
+
+// MobileGatewaySettingCreate represents API parameter/response structure
+type MobileGatewaySettingCreate struct {
+	StaticRoute                     []*MobileGatewayStaticRoute `json:",omitempty" mapconv:"MobileGateway.[]StaticRoutes,omitempty,recursive"`
+	InternetConnectionEnabled       types.StringFlag            `mapconv:"MobileGateway.InternetConnection.Enabled"`
+	InterDeviceCommunicationEnabled types.StringFlag            `mapconv:"MobileGateway.InterDeviceCommunication.Enabled"`
+}
+
+// Validate validates by field tags
+func (o *MobileGatewaySettingCreate) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetStaticRoute returns value of StaticRoute
+func (o *MobileGatewaySettingCreate) GetStaticRoute() []*MobileGatewayStaticRoute {
+	return o.StaticRoute
+}
+
+// SetStaticRoute sets value to StaticRoute
+func (o *MobileGatewaySettingCreate) SetStaticRoute(v []*MobileGatewayStaticRoute) {
+	o.StaticRoute = v
+}
+
+// GetInternetConnectionEnabled returns value of InternetConnectionEnabled
+func (o *MobileGatewaySettingCreate) GetInternetConnectionEnabled() types.StringFlag {
+	return o.InternetConnectionEnabled
+}
+
+// SetInternetConnectionEnabled sets value to InternetConnectionEnabled
+func (o *MobileGatewaySettingCreate) SetInternetConnectionEnabled(v types.StringFlag) {
+	o.InternetConnectionEnabled = v
+}
+
+// GetInterDeviceCommunicationEnabled returns value of InterDeviceCommunicationEnabled
+func (o *MobileGatewaySettingCreate) GetInterDeviceCommunicationEnabled() types.StringFlag {
+	return o.InterDeviceCommunicationEnabled
+}
+
+// SetInterDeviceCommunicationEnabled sets value to InterDeviceCommunicationEnabled
+func (o *MobileGatewaySettingCreate) SetInterDeviceCommunicationEnabled(v types.StringFlag) {
+	o.InterDeviceCommunicationEnabled = v
+}
+
+/*************************************************
+* MobileGatewayUpdateRequest
+*************************************************/
+
+// MobileGatewayUpdateRequest represents API parameter/response structure
+type MobileGatewayUpdateRequest struct {
+	Name        string `validate:"required"`
+	Description string `validate:"min=0,max=512"`
+	Tags        []string
+	IconID      types.ID              `mapconv:"Icon.ID"`
+	Settings    *MobileGatewaySetting `json:",omitempty" mapconv:",omitempty,recursive"`
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayUpdateRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetName returns value of Name
+func (o *MobileGatewayUpdateRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *MobileGatewayUpdateRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *MobileGatewayUpdateRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *MobileGatewayUpdateRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *MobileGatewayUpdateRequest) GetTags() []string {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *MobileGatewayUpdateRequest) SetTags(v []string) {
+	o.Tags = v
+}
+
+// GetIconID returns value of IconID
+func (o *MobileGatewayUpdateRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *MobileGatewayUpdateRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetSettings returns value of Settings
+func (o *MobileGatewayUpdateRequest) GetSettings() *MobileGatewaySetting {
+	return o.Settings
+}
+
+// SetSettings sets value to Settings
+func (o *MobileGatewayUpdateRequest) SetSettings(v *MobileGatewaySetting) {
+	o.Settings = v
+}
+
+/*************************************************
+* MobileGatewayDNSSetting
+*************************************************/
+
+// MobileGatewayDNSSetting represents API parameter/response structure
+type MobileGatewayDNSSetting struct {
+	DNS1 string
+	DNS2 string
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayDNSSetting) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetDNS1 returns value of DNS1
+func (o *MobileGatewayDNSSetting) GetDNS1() string {
+	return o.DNS1
+}
+
+// SetDNS1 sets value to DNS1
+func (o *MobileGatewayDNSSetting) SetDNS1(v string) {
+	o.DNS1 = v
+}
+
+// GetDNS2 returns value of DNS2
+func (o *MobileGatewayDNSSetting) GetDNS2() string {
+	return o.DNS2
+}
+
+// SetDNS2 sets value to DNS2
+func (o *MobileGatewayDNSSetting) SetDNS2(v string) {
+	o.DNS2 = v
+}
+
+/*************************************************
+* MobileGatewaySIMRoute
+*************************************************/
+
+// MobileGatewaySIMRoute represents API parameter/response structure
+type MobileGatewaySIMRoute struct {
+	ResourceID string
+	Prefix     string
+	ICCID      string
+}
+
+// Validate validates by field tags
+func (o *MobileGatewaySIMRoute) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetResourceID returns value of ResourceID
+func (o *MobileGatewaySIMRoute) GetResourceID() string {
+	return o.ResourceID
+}
+
+// SetResourceID sets value to ResourceID
+func (o *MobileGatewaySIMRoute) SetResourceID(v string) {
+	o.ResourceID = v
+}
+
+// GetPrefix returns value of Prefix
+func (o *MobileGatewaySIMRoute) GetPrefix() string {
+	return o.Prefix
+}
+
+// SetPrefix sets value to Prefix
+func (o *MobileGatewaySIMRoute) SetPrefix(v string) {
+	o.Prefix = v
+}
+
+// GetICCID returns value of ICCID
+func (o *MobileGatewaySIMRoute) GetICCID() string {
+	return o.ICCID
+}
+
+// SetICCID sets value to ICCID
+func (o *MobileGatewaySIMRoute) SetICCID(v string) {
+	o.ICCID = v
+}
+
+/*************************************************
+* MobileGatewaySIMRouteParam
+*************************************************/
+
+// MobileGatewaySIMRouteParam represents API parameter/response structure
+type MobileGatewaySIMRouteParam struct {
+	ResourceID string
+	Prefix     string
+}
+
+// Validate validates by field tags
+func (o *MobileGatewaySIMRouteParam) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetResourceID returns value of ResourceID
+func (o *MobileGatewaySIMRouteParam) GetResourceID() string {
+	return o.ResourceID
+}
+
+// SetResourceID sets value to ResourceID
+func (o *MobileGatewaySIMRouteParam) SetResourceID(v string) {
+	o.ResourceID = v
+}
+
+// GetPrefix returns value of Prefix
+func (o *MobileGatewaySIMRouteParam) GetPrefix() string {
+	return o.Prefix
+}
+
+// SetPrefix sets value to Prefix
+func (o *MobileGatewaySIMRouteParam) SetPrefix(v string) {
+	o.Prefix = v
+}
+
+/*************************************************
+* MobileGatewaySIMInfo
+*************************************************/
+
+// MobileGatewaySIMInfo represents API parameter/response structure
+type MobileGatewaySIMInfo struct {
+	ICCID                      string
+	IMSI                       []string
+	IP                         string
+	SessionStatus              string
+	IMEILock                   bool
+	Registered                 bool
+	Activated                  bool
+	ResourceID                 string
+	RegisteredDate             time.Time
+	ActivatedDate              time.Time
+	DeactivatedDate            time.Time
+	SIMGroupID                 string
+	TrafficBytesOfCurrentMonth *SIMTrafficBytes `mapconv:",recursive"`
+	ConnectedIMEI              string
+}
+
+// Validate validates by field tags
+func (o *MobileGatewaySIMInfo) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetICCID returns value of ICCID
+func (o *MobileGatewaySIMInfo) GetICCID() string {
+	return o.ICCID
+}
+
+// SetICCID sets value to ICCID
+func (o *MobileGatewaySIMInfo) SetICCID(v string) {
+	o.ICCID = v
+}
+
+// GetIMSI returns value of IMSI
+func (o *MobileGatewaySIMInfo) GetIMSI() []string {
+	return o.IMSI
+}
+
+// SetIMSI sets value to IMSI
+func (o *MobileGatewaySIMInfo) SetIMSI(v []string) {
+	o.IMSI = v
+}
+
+// GetIP returns value of IP
+func (o *MobileGatewaySIMInfo) GetIP() string {
+	return o.IP
+}
+
+// SetIP sets value to IP
+func (o *MobileGatewaySIMInfo) SetIP(v string) {
+	o.IP = v
+}
+
+// GetSessionStatus returns value of SessionStatus
+func (o *MobileGatewaySIMInfo) GetSessionStatus() string {
+	return o.SessionStatus
+}
+
+// SetSessionStatus sets value to SessionStatus
+func (o *MobileGatewaySIMInfo) SetSessionStatus(v string) {
+	o.SessionStatus = v
+}
+
+// GetIMEILock returns value of IMEILock
+func (o *MobileGatewaySIMInfo) GetIMEILock() bool {
+	return o.IMEILock
+}
+
+// SetIMEILock sets value to IMEILock
+func (o *MobileGatewaySIMInfo) SetIMEILock(v bool) {
+	o.IMEILock = v
+}
+
+// GetRegistered returns value of Registered
+func (o *MobileGatewaySIMInfo) GetRegistered() bool {
+	return o.Registered
+}
+
+// SetRegistered sets value to Registered
+func (o *MobileGatewaySIMInfo) SetRegistered(v bool) {
+	o.Registered = v
+}
+
+// GetActivated returns value of Activated
+func (o *MobileGatewaySIMInfo) GetActivated() bool {
+	return o.Activated
+}
+
+// SetActivated sets value to Activated
+func (o *MobileGatewaySIMInfo) SetActivated(v bool) {
+	o.Activated = v
+}
+
+// GetResourceID returns value of ResourceID
+func (o *MobileGatewaySIMInfo) GetResourceID() string {
+	return o.ResourceID
+}
+
+// SetResourceID sets value to ResourceID
+func (o *MobileGatewaySIMInfo) SetResourceID(v string) {
+	o.ResourceID = v
+}
+
+// GetRegisteredDate returns value of RegisteredDate
+func (o *MobileGatewaySIMInfo) GetRegisteredDate() time.Time {
+	return o.RegisteredDate
+}
+
+// SetRegisteredDate sets value to RegisteredDate
+func (o *MobileGatewaySIMInfo) SetRegisteredDate(v time.Time) {
+	o.RegisteredDate = v
+}
+
+// GetActivatedDate returns value of ActivatedDate
+func (o *MobileGatewaySIMInfo) GetActivatedDate() time.Time {
+	return o.ActivatedDate
+}
+
+// SetActivatedDate sets value to ActivatedDate
+func (o *MobileGatewaySIMInfo) SetActivatedDate(v time.Time) {
+	o.ActivatedDate = v
+}
+
+// GetDeactivatedDate returns value of DeactivatedDate
+func (o *MobileGatewaySIMInfo) GetDeactivatedDate() time.Time {
+	return o.DeactivatedDate
+}
+
+// SetDeactivatedDate sets value to DeactivatedDate
+func (o *MobileGatewaySIMInfo) SetDeactivatedDate(v time.Time) {
+	o.DeactivatedDate = v
+}
+
+// GetSIMGroupID returns value of SIMGroupID
+func (o *MobileGatewaySIMInfo) GetSIMGroupID() string {
+	return o.SIMGroupID
+}
+
+// SetSIMGroupID sets value to SIMGroupID
+func (o *MobileGatewaySIMInfo) SetSIMGroupID(v string) {
+	o.SIMGroupID = v
+}
+
+// GetTrafficBytesOfCurrentMonth returns value of TrafficBytesOfCurrentMonth
+func (o *MobileGatewaySIMInfo) GetTrafficBytesOfCurrentMonth() *SIMTrafficBytes {
+	return o.TrafficBytesOfCurrentMonth
+}
+
+// SetTrafficBytesOfCurrentMonth sets value to TrafficBytesOfCurrentMonth
+func (o *MobileGatewaySIMInfo) SetTrafficBytesOfCurrentMonth(v *SIMTrafficBytes) {
+	o.TrafficBytesOfCurrentMonth = v
+}
+
+// GetConnectedIMEI returns value of ConnectedIMEI
+func (o *MobileGatewaySIMInfo) GetConnectedIMEI() string {
+	return o.ConnectedIMEI
+}
+
+// SetConnectedIMEI sets value to ConnectedIMEI
+func (o *MobileGatewaySIMInfo) SetConnectedIMEI(v string) {
+	o.ConnectedIMEI = v
+}
+
+/*************************************************
+* SIMTrafficBytes
+*************************************************/
+
+// SIMTrafficBytes represents API parameter/response structure
+type SIMTrafficBytes struct {
+	UplinkBytes   int64
+	DownlinkBytes int64
+}
+
+// Validate validates by field tags
+func (o *SIMTrafficBytes) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetUplinkBytes returns value of UplinkBytes
+func (o *SIMTrafficBytes) GetUplinkBytes() int64 {
+	return o.UplinkBytes
+}
+
+// SetUplinkBytes sets value to UplinkBytes
+func (o *SIMTrafficBytes) SetUplinkBytes(v int64) {
+	o.UplinkBytes = v
+}
+
+// GetDownlinkBytes returns value of DownlinkBytes
+func (o *SIMTrafficBytes) GetDownlinkBytes() int64 {
+	return o.DownlinkBytes
+}
+
+// SetDownlinkBytes sets value to DownlinkBytes
+func (o *SIMTrafficBytes) SetDownlinkBytes(v int64) {
+	o.DownlinkBytes = v
+}
+
+/*************************************************
+* MobileGatewayAddSIMRequest
+*************************************************/
+
+// MobileGatewayAddSIMRequest represents API parameter/response structure
+type MobileGatewayAddSIMRequest struct {
+	SIMID string `json:"resource_id" mapconv:"ResourceID"`
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayAddSIMRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetSIMID returns value of SIMID
+func (o *MobileGatewayAddSIMRequest) GetSIMID() string {
+	return o.SIMID
+}
+
+// SetSIMID sets value to SIMID
+func (o *MobileGatewayAddSIMRequest) SetSIMID(v string) {
+	o.SIMID = v
+}
+
+/*************************************************
+* MobileGatewaySIMLogs
+*************************************************/
+
+// MobileGatewaySIMLogs represents API parameter/response structure
+type MobileGatewaySIMLogs struct {
+	Date          time.Time
+	SessionStatus string
+	ResourceID    string
+	IMEI          string
+	IMSI          string
+}
+
+// Validate validates by field tags
+func (o *MobileGatewaySIMLogs) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetDate returns value of Date
+func (o *MobileGatewaySIMLogs) GetDate() time.Time {
+	return o.Date
+}
+
+// SetDate sets value to Date
+func (o *MobileGatewaySIMLogs) SetDate(v time.Time) {
+	o.Date = v
+}
+
+// GetSessionStatus returns value of SessionStatus
+func (o *MobileGatewaySIMLogs) GetSessionStatus() string {
+	return o.SessionStatus
+}
+
+// SetSessionStatus sets value to SessionStatus
+func (o *MobileGatewaySIMLogs) SetSessionStatus(v string) {
+	o.SessionStatus = v
+}
+
+// GetResourceID returns value of ResourceID
+func (o *MobileGatewaySIMLogs) GetResourceID() string {
+	return o.ResourceID
+}
+
+// SetResourceID sets value to ResourceID
+func (o *MobileGatewaySIMLogs) SetResourceID(v string) {
+	o.ResourceID = v
+}
+
+// GetIMEI returns value of IMEI
+func (o *MobileGatewaySIMLogs) GetIMEI() string {
+	return o.IMEI
+}
+
+// SetIMEI sets value to IMEI
+func (o *MobileGatewaySIMLogs) SetIMEI(v string) {
+	o.IMEI = v
+}
+
+// GetIMSI returns value of IMSI
+func (o *MobileGatewaySIMLogs) GetIMSI() string {
+	return o.IMSI
+}
+
+// SetIMSI sets value to IMSI
+func (o *MobileGatewaySIMLogs) SetIMSI(v string) {
+	o.IMSI = v
+}
+
+/*************************************************
+* MobileGatewayTrafficControl
+*************************************************/
+
+// MobileGatewayTrafficControl represents API parameter/response structure
+type MobileGatewayTrafficControl struct {
+	TrafficQuotaInMB       int
+	BandWidthLimitInKbps   int
+	EmailNotifyEnabled     bool   `mapconv:"EMailConfig.Enabled"`
+	SlackNotifyEnabled     bool   `mapconv:"SlackConfig.Enabled"`
+	SlackNotifyWebhooksURL string `mapconv:"SlackConfig.IncomingWebhooksURL"`
+	AutoTrafficShaping     bool
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayTrafficControl) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetTrafficQuotaInMB returns value of TrafficQuotaInMB
+func (o *MobileGatewayTrafficControl) GetTrafficQuotaInMB() int {
+	return o.TrafficQuotaInMB
+}
+
+// SetTrafficQuotaInMB sets value to TrafficQuotaInMB
+func (o *MobileGatewayTrafficControl) SetTrafficQuotaInMB(v int) {
+	o.TrafficQuotaInMB = v
+}
+
+// GetBandWidthLimitInKbps returns value of BandWidthLimitInKbps
+func (o *MobileGatewayTrafficControl) GetBandWidthLimitInKbps() int {
+	return o.BandWidthLimitInKbps
+}
+
+// SetBandWidthLimitInKbps sets value to BandWidthLimitInKbps
+func (o *MobileGatewayTrafficControl) SetBandWidthLimitInKbps(v int) {
+	o.BandWidthLimitInKbps = v
+}
+
+// GetEmailNotifyEnabled returns value of EmailNotifyEnabled
+func (o *MobileGatewayTrafficControl) GetEmailNotifyEnabled() bool {
+	return o.EmailNotifyEnabled
+}
+
+// SetEmailNotifyEnabled sets value to EmailNotifyEnabled
+func (o *MobileGatewayTrafficControl) SetEmailNotifyEnabled(v bool) {
+	o.EmailNotifyEnabled = v
+}
+
+// GetSlackNotifyEnabled returns value of SlackNotifyEnabled
+func (o *MobileGatewayTrafficControl) GetSlackNotifyEnabled() bool {
+	return o.SlackNotifyEnabled
+}
+
+// SetSlackNotifyEnabled sets value to SlackNotifyEnabled
+func (o *MobileGatewayTrafficControl) SetSlackNotifyEnabled(v bool) {
+	o.SlackNotifyEnabled = v
+}
+
+// GetSlackNotifyWebhooksURL returns value of SlackNotifyWebhooksURL
+func (o *MobileGatewayTrafficControl) GetSlackNotifyWebhooksURL() string {
+	return o.SlackNotifyWebhooksURL
+}
+
+// SetSlackNotifyWebhooksURL sets value to SlackNotifyWebhooksURL
+func (o *MobileGatewayTrafficControl) SetSlackNotifyWebhooksURL(v string) {
+	o.SlackNotifyWebhooksURL = v
+}
+
+// GetAutoTrafficShaping returns value of AutoTrafficShaping
+func (o *MobileGatewayTrafficControl) GetAutoTrafficShaping() bool {
+	return o.AutoTrafficShaping
+}
+
+// SetAutoTrafficShaping sets value to AutoTrafficShaping
+func (o *MobileGatewayTrafficControl) SetAutoTrafficShaping(v bool) {
+	o.AutoTrafficShaping = v
+}
+
+/*************************************************
+* MobileGatewayTrafficStatus
+*************************************************/
+
+// MobileGatewayTrafficStatus represents API parameter/response structure
+type MobileGatewayTrafficStatus struct {
+	UplinkBytes    types.StringNumber
+	DownlinkBytes  types.StringNumber
+	TrafficShaping bool
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayTrafficStatus) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetUplinkBytes returns value of UplinkBytes
+func (o *MobileGatewayTrafficStatus) GetUplinkBytes() types.StringNumber {
+	return o.UplinkBytes
+}
+
+// SetUplinkBytes sets value to UplinkBytes
+func (o *MobileGatewayTrafficStatus) SetUplinkBytes(v types.StringNumber) {
+	o.UplinkBytes = v
+}
+
+// GetDownlinkBytes returns value of DownlinkBytes
+func (o *MobileGatewayTrafficStatus) GetDownlinkBytes() types.StringNumber {
+	return o.DownlinkBytes
+}
+
+// SetDownlinkBytes sets value to DownlinkBytes
+func (o *MobileGatewayTrafficStatus) SetDownlinkBytes(v types.StringNumber) {
+	o.DownlinkBytes = v
+}
+
+// GetTrafficShaping returns value of TrafficShaping
+func (o *MobileGatewayTrafficStatus) GetTrafficShaping() bool {
+	return o.TrafficShaping
+}
+
+// SetTrafficShaping sets value to TrafficShaping
+func (o *MobileGatewayTrafficStatus) SetTrafficShaping(v bool) {
+	o.TrafficShaping = v
+}
+
+/*************************************************
 * NFS
 *************************************************/
 
@@ -12731,8 +14070,9 @@ type SIM struct {
 	Tags         []string
 	Availability types.EAvailability
 	Class        string
-	ICCID        types.StringNumber `mapconv:"Status.ICCID" validate:"numeric"`
-	IconID       types.ID           `mapconv:"Icon.ID"`
+	ICCID        string   `mapconv:"Status.ICCID" validate:"numeric"`
+	Info         *SIMInfo `mapconv:"Status.SIMInfo"`
+	IconID       types.ID `mapconv:"Icon.ID"`
 	CreatedAt    time.Time
 	ModifiedAt   time.Time
 }
@@ -12823,13 +14163,23 @@ func (o *SIM) SetClass(v string) {
 }
 
 // GetICCID returns value of ICCID
-func (o *SIM) GetICCID() types.StringNumber {
+func (o *SIM) GetICCID() string {
 	return o.ICCID
 }
 
 // SetICCID sets value to ICCID
-func (o *SIM) SetICCID(v types.StringNumber) {
+func (o *SIM) SetICCID(v string) {
 	o.ICCID = v
+}
+
+// GetInfo returns value of Info
+func (o *SIM) GetInfo() *SIMInfo {
+	return o.Info
+}
+
+// SetInfo sets value to Info
+func (o *SIM) SetInfo(v *SIMInfo) {
+	o.Info = v
 }
 
 // GetIconID returns value of IconID
@@ -12863,6 +14213,173 @@ func (o *SIM) SetModifiedAt(v time.Time) {
 }
 
 /*************************************************
+* SIMInfo
+*************************************************/
+
+// SIMInfo represents API parameter/response structure
+type SIMInfo struct {
+	ICCID                      string
+	IMSI                       []string
+	IP                         string
+	SessionStatus              string
+	IMEILock                   bool
+	Registered                 bool
+	Activated                  bool
+	ResourceID                 string
+	RegisteredDate             time.Time
+	ActivatedDate              time.Time
+	DeactivatedDate            time.Time
+	SIMGroupID                 string
+	TrafficBytesOfCurrentMonth *SIMTrafficBytes `mapconv:",recursive"`
+	ConnectedIMEI              string
+}
+
+// Validate validates by field tags
+func (o *SIMInfo) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// GetICCID returns value of ICCID
+func (o *SIMInfo) GetICCID() string {
+	return o.ICCID
+}
+
+// SetICCID sets value to ICCID
+func (o *SIMInfo) SetICCID(v string) {
+	o.ICCID = v
+}
+
+// GetIMSI returns value of IMSI
+func (o *SIMInfo) GetIMSI() []string {
+	return o.IMSI
+}
+
+// SetIMSI sets value to IMSI
+func (o *SIMInfo) SetIMSI(v []string) {
+	o.IMSI = v
+}
+
+// GetIP returns value of IP
+func (o *SIMInfo) GetIP() string {
+	return o.IP
+}
+
+// SetIP sets value to IP
+func (o *SIMInfo) SetIP(v string) {
+	o.IP = v
+}
+
+// GetSessionStatus returns value of SessionStatus
+func (o *SIMInfo) GetSessionStatus() string {
+	return o.SessionStatus
+}
+
+// SetSessionStatus sets value to SessionStatus
+func (o *SIMInfo) SetSessionStatus(v string) {
+	o.SessionStatus = v
+}
+
+// GetIMEILock returns value of IMEILock
+func (o *SIMInfo) GetIMEILock() bool {
+	return o.IMEILock
+}
+
+// SetIMEILock sets value to IMEILock
+func (o *SIMInfo) SetIMEILock(v bool) {
+	o.IMEILock = v
+}
+
+// GetRegistered returns value of Registered
+func (o *SIMInfo) GetRegistered() bool {
+	return o.Registered
+}
+
+// SetRegistered sets value to Registered
+func (o *SIMInfo) SetRegistered(v bool) {
+	o.Registered = v
+}
+
+// GetActivated returns value of Activated
+func (o *SIMInfo) GetActivated() bool {
+	return o.Activated
+}
+
+// SetActivated sets value to Activated
+func (o *SIMInfo) SetActivated(v bool) {
+	o.Activated = v
+}
+
+// GetResourceID returns value of ResourceID
+func (o *SIMInfo) GetResourceID() string {
+	return o.ResourceID
+}
+
+// SetResourceID sets value to ResourceID
+func (o *SIMInfo) SetResourceID(v string) {
+	o.ResourceID = v
+}
+
+// GetRegisteredDate returns value of RegisteredDate
+func (o *SIMInfo) GetRegisteredDate() time.Time {
+	return o.RegisteredDate
+}
+
+// SetRegisteredDate sets value to RegisteredDate
+func (o *SIMInfo) SetRegisteredDate(v time.Time) {
+	o.RegisteredDate = v
+}
+
+// GetActivatedDate returns value of ActivatedDate
+func (o *SIMInfo) GetActivatedDate() time.Time {
+	return o.ActivatedDate
+}
+
+// SetActivatedDate sets value to ActivatedDate
+func (o *SIMInfo) SetActivatedDate(v time.Time) {
+	o.ActivatedDate = v
+}
+
+// GetDeactivatedDate returns value of DeactivatedDate
+func (o *SIMInfo) GetDeactivatedDate() time.Time {
+	return o.DeactivatedDate
+}
+
+// SetDeactivatedDate sets value to DeactivatedDate
+func (o *SIMInfo) SetDeactivatedDate(v time.Time) {
+	o.DeactivatedDate = v
+}
+
+// GetSIMGroupID returns value of SIMGroupID
+func (o *SIMInfo) GetSIMGroupID() string {
+	return o.SIMGroupID
+}
+
+// SetSIMGroupID sets value to SIMGroupID
+func (o *SIMInfo) SetSIMGroupID(v string) {
+	o.SIMGroupID = v
+}
+
+// GetTrafficBytesOfCurrentMonth returns value of TrafficBytesOfCurrentMonth
+func (o *SIMInfo) GetTrafficBytesOfCurrentMonth() *SIMTrafficBytes {
+	return o.TrafficBytesOfCurrentMonth
+}
+
+// SetTrafficBytesOfCurrentMonth sets value to TrafficBytesOfCurrentMonth
+func (o *SIMInfo) SetTrafficBytesOfCurrentMonth(v *SIMTrafficBytes) {
+	o.TrafficBytesOfCurrentMonth = v
+}
+
+// GetConnectedIMEI returns value of ConnectedIMEI
+func (o *SIMInfo) GetConnectedIMEI() string {
+	return o.ConnectedIMEI
+}
+
+// SetConnectedIMEI sets value to ConnectedIMEI
+func (o *SIMInfo) SetConnectedIMEI(v string) {
+	o.ConnectedIMEI = v
+}
+
+/*************************************************
 * SIMCreateRequest
 *************************************************/
 
@@ -12871,10 +14388,10 @@ type SIMCreateRequest struct {
 	Name        string `validate:"required"`
 	Description string `validate:"min=0,max=512"`
 	Tags        []string
-	IconID      types.ID           `mapconv:"Icon.ID"`
-	Class       string             `mapconv:"Provider.Class,default=sim"`
-	ICCID       types.StringNumber `mapconv:"Status.ICCID" validate:"numeric"`
-	PassCode    string             `mapconv:"Remark.PassCode"`
+	IconID      types.ID `mapconv:"Icon.ID"`
+	Class       string   `mapconv:"Provider.Class,default=sim"`
+	ICCID       string   `mapconv:"Status.ICCID" validate:"numeric"`
+	PassCode    string   `mapconv:"Remark.PassCode"`
 }
 
 // Validate validates by field tags
@@ -12933,12 +14450,12 @@ func (o *SIMCreateRequest) SetClass(v string) {
 }
 
 // GetICCID returns value of ICCID
-func (o *SIMCreateRequest) GetICCID() types.StringNumber {
+func (o *SIMCreateRequest) GetICCID() string {
 	return o.ICCID
 }
 
 // SetICCID sets value to ICCID
-func (o *SIMCreateRequest) SetICCID(v types.StringNumber) {
+func (o *SIMCreateRequest) SetICCID(v string) {
 	o.ICCID = v
 }
 
@@ -13169,30 +14686,6 @@ func (o *SIMNetworkOperatorConfig) GetName() string {
 // SetName sets value to Name
 func (o *SIMNetworkOperatorConfig) SetName(v string) {
 	o.Name = v
-}
-
-/*************************************************
-* SIMNetworkOperatorConfigs
-*************************************************/
-
-// SIMNetworkOperatorConfigs represents API parameter/response structure
-type SIMNetworkOperatorConfigs struct {
-	NetworkOperatorConfigs []*SIMNetworkOperatorConfig
-}
-
-// Validate validates by field tags
-func (o *SIMNetworkOperatorConfigs) Validate() error {
-	return validator.New().Struct(o)
-}
-
-// GetNetworkOperatorConfigs returns value of NetworkOperatorConfigs
-func (o *SIMNetworkOperatorConfigs) GetNetworkOperatorConfigs() []*SIMNetworkOperatorConfig {
-	return o.NetworkOperatorConfigs
-}
-
-// SetNetworkOperatorConfigs sets value to NetworkOperatorConfigs
-func (o *SIMNetworkOperatorConfigs) SetNetworkOperatorConfigs(v []*SIMNetworkOperatorConfig) {
-	o.NetworkOperatorConfigs = v
 }
 
 /*************************************************

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -5900,7 +5900,7 @@ func (o *GSLB) SetDestinationServers(v []*GSLBServer) {
 type GSLBServer struct {
 	IPAddress string `validate:"ipv4"`
 	Enabled   types.StringFlag
-	Weight    types.StringNumber `mapconv:",default=1"`
+	Weight    types.StringNumber
 }
 
 // Validate validates by field tags

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -735,6 +735,85 @@ type LoadBalancerStatusResult struct {
 	Status []*LoadBalancerStatus `json:",omitempty" mapconv:"[]LoadBalancer,omitempty,recursive"`
 }
 
+// MobileGatewayFindResult represents the Result of API
+type MobileGatewayFindResult struct {
+	Total int `json:",omitempty"` // Total count of target resources
+	From  int `json:",omitempty"` // Current page number
+	Count int `json:",omitempty"` // Count of current page
+
+	MobileGateways []*MobileGateway `json:",omitempty" mapconv:"[]Appliances,omitempty,recursive"`
+}
+
+// mobileGatewayCreateResult represents the Result of API
+type mobileGatewayCreateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	MobileGateway *MobileGateway `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// mobileGatewayReadResult represents the Result of API
+type mobileGatewayReadResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	MobileGateway *MobileGateway `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// mobileGatewayUpdateResult represents the Result of API
+type mobileGatewayUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	MobileGateway *MobileGateway `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// mobileGatewayGetDNSResult represents the Result of API
+type mobileGatewayGetDNSResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	SIMGroup *MobileGatewayDNSSetting `json:",omitempty" mapconv:"SIMGroup,omitempty,recursive"`
+}
+
+// mobileGatewayGetSIMRoutesResult represents the Result of API
+type mobileGatewayGetSIMRoutesResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	SIMRoutes []*MobileGatewaySIMRoute `json:",omitempty" mapconv:"[]SIMRoutes,omitempty,recursive"`
+}
+
+// mobileGatewayListSIMResult represents the Result of API
+type mobileGatewayListSIMResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	SIM []*MobileGatewaySIMInfo `json:",omitempty" mapconv:"[]SIM,omitempty,recursive"`
+}
+
+// mobileGatewayLogsResult represents the Result of API
+type mobileGatewayLogsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Logs []*MobileGatewaySIMLogs `json:",omitempty" mapconv:"[]Logs,omitempty,recursive"`
+}
+
+// mobileGatewayGetTrafficConfigResult represents the Result of API
+type mobileGatewayGetTrafficConfigResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	TrafficMonitoring *MobileGatewayTrafficControl `json:",omitempty" mapconv:"TrafficMonitoring,omitempty,recursive"`
+}
+
+// mobileGatewayTrafficStatusResult represents the Result of API
+type mobileGatewayTrafficStatusResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	TrafficStatus *MobileGatewayTrafficStatus `json:",omitempty" mapconv:"TrafficStatus,omitempty,recursive"`
+}
+
+// mobileGatewayMonitorInterfaceResult represents the Result of API
+type mobileGatewayMonitorInterfaceResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	InterfaceActivity *InterfaceActivity `json:",omitempty" mapconv:"Data,omitempty,recursive"`
+}
+
 // NFSFindResult represents the Result of API
 type NFSFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -1067,11 +1146,9 @@ type SIMLogsResult struct {
 	Logs []*SIMLog `json:",omitempty" mapconv:"[]Logs,omitempty,recursive"`
 }
 
-// SIMGetNetworkOperatorResult represents the Result of API
-type SIMGetNetworkOperatorResult struct {
-	Total int `json:",omitempty"` // Total count of target resources
-	From  int `json:",omitempty"` // Current page number
-	Count int `json:",omitempty"` // Count of current page
+// sIMGetNetworkOperatorResult represents the Result of API
+type sIMGetNetworkOperatorResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
 
 	Configs []*SIMNetworkOperatorConfig `json:",omitempty" mapconv:"[]NetworkOperationConfigs,omitempty,recursive"`
 }
@@ -1081,6 +1158,13 @@ type sIMMonitorSIMResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	LinkActivity *LinkActivity `json:",omitempty" mapconv:"Data,omitempty,recursive"`
+}
+
+// sIMStatusResult represents the Result of API
+type sIMStatusResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	SIM *SIMInfo `json:",omitempty" mapconv:"SIM,omitempty,recursive"`
 }
 
 // SimpleMonitorFindResult represents the Result of API


### PR DESCRIPTION
- モバイルゲートウェイ APIの追加
- SIMのfakeドライバー実装
- mapconvの内部でmapstructureを利用するように変更
- GSLBのレグレッションの修正

Note: mapconvでは内部的にmapを利用してデータ変換を行い、最後にjson.Marshal/json.Unmarshalを行ってmapからstructへ変換していた。
かつモバイルゲートウェイAPIでは一部フィールドでスネークケースとなっているため、naked型へJSONタグを付与して対応していた。
この場合mapconvにおいてJSONタグ起因でうまく変換できないケースがあったため、json.Marshal/Unmarshalの使用をやめ[mapstructure](https://github.com/mitchellh/mapstructure)を利用するように変更した。