### PR TITLE
GSLBの実サーバ上限数を12に変更

### DIFF
--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -879,7 +879,7 @@ func (f *fieldsDef) GSLBDestinationServers() *dsl.FieldDesc {
 		},
 		Tags: &dsl.FieldTags{
 			MapConv:  "Settings.GSLB.[]Servers,recursive",
-			Validate: "min=0,max=6",
+			Validate: "min=0,max=12",
 		},
 	}
 }

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -5664,7 +5664,7 @@ type GSLB struct {
 	HealthCheckResponseCode types.StringNumber `mapconv:"Settings.GSLB.HealthCheck.Status"`
 	HealthCheckPort         types.StringNumber `mapconv:"Settings.GSLB.HealthCheck.Port"`
 	SorryServer             string             `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers      []*GSLBServer      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=6"`
+	DestinationServers      []*GSLBServer      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
 }
 
 // Validate validates by field tags
@@ -5953,7 +5953,7 @@ type GSLBCreateRequest struct {
 	DelayLoop               int                `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
 	Weighted                types.StringFlag   `mapconv:"Settings.GSLB.Weighted"`
 	SorryServer             string             `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers      []*GSLBServer      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=6"`
+	DestinationServers      []*GSLBServer      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
 	Name                    string             `validate:"required"`
 	Description             string             `validate:"min=0,max=512"`
 	Tags                    []string
@@ -6119,7 +6119,7 @@ type GSLBUpdateRequest struct {
 	DelayLoop               int                `mapconv:"Settings.GSLB.DelayLoop,default=10" validate:"min=10,max=60"`
 	Weighted                types.StringFlag   `mapconv:"Settings.GSLB.Weighted"`
 	SorryServer             string             `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers      []*GSLBServer      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=6"`
+	DestinationServers      []*GSLBServer      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
 	Name                    string             `validate:"required"`
 	Description             string             `validate:"min=0,max=512"`
 	Tags                    []string


### PR DESCRIPTION
https://cloud-news.sakura.ad.jp/2019/07/18/gslb-realserver-maximum-12/