### PR TITLE
Remove newsfeed from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Library for SakuraCloud API
 - [x] `License`: ライセンス
 - [x] `LoadBalancer`: ロードバランサ
 - [x] `MobileGateway`: モバイルゲートウェイ 
-- [ ] `NewsFeed`: ニュースフィード(メンテナンス情報)
 - [x] `NFS`: NFS
 - [x] `Note`: スタートアップスクリプト
 - [x] `PacketFilter`: パケットフィルタ


### PR DESCRIPTION
v1で提供されていたnewsfeed APIについて、実態はRSSの取得処理でAPIキーも不要な処理なためv2では廃止する。