### PR TITLE
グローバルリソースのAPI引数からゾーンを除去

### DIFF
--- a/internal/define/archive.go
+++ b/internal/define/archive.go
@@ -47,7 +47,6 @@ var archiveAPI = &dsl.Resource{
 				},
 			),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.MappableArgument("param", archiveCreateBlankParam, names.ResourceFieldName(archiveAPIName, dsl.PayloadForms.Singular)),
 			},
 			Results: dsl.Results{

--- a/internal/define/auth_status.go
+++ b/internal/define/auth_status.go
@@ -25,7 +25,6 @@ var authStatusAPI = &dsl.Resource{
 			Name:         "Read",
 			Method:       http.MethodGet,
 			PathFormat:   dsl.DefaultPathFormat,
-			Arguments:    dsl.Arguments{dsl.ArgumentZone},
 			ResponseEnvelope: dsl.ResponseEnvelope(
 				&dsl.EnvelopePayloadDesc{
 					Name: authStatusAPIName,

--- a/internal/define/bill.go
+++ b/internal/define/bill.go
@@ -29,7 +29,6 @@ var billAPI = &dsl.Resource{
 			Method:           http.MethodGet,
 			UseWrappedResult: true,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				billArgAccountID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelopePlural(&dsl.EnvelopePayloadDesc{
@@ -53,7 +52,6 @@ var billAPI = &dsl.Resource{
 			Method:           http.MethodGet,
 			UseWrappedResult: true,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				billArgAccountID,
 				billArgYear,
 			},
@@ -78,7 +76,6 @@ var billAPI = &dsl.Resource{
 			Method:           http.MethodGet,
 			UseWrappedResult: true,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				billArgAccountID,
 				billArgYear,
 				billArgMonth,
@@ -104,7 +101,6 @@ var billAPI = &dsl.Resource{
 			Method:           http.MethodGet,
 			UseWrappedResult: true,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelopePlural(&dsl.EnvelopePayloadDesc{
@@ -128,7 +124,6 @@ var billAPI = &dsl.Resource{
 			Method:           http.MethodGet,
 			UseWrappedResult: true,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				billArgMemberCode,
 				dsl.ArgumentID,
 			},
@@ -152,7 +147,6 @@ var billAPI = &dsl.Resource{
 			PathFormat:   billDetailPath + "/csv",
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				billArgMemberCode,
 				dsl.ArgumentID,
 			},

--- a/internal/define/cdrom.go
+++ b/internal/define/cdrom.go
@@ -44,7 +44,6 @@ var cdromAPI = &dsl.Resource{
 				},
 			),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.MappableArgument("param", cdromCreateParam, names.ResourceFieldName(cdromAPIName, dsl.PayloadForms.Singular)),
 			},
 			Results: dsl.Results{

--- a/internal/define/coupon.go
+++ b/internal/define/coupon.go
@@ -28,7 +28,6 @@ var couponAPI = &dsl.Resource{
 			Method:           http.MethodGet,
 			UseWrappedResult: true,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				couponArgAccountID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelopePlural(&dsl.EnvelopePayloadDesc{

--- a/internal/define/database.go
+++ b/internal/define/database.go
@@ -60,7 +60,6 @@ var databaseAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("status"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{

--- a/internal/define/disk.go
+++ b/internal/define/disk.go
@@ -44,7 +44,6 @@ var diskAPI = &dsl.Resource{
 				},
 			),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				{
 					Name:       "createParam",
 					MapConvTag: "Disk",
@@ -78,7 +77,6 @@ var diskAPI = &dsl.Resource{
 			Method:          http.MethodPut,
 			RequestEnvelope: dsl.RequestEnvelopeFromModel(diskEditParam),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.PassthroughModelArgument("edit", diskEditParam),
 			},
@@ -109,7 +107,6 @@ var diskAPI = &dsl.Resource{
 				Name: "Disk",
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				{
 					Name:       "createParam",
 					MapConvTag: "Disk",
@@ -164,7 +161,6 @@ var diskAPI = &dsl.Resource{
 				Name: "Disk",
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				{
 					Name:       "createParam",
 					MapConvTag: "Disk",
@@ -234,7 +230,6 @@ var diskAPI = &dsl.Resource{
 				Name: "Disk",
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				{
 					Name:       "installParam",
@@ -273,7 +268,6 @@ var diskAPI = &dsl.Resource{
 				Name: "Disk",
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				{
 					Name:       "installParam",

--- a/internal/define/internet.go
+++ b/internal/define/internet.go
@@ -49,7 +49,6 @@ var internetAPI = &dsl.Resource{
 				},
 			),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", internetUpdateBandWidthParam, "Internet"),
 			},
@@ -75,7 +74,6 @@ var internetAPI = &dsl.Resource{
 			Method:          http.MethodPost,
 			RequestEnvelope: dsl.RequestEnvelopeFromModel(internetAddSubnetParam),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.PassthroughModelArgument("param", internetAddSubnetParam),
 			},
@@ -101,7 +99,6 @@ var internetAPI = &dsl.Resource{
 			Method:          http.MethodPut,
 			RequestEnvelope: dsl.RequestEnvelopeFromModel(internetUpdateSubnetParam),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				{
 					Name: "subnetID",
@@ -141,7 +138,6 @@ var internetAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("ipv6net"),
 			Method:       http.MethodPost,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{

--- a/internal/define/ipaddress.go
+++ b/internal/define/ipaddress.go
@@ -26,9 +26,6 @@ var ipAPI = &dsl.Resource{
 			PathFormat:       dsl.DefaultPathFormat,
 			Method:           http.MethodGet,
 			UseWrappedResult: true,
-			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
-			},
 			ResponseEnvelope: dsl.ResponseEnvelopePlural(&dsl.EnvelopePayloadDesc{
 				Type: ipNakedType,
 				Name: ipAPIName,
@@ -49,7 +46,6 @@ var ipAPI = &dsl.Resource{
 			PathFormat:   dsl.DefaultPathFormat + "/{{.ipAddress}}",
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				{
 					Name: "ipAddress",
 					Type: meta.TypeString,
@@ -80,7 +76,6 @@ var ipAPI = &dsl.Resource{
 				Name: ipAPIName,
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				{
 					Name: "ipAddress",
 					Type: meta.TypeString,

--- a/internal/define/ipv6addr.go
+++ b/internal/define/ipv6addr.go
@@ -33,7 +33,6 @@ var ipv6AddrAPI = &dsl.Resource{
 			PathFormat:   dsl.DefaultPathFormatWithID,
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				argIPv6Addr,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -61,7 +60,6 @@ var ipv6AddrAPI = &dsl.Resource{
 				Name: ipv6AddrAPIName,
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				argIPv6Addr,
 				dsl.MappableArgument("param", ipv6AddrUpdateParam, ipv6AddrAPIName),
 			},
@@ -86,7 +84,6 @@ var ipv6AddrAPI = &dsl.Resource{
 			PathFormat:   dsl.DefaultPathFormatWithID,
 			Method:       http.MethodDelete,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				argIPv6Addr,
 			},
 		},

--- a/internal/define/mobile_gateway.go
+++ b/internal/define/mobile_gateway.go
@@ -64,7 +64,6 @@ var mobileGatewayAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/dnsresolver"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -89,7 +88,6 @@ var mobileGatewayAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/dnsresolver"),
 			Method:       http.MethodPut,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", mobileGatewayDNSModel, "SIMGroup"),
 			},
@@ -109,7 +107,6 @@ var mobileGatewayAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/simroutes"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -141,7 +138,6 @@ var mobileGatewayAPI = &dsl.Resource{
 				},
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", mobileGatewaySIMRouteParam, "[]SIMRoutes"),
 			},
@@ -154,7 +150,6 @@ var mobileGatewayAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/sims"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -187,7 +182,6 @@ var mobileGatewayAPI = &dsl.Resource{
 				},
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", mobileGatewayAddSIMParam, "SIM"),
 			},
@@ -199,7 +193,6 @@ var mobileGatewayAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/sims/{{.simID}}"),
 			Method:       http.MethodDelete,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				{
 					Name: "simID",
@@ -215,7 +208,6 @@ var mobileGatewayAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/sessionlog"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -242,7 +234,6 @@ var mobileGatewayAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/traffic_monitoring"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -275,7 +266,6 @@ var mobileGatewayAPI = &dsl.Resource{
 				},
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", mobileGatewayTrafficConfigModel, "TrafficMonitoring"),
 			},
@@ -287,7 +277,6 @@ var mobileGatewayAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/traffic_monitoring"),
 			Method:       http.MethodDelete,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 		},
@@ -299,7 +288,6 @@ var mobileGatewayAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("mobilegateway/traffic_status"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{

--- a/internal/define/ops/operations.go
+++ b/internal/define/ops/operations.go
@@ -22,7 +22,6 @@ func find(resourceName string, nakedType meta.Type, findParam, result *dsl.Model
 		UseWrappedResult: true,
 		RequestEnvelope:  dsl.RequestEnvelopeFromModel(findParam),
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.PassthroughModelArgument("conditions", findParam),
 		},
 		ResponseEnvelope: dsl.ResponseEnvelopePlural(&dsl.EnvelopePayloadDesc{
@@ -63,9 +62,6 @@ func List(resourceName string, nakedType meta.Type, result *dsl.Model) *dsl.Oper
 		PathFormat:       dsl.DefaultPathFormat,
 		Method:           http.MethodGet,
 		UseWrappedResult: true,
-		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
-		},
 		ResponseEnvelope: dsl.ResponseEnvelopePlural(&dsl.EnvelopePayloadDesc{
 			Type: nakedType,
 			Name: names.ResourceFieldName(resourceName, dsl.PayloadForms.Plural),
@@ -96,7 +92,6 @@ func create(resourceName string, nakedType meta.Type, createParam, result *dsl.M
 			Name: payloadName,
 		}),
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.MappableArgument("param", createParam, payloadName),
 		},
 		ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -140,7 +135,6 @@ func read(resourceName string, nakedType meta.Type, result *dsl.Model, payloadNa
 		PathFormat:   dsl.DefaultPathFormatWithID,
 		Method:       http.MethodGet,
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 		},
 		ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -188,7 +182,6 @@ func update(resourceName string, nakedType meta.Type, updateParam, result *dsl.M
 			Name: payloadName,
 		}),
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 			dsl.MappableArgument("param", updateParam, payloadName),
 		},
@@ -230,7 +223,6 @@ func Delete(resourceName string) *dsl.Operation {
 		PathFormat:   dsl.DefaultPathFormatWithID,
 		Method:       http.MethodDelete,
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 		},
 	}
@@ -244,7 +236,6 @@ func Config(resourceName string) *dsl.Operation {
 		PathFormat:   dsl.IDAndSuffixPathFormat("config"),
 		Method:       http.MethodPut,
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 		},
 	}
@@ -258,7 +249,6 @@ func Boot(resourceName string) *dsl.Operation {
 		PathFormat:   dsl.IDAndSuffixPathFormat("power"),
 		Method:       http.MethodPut,
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 		},
 	}
@@ -282,7 +272,6 @@ func Shutdown(resourceName string) *dsl.Operation {
 		Method:          http.MethodDelete,
 		RequestEnvelope: dsl.RequestEnvelopeFromModel(param),
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 			dsl.PassthroughModelArgument("shutdownOption", param),
 		},
@@ -297,7 +286,6 @@ func Reset(resourceName string) *dsl.Operation {
 		PathFormat:   dsl.IDAndSuffixPathFormat("reset"),
 		Method:       http.MethodPut,
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 		},
 	}
@@ -311,7 +299,6 @@ func Status(resourceName string, nakedType meta.Type, result *dsl.Model) *dsl.Op
 		Name:             "Status",
 		UseWrappedResult: true,
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 		},
 		PathFormat: dsl.IDAndSuffixPathFormat("status"),
@@ -338,7 +325,6 @@ func HealthStatus(resourceName string, nakedType meta.Type, result *dsl.Model) *
 		ResourceName: resourceName,
 		Name:         "HealthStatus",
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 		},
 		PathFormat: dsl.IDAndSuffixPathFormat("health"),
@@ -367,7 +353,6 @@ func OpenFTP(resourceName string, openParam, result *dsl.Model) *dsl.Operation {
 		Method:          http.MethodPut,
 		RequestEnvelope: dsl.RequestEnvelopeFromModel(openParam),
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 			dsl.PassthroughModelArgument("openOption", openParam),
 		},
@@ -392,7 +377,6 @@ func CloseFTP(resourceName string) *dsl.Operation {
 		ResourceName: resourceName,
 		Name:         "CloseFTP",
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 		},
 		PathFormat: dsl.IDAndSuffixPathFormat("ftp"),
@@ -402,7 +386,7 @@ func CloseFTP(resourceName string) *dsl.Operation {
 
 // WithIDAction ID+αのみを引数にとるシンプルなオペレーションを定義
 func WithIDAction(resourceName, opName, method, pathSuffix string, arguments ...*dsl.Argument) *dsl.Operation {
-	args := dsl.Arguments{dsl.ArgumentZone, dsl.ArgumentID}
+	args := dsl.Arguments{dsl.ArgumentID}
 	args = append(args, arguments...)
 	return &dsl.Operation{
 		ResourceName: resourceName,
@@ -422,7 +406,6 @@ func Monitor(resourceName string, monitorParam, result *dsl.Model) *dsl.Operatio
 		Method:          http.MethodGet,
 		RequestEnvelope: dsl.RequestEnvelopeFromModel(monitorParam),
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 			dsl.PassthroughModelArgument("condition", monitorParam),
 		},
@@ -450,7 +433,6 @@ func MonitorChild(resourceName, funcNameSuffix, childResourceName string, monito
 		Method:          http.MethodGet,
 		RequestEnvelope: dsl.RequestEnvelopeFromModel(monitorParam),
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 			dsl.PassthroughModelArgument("condition", monitorParam),
 		},
@@ -479,7 +461,6 @@ func MonitorChildBy(resourceName, funcNameSuffix, childResourceName string, moni
 		Method:          http.MethodGet,
 		RequestEnvelope: dsl.RequestEnvelopeFromModel(monitorParam),
 		Arguments: dsl.Arguments{
-			dsl.ArgumentZone,
 			dsl.ArgumentID,
 			{
 				Name: "index",

--- a/internal/define/proxylb.go
+++ b/internal/define/proxylb.go
@@ -47,7 +47,6 @@ var proxyLBAPI = &dsl.Resource{
 				Name: "CommonServiceItem",
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", proxyLBChangePlanParam, "CommonServiceItem"),
 			},
@@ -72,7 +71,6 @@ var proxyLBAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("proxylb/sslcertificate"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -100,7 +98,6 @@ var proxyLBAPI = &dsl.Resource{
 				Name: proxyLBAPIName,
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", proxyLBCertificateSetParam, proxyLBAPIName),
 			},
@@ -125,7 +122,6 @@ var proxyLBAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("proxylb/sslcertificate"),
 			Method:       http.MethodDelete,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 		},

--- a/internal/define/server.go
+++ b/internal/define/server.go
@@ -43,7 +43,6 @@ var serverAPI = &dsl.Resource{
 			Method:          http.MethodPut,
 			RequestEnvelope: dsl.RequestEnvelopeFromModel(serverChangePlanParam),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.PassthroughModelArgument("plan", serverChangePlanParam),
 			},
@@ -74,7 +73,6 @@ var serverAPI = &dsl.Resource{
 				},
 			),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				{
 					Name: "insertParam",
@@ -103,7 +101,6 @@ var serverAPI = &dsl.Resource{
 				},
 			),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				{
 					Name: "insertParam",

--- a/internal/define/sim.go
+++ b/internal/define/sim.go
@@ -57,7 +57,6 @@ var simAPI = &dsl.Resource{
 				},
 			),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", simAssignIPParam, "SIM"),
 			},
@@ -82,7 +81,6 @@ var simAPI = &dsl.Resource{
 				},
 			),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", simIMEILockParam, "SIM"),
 			},
@@ -99,7 +97,6 @@ var simAPI = &dsl.Resource{
 			Name:             "Logs",
 			UseWrappedResult: true,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelopePlural(&dsl.EnvelopePayloadDesc{
@@ -126,7 +123,6 @@ var simAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("sim/network_operator_config"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -160,7 +156,6 @@ var simAPI = &dsl.Resource{
 				},
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				&dsl.Argument{
 					Name:       "configs",
@@ -181,7 +176,6 @@ var simAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("sim/status"),
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{

--- a/internal/define/ssh_key.go
+++ b/internal/define/ssh_key.go
@@ -38,7 +38,6 @@ var sshKeyAPI = &dsl.Resource{
 				Name: sshKeyAPIName,
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.MappableArgument("param", sshKeyGenerateParam, sshKeyAPIName),
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{

--- a/internal/define/webaccel.go
+++ b/internal/define/webaccel.go
@@ -27,9 +27,6 @@ var webaccelAPI = &dsl.Resource{
 			PathFormat:       "{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/site",
 			Method:           http.MethodGet,
 			UseWrappedResult: true,
-			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
-			},
 			ResponseEnvelope: dsl.ResponseEnvelopePlural(&dsl.EnvelopePayloadDesc{
 				Type: webAccelSiteNakedType,
 				Name: "Sites",
@@ -50,7 +47,6 @@ var webaccelAPI = &dsl.Resource{
 			PathFormat:   "{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/site/{{.id}}",
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -73,7 +69,6 @@ var webaccelAPI = &dsl.Resource{
 			PathFormat:   "{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/site/{{.id}}/certificate",
 			Method:       http.MethodGet,
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
@@ -100,7 +95,6 @@ var webaccelAPI = &dsl.Resource{
 				Name: "Certificate",
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.ArgumentID,
 				dsl.MappableArgument("param", webAccelCertUpdateParam, "Certificate"),
 			},
@@ -128,7 +122,6 @@ var webaccelAPI = &dsl.Resource{
 				Name: "Site",
 			}),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.MappableArgument("param", webAccelDeleteAllCacheParam, "Site"),
 			},
 		},
@@ -141,7 +134,6 @@ var webaccelAPI = &dsl.Resource{
 			Method:          http.MethodPost,
 			RequestEnvelope: dsl.RequestEnvelopeFromModel(webAccelDeleteCacheParam),
 			Arguments: dsl.Arguments{
-				dsl.ArgumentZone,
 				dsl.PassthroughModelArgument("param", webAccelDeleteCacheParam),
 			},
 			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{

--- a/internal/dsl/argument.go
+++ b/internal/dsl/argument.go
@@ -15,12 +15,6 @@ var (
 		Name: "id",
 		Type: meta.TypeID,
 	}
-
-	// ArgumentZone 引数でのゾーンを示すValue
-	ArgumentZone = &Argument{
-		Name: "zone",
-		Type: meta.TypeString,
-	}
 )
 
 // Argument 引数の型情報

--- a/internal/dsl/operation_test.go
+++ b/internal/dsl/operation_test.go
@@ -38,7 +38,6 @@ func TestOperation(t *testing.T) {
 					Name: "Test",
 				}),
 				Arguments: []*Argument{
-					ArgumentZone,
 					{
 						Name:       "arg1",
 						MapConvTag: "Destination",

--- a/internal/tools/gen-api-fake-op/main.go
+++ b/internal/tools/gen-api-fake-op/main.go
@@ -77,7 +77,7 @@ func SwitchFactoryFuncToFake() {
 }
 
 
-{{ range . }}{{ $typeName := .TypeName}}
+{{ range . }}{{ $typeName := .TypeName}} 
 
 /************************************************* 
 * {{$typeName}}Op
@@ -107,7 +107,7 @@ import (
 
 {{ range .Operations }}
 // {{ .MethodName }} is fake implementation
-func (o *{{ $.TypeName }}Op) {{ .MethodName }}(ctx context.Context{{ range .Arguments }}, {{ .ArgName }} {{ .TypeName }}{{ end }}) {{.ResultsStatement}} {
+func (o *{{ $.TypeName }}Op) {{ .MethodName }}(ctx context.Context{{if not $.IsGlobal}}, zone string{{end}}{{ range .Arguments }}, {{ .ArgName }} {{ .TypeName }}{{ end }}) {{.ResultsStatement}} {
 {{ if eq .MethodName "Find" -}}
 	results, _ := find(o.key, {{if $.IsGlobal}}sacloud.APIDefaultZone{{else}}zone{{end}}, conditions)
 	var values []*sacloud.{{$.TypeName}}
@@ -154,7 +154,7 @@ func (o *{{ $.TypeName }}Op) {{ .MethodName }}(ctx context.Context{{ range .Argu
 	copySameNameField(value, dest)
 	return dest, nil
 {{ else if eq .MethodName "Update" -}}
-	value, err := o.Read(ctx, {{if $.IsGlobal}}sacloud.APIDefaultZone{{else}}zone{{end}}, id)
+	value, err := o.Read(ctx{{if not $.IsGlobal}}, zone{{end}}, id)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func (o *{{ $.TypeName }}Op) {{ .MethodName }}(ctx context.Context{{ range .Argu
 	// TODO core logic is not implemented
 	return value, nil
 {{ else if eq .MethodName "Delete" -}}
-	_, err := o.Read(ctx, {{if $.IsGlobal}}sacloud.APIDefaultZone{{else}}zone{{end}}, id)
+	_, err := o.Read(ctx{{if not $.IsGlobal}}, zone{{end}}, id)
 	if err != nil {
 		return err
 	}

--- a/internal/tools/gen-api-interfaces/main.go
+++ b/internal/tools/gen-api-interfaces/main.go
@@ -34,7 +34,7 @@ import (
 {{- end }}
 )
 
-{{ range . }} {{ $typeName := .TypeName }}
+{{ range . }} {{ $typeName := .TypeName }} {{ $resource := . }}
 
 /************************************************* 
 * {{ $typeName }}API
@@ -43,7 +43,7 @@ import (
 // {{ $typeName }}API is interface for operate {{ $typeName }} resource
 type {{ $typeName }}API interface {
 {{ range .Operations }}
-	{{ .MethodName }}(ctx context.Context{{ range .Arguments }}, {{ .ArgName }} {{ .TypeName }}{{ end }}) {{.ResultsStatement}} 
+	{{ .MethodName }}(ctx context.Context{{if not $resource.IsGlobal}}, zone string{{end}}{{ range .Arguments }}, {{ .ArgName }} {{ .TypeName }}{{ end }}) {{.ResultsStatement}} 
 {{- end -}}
 }
 {{ end }}

--- a/internal/tools/gen-api-op/main.go
+++ b/internal/tools/gen-api-op/main.go
@@ -77,6 +77,8 @@ func (o *{{ $typeName }}Op) {{ .MethodName }}(ctx context.Context{{if not $resou
 		"pathName": o.PathName,
 		{{- if $resource.IsGlobal }}
 		"zone": APIDefaultZone,
+		{{- else }}
+		"zone": zone,
 		{{- end }}
 		{{- range .Arguments }}
 		"{{.PathFormatName}}": {{.Name}},

--- a/internal/tools/gen-api-op/main.go
+++ b/internal/tools/gen-api-op/main.go
@@ -47,7 +47,7 @@ func init() {
 {{ end -}}
 }
 
-{{ range . }}{{ $typeName := .TypeName}}
+{{ range . }}{{ $typeName := .TypeName }}{{$resource := .}}
 
 /************************************************* 
 * {{$typeName}}Op
@@ -70,11 +70,14 @@ func New{{ $typeName}}Op(caller APICaller) {{ $typeName}}API {
 
 {{ range .Operations }}{{$returnErrStatement := .ReturnErrorStatement}}{{ $operationName := .MethodName }}
 // {{ .MethodName }} is API call
-func (o *{{ $typeName }}Op) {{ .MethodName }}(ctx context.Context{{ range .Arguments }}, {{ .ArgName }} {{ .TypeName }}{{ end }}) {{.ResultsStatement}} {
+func (o *{{ $typeName }}Op) {{ .MethodName }}(ctx context.Context{{if not $resource.IsGlobal}}, zone string{{end}}{{ range .Arguments }}, {{ .ArgName }} {{ .TypeName }}{{ end }}) {{.ResultsStatement}} {
 	url, err := buildURL("{{.GetPathFormat}}", map[string]interface{}{
 		"rootURL": SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName": o.PathName,
+		{{- if $resource.IsGlobal }}
+		"zone": APIDefaultZone,
+		{{- end }}
 		{{- range .Arguments }}
 		"{{.PathFormatName}}": {{.Name}},
 		{{- end }}

--- a/internal/tools/gen-api-stub/main.go
+++ b/internal/tools/gen-api-stub/main.go
@@ -37,7 +37,7 @@ import (
 {{- end }}
 )
 
-{{ range . }} {{ $typeName := .TypeName }}
+{{ range . }} {{ $typeName := .TypeName }}{{ $resource := . }}
 
 /************************************************* 
 * {{ $typeName }}Stub
@@ -67,7 +67,7 @@ func New{{ $typeName}}Stub(caller sacloud.APICaller) sacloud.{{$typeName}}API {
 
 {{ range .Operations }}{{$returnErrStatement := .ReturnErrorStatement}}{{ $operationName := .MethodName }}
 // {{ .MethodName }} is API call with trace log
-func (s *{{ $typeName }}Stub) {{ .MethodName }}(ctx context.Context{{ range .Arguments }}, {{ .ArgName }} {{ .TypeName }}{{ end }}) {{.ResultsStatement}} {
+func (s *{{ $typeName }}Stub) {{ .MethodName }}(ctx context.Context{{if not $resource.IsGlobal}}, zone string{{end}}{{ range .Arguments }}, {{ .ArgName }} {{ .TypeName }}{{ end }}) {{.ResultsStatement}} {
 	if s.{{$operationName}}StubResult == nil {
 		log.Fatal("{{$typeName}}Stub.{{$operationName}}StubResult is not set")
 	}

--- a/sacloud/fake/ops_auth_status.go
+++ b/sacloud/fake/ops_auth_status.go
@@ -7,6 +7,6 @@ import (
 )
 
 // Read is fake implementation
-func (o *AuthStatusOp) Read(ctx context.Context, zone string) (*sacloud.AuthStatus, error) {
+func (o *AuthStatusOp) Read(ctx context.Context) (*sacloud.AuthStatus, error) {
 	return authStatus, nil
 }

--- a/sacloud/fake/ops_bill.go
+++ b/sacloud/fake/ops_bill.go
@@ -9,7 +9,7 @@ import (
 )
 
 // ByContract is fake implementation
-func (o *BillOp) ByContract(ctx context.Context, zone string, accountID types.ID) (*sacloud.BillByContractResult, error) {
+func (o *BillOp) ByContract(ctx context.Context, accountID types.ID) (*sacloud.BillByContractResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, nil)
 	var values []*sacloud.Bill
 	for _, res := range results {
@@ -26,7 +26,7 @@ func (o *BillOp) ByContract(ctx context.Context, zone string, accountID types.ID
 }
 
 // ByContractYear is fake implementation
-func (o *BillOp) ByContractYear(ctx context.Context, zone string, accountID types.ID, year int) (*sacloud.BillByContractYearResult, error) {
+func (o *BillOp) ByContractYear(ctx context.Context, accountID types.ID, year int) (*sacloud.BillByContractYearResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, nil)
 	var values []*sacloud.Bill
 	for _, res := range results {
@@ -45,7 +45,7 @@ func (o *BillOp) ByContractYear(ctx context.Context, zone string, accountID type
 }
 
 // ByContractYearMonth is fake implementation
-func (o *BillOp) ByContractYearMonth(ctx context.Context, zone string, accountID types.ID, year int, month int) (*sacloud.BillByContractYearMonthResult, error) {
+func (o *BillOp) ByContractYearMonth(ctx context.Context, accountID types.ID, year int, month int) (*sacloud.BillByContractYearMonthResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, nil)
 	var values []*sacloud.Bill
 	for _, res := range results {
@@ -64,7 +64,7 @@ func (o *BillOp) ByContractYearMonth(ctx context.Context, zone string, accountID
 }
 
 // Read is fake implementation
-func (o *BillOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.BillReadResult, error) {
+func (o *BillOp) Read(ctx context.Context, id types.ID) (*sacloud.BillReadResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, nil)
 	var values []*sacloud.Bill
 	for _, res := range results {
@@ -83,7 +83,7 @@ func (o *BillOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.B
 }
 
 // Details is fake implementation
-func (o *BillOp) Details(ctx context.Context, zone string, MemberCode string, id types.ID) (*sacloud.BillDetailsResult, error) {
+func (o *BillOp) Details(ctx context.Context, MemberCode string, id types.ID) (*sacloud.BillDetailsResult, error) {
 	rawResults := s.getByID(o.key+"Details", sacloud.APIDefaultZone, id)
 	if rawResults == nil {
 		return nil, newErrorNotFound(o.key+"Details", id)
@@ -106,7 +106,7 @@ func (o *BillOp) Details(ctx context.Context, zone string, MemberCode string, id
 }
 
 // DetailsCSV is fake implementation
-func (o *BillOp) DetailsCSV(ctx context.Context, zone string, MemberCode string, id types.ID) (*sacloud.BillDetailCSV, error) {
+func (o *BillOp) DetailsCSV(ctx context.Context, MemberCode string, id types.ID) (*sacloud.BillDetailCSV, error) {
 	rawResults := s.getByID(o.key+"Details", sacloud.APIDefaultZone, id)
 	if rawResults == nil {
 		return nil, newErrorNotFound(o.key+"Details", id)

--- a/sacloud/fake/ops_coupon.go
+++ b/sacloud/fake/ops_coupon.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *CouponOp) Find(ctx context.Context, zone string, accountID types.ID) (*sacloud.CouponFindResult, error) {
+func (o *CouponOp) Find(ctx context.Context, accountID types.ID) (*sacloud.CouponFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, nil)
 	var values []*sacloud.Coupon
 	for _, res := range results {

--- a/sacloud/fake/ops_dns.go
+++ b/sacloud/fake/ops_dns.go
@@ -8,8 +8,8 @@ import (
 )
 
 // Find is fake implementation
-func (o *DNSOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.DNSFindResult, error) {
-	results, _ := find(o.key, zone, conditions)
+func (o *DNSOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.DNSFindResult, error) {
+	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.DNS
 	for _, res := range results {
 		dest := &sacloud.DNS{}
@@ -25,7 +25,7 @@ func (o *DNSOp) Find(ctx context.Context, zone string, conditions *sacloud.FindC
 }
 
 // Create is fake implementation
-func (o *DNSOp) Create(ctx context.Context, zone string, param *sacloud.DNSCreateRequest) (*sacloud.DNS, error) {
+func (o *DNSOp) Create(ctx context.Context, param *sacloud.DNSCreateRequest) (*sacloud.DNS, error) {
 	result := &sacloud.DNS{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt)
@@ -35,13 +35,13 @@ func (o *DNSOp) Create(ctx context.Context, zone string, param *sacloud.DNSCreat
 	result.SettingsHash = "settingshash"
 	result.DNSZone = param.Name
 
-	s.setDNS(zone, result)
+	s.setDNS(sacloud.APIDefaultZone, result)
 	return result, nil
 }
 
 // Read is fake implementation
-func (o *DNSOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.DNS, error) {
-	value := s.getDNSByID(zone, id)
+func (o *DNSOp) Read(ctx context.Context, id types.ID) (*sacloud.DNS, error) {
+	value := s.getDNSByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
 	}
@@ -51,8 +51,8 @@ func (o *DNSOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.DN
 }
 
 // Update is fake implementation
-func (o *DNSOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.DNSUpdateRequest) (*sacloud.DNS, error) {
-	value, err := o.Read(ctx, zone, id)
+func (o *DNSOp) Update(ctx context.Context, id types.ID, param *sacloud.DNSUpdateRequest) (*sacloud.DNS, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -63,12 +63,12 @@ func (o *DNSOp) Update(ctx context.Context, zone string, id types.ID, param *sac
 }
 
 // Delete is fake implementation
-func (o *DNSOp) Delete(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, zone, id)
+func (o *DNSOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	s.delete(o.key, zone, id)
+	s.delete(o.key, sacloud.APIDefaultZone, id)
 	return nil
 }

--- a/sacloud/fake/ops_gslb.go
+++ b/sacloud/fake/ops_gslb.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *GSLBOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.GSLBFindResult, error) {
+func (o *GSLBOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.GSLBFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.GSLB
 	for _, res := range results {
@@ -26,7 +26,7 @@ func (o *GSLBOp) Find(ctx context.Context, zone string, conditions *sacloud.Find
 }
 
 // Create is fake implementation
-func (o *GSLBOp) Create(ctx context.Context, zone string, param *sacloud.GSLBCreateRequest) (*sacloud.GSLB, error) {
+func (o *GSLBOp) Create(ctx context.Context, param *sacloud.GSLBCreateRequest) (*sacloud.GSLB, error) {
 	result := &sacloud.GSLB{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt, fillAvailability)
@@ -39,7 +39,7 @@ func (o *GSLBOp) Create(ctx context.Context, zone string, param *sacloud.GSLBCre
 }
 
 // Read is fake implementation
-func (o *GSLBOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.GSLB, error) {
+func (o *GSLBOp) Read(ctx context.Context, id types.ID) (*sacloud.GSLB, error) {
 	value := s.getGSLBByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
@@ -51,8 +51,8 @@ func (o *GSLBOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.G
 }
 
 // Update is fake implementation
-func (o *GSLBOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.GSLBUpdateRequest) (*sacloud.GSLB, error) {
-	value, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *GSLBOp) Update(ctx context.Context, id types.ID, param *sacloud.GSLBUpdateRequest) (*sacloud.GSLB, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +62,8 @@ func (o *GSLBOp) Update(ctx context.Context, zone string, id types.ID, param *sa
 }
 
 // Delete is fake implementation
-func (o *GSLBOp) Delete(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *GSLBOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/sacloud/fake/ops_icon.go
+++ b/sacloud/fake/ops_icon.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *IconOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.IconFindResult, error) {
+func (o *IconOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.IconFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.Icon
 	for _, res := range results {
@@ -26,7 +26,7 @@ func (o *IconOp) Find(ctx context.Context, zone string, conditions *sacloud.Find
 }
 
 // Create is fake implementation
-func (o *IconOp) Create(ctx context.Context, zone string, param *sacloud.IconCreateRequest) (*sacloud.Icon, error) {
+func (o *IconOp) Create(ctx context.Context, param *sacloud.IconCreateRequest) (*sacloud.Icon, error) {
 	result := &sacloud.Icon{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt, fillModifiedAt)
@@ -40,7 +40,7 @@ func (o *IconOp) Create(ctx context.Context, zone string, param *sacloud.IconCre
 }
 
 // Read is fake implementation
-func (o *IconOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Icon, error) {
+func (o *IconOp) Read(ctx context.Context, id types.ID) (*sacloud.Icon, error) {
 	value := s.getIconByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
@@ -51,8 +51,8 @@ func (o *IconOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.I
 }
 
 // Update is fake implementation
-func (o *IconOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.IconUpdateRequest) (*sacloud.Icon, error) {
-	value, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *IconOp) Update(ctx context.Context, id types.ID, param *sacloud.IconUpdateRequest) (*sacloud.Icon, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -62,8 +62,8 @@ func (o *IconOp) Update(ctx context.Context, zone string, id types.ID, param *sa
 }
 
 // Delete is fake implementation
-func (o *IconOp) Delete(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *IconOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/sacloud/fake/ops_license.go
+++ b/sacloud/fake/ops_license.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *LicenseOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.LicenseFindResult, error) {
+func (o *LicenseOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LicenseFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.License
 	for _, res := range results {
@@ -25,7 +25,7 @@ func (o *LicenseOp) Find(ctx context.Context, zone string, conditions *sacloud.F
 }
 
 // Create is fake implementation
-func (o *LicenseOp) Create(ctx context.Context, zone string, param *sacloud.LicenseCreateRequest) (*sacloud.License, error) {
+func (o *LicenseOp) Create(ctx context.Context, param *sacloud.LicenseCreateRequest) (*sacloud.License, error) {
 	result := &sacloud.License{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt, fillModifiedAt)
@@ -35,7 +35,7 @@ func (o *LicenseOp) Create(ctx context.Context, zone string, param *sacloud.Lice
 }
 
 // Read is fake implementation
-func (o *LicenseOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.License, error) {
+func (o *LicenseOp) Read(ctx context.Context, id types.ID) (*sacloud.License, error) {
 	value := s.getLicenseByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
@@ -46,8 +46,8 @@ func (o *LicenseOp) Read(ctx context.Context, zone string, id types.ID) (*saclou
 }
 
 // Update is fake implementation
-func (o *LicenseOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.LicenseUpdateRequest) (*sacloud.License, error) {
-	value, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *LicenseOp) Update(ctx context.Context, id types.ID, param *sacloud.LicenseUpdateRequest) (*sacloud.License, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -57,8 +57,8 @@ func (o *LicenseOp) Update(ctx context.Context, zone string, id types.ID, param 
 }
 
 // Delete is fake implementation
-func (o *LicenseOp) Delete(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *LicenseOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/sacloud/fake/ops_license_info.go
+++ b/sacloud/fake/ops_license_info.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *LicenseInfoOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.LicenseInfoFindResult, error) {
+func (o *LicenseInfoOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LicenseInfoFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.LicenseInfo
 	for _, res := range results {
@@ -25,7 +25,7 @@ func (o *LicenseInfoOp) Find(ctx context.Context, zone string, conditions *saclo
 }
 
 // Read is fake implementation
-func (o *LicenseInfoOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.LicenseInfo, error) {
+func (o *LicenseInfoOp) Read(ctx context.Context, id types.ID) (*sacloud.LicenseInfo, error) {
 	value := s.getLicenseInfoByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)

--- a/sacloud/fake/ops_mobile_gateway.go
+++ b/sacloud/fake/ops_mobile_gateway.go
@@ -295,7 +295,7 @@ func (o *MobileGatewayOp) AddSIM(ctx context.Context, zone string, id types.ID, 
 	}
 
 	simOp := NewSIMOp()
-	simInfo, err := simOp.Status(context.Background(), sacloud.APIDefaultZone, types.StringID(param.SIMID))
+	simInfo, err := simOp.Status(context.Background(), types.StringID(param.SIMID))
 	if err != nil {
 		return err
 	}

--- a/sacloud/fake/ops_note.go
+++ b/sacloud/fake/ops_note.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *NoteOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.NoteFindResult, error) {
+func (o *NoteOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.NoteFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.Note
 	for _, res := range results {
@@ -25,7 +25,7 @@ func (o *NoteOp) Find(ctx context.Context, zone string, conditions *sacloud.Find
 }
 
 // Create is fake implementation
-func (o *NoteOp) Create(ctx context.Context, zone string, param *sacloud.NoteCreateRequest) (*sacloud.Note, error) {
+func (o *NoteOp) Create(ctx context.Context, param *sacloud.NoteCreateRequest) (*sacloud.Note, error) {
 	result := &sacloud.Note{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt, fillAvailability, fillScope)
@@ -34,7 +34,7 @@ func (o *NoteOp) Create(ctx context.Context, zone string, param *sacloud.NoteCre
 }
 
 // Read is fake implementation
-func (o *NoteOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Note, error) {
+func (o *NoteOp) Read(ctx context.Context, id types.ID) (*sacloud.Note, error) {
 	value := s.getNoteByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
@@ -46,8 +46,8 @@ func (o *NoteOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.N
 }
 
 // Update is fake implementation
-func (o *NoteOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.NoteUpdateRequest) (*sacloud.Note, error) {
-	value, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *NoteOp) Update(ctx context.Context, id types.ID, param *sacloud.NoteUpdateRequest) (*sacloud.Note, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -58,8 +58,8 @@ func (o *NoteOp) Update(ctx context.Context, zone string, id types.ID, param *sa
 }
 
 // Delete is fake implementation
-func (o *NoteOp) Delete(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *NoteOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/sacloud/fake/ops_proxy_lb.go
+++ b/sacloud/fake/ops_proxy_lb.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *ProxyLBOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ProxyLBFindResult, error) {
+func (o *ProxyLBOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.ProxyLBFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.ProxyLB
 	for _, res := range results {
@@ -27,7 +27,7 @@ func (o *ProxyLBOp) Find(ctx context.Context, zone string, conditions *sacloud.F
 }
 
 // Create is fake implementation
-func (o *ProxyLBOp) Create(ctx context.Context, zone string, param *sacloud.ProxyLBCreateRequest) (*sacloud.ProxyLB, error) {
+func (o *ProxyLBOp) Create(ctx context.Context, param *sacloud.ProxyLBCreateRequest) (*sacloud.ProxyLB, error) {
 	result := &sacloud.ProxyLB{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt)
@@ -56,14 +56,14 @@ func (o *ProxyLBOp) Create(ctx context.Context, zone string, param *sacloud.Prox
 			CPS:        10,
 		})
 	}
-	s.setWithID(ResourceProxyLB+"Status", zone, status, result.ID)
+	s.setWithID(ResourceProxyLB+"Status", sacloud.APIDefaultZone, status, result.ID)
 
 	s.setProxyLB(sacloud.APIDefaultZone, result)
 	return result, nil
 }
 
 // Read is fake implementation
-func (o *ProxyLBOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.ProxyLB, error) {
+func (o *ProxyLBOp) Read(ctx context.Context, id types.ID) (*sacloud.ProxyLB, error) {
 	value := s.getProxyLBByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
@@ -74,15 +74,15 @@ func (o *ProxyLBOp) Read(ctx context.Context, zone string, id types.ID) (*saclou
 }
 
 // Update is fake implementation
-func (o *ProxyLBOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.ProxyLBUpdateRequest) (*sacloud.ProxyLB, error) {
-	value, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *ProxyLBOp) Update(ctx context.Context, id types.ID, param *sacloud.ProxyLBUpdateRequest) (*sacloud.ProxyLB, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
 
-	status := s.getByID(ResourceProxyLB+"Status", zone, id).(*sacloud.ProxyLBHealth)
+	status := s.getByID(ResourceProxyLB+"Status", sacloud.APIDefaultZone, id).(*sacloud.ProxyLBHealth)
 	status.Servers = []*sacloud.LoadBalancerServerStatus{}
 	for _, server := range param.Servers {
 		status.Servers = append(status.Servers, &sacloud.LoadBalancerServerStatus{
@@ -93,28 +93,28 @@ func (o *ProxyLBOp) Update(ctx context.Context, zone string, id types.ID, param 
 			CPS:        10,
 		})
 	}
-	s.setWithID(ResourceProxyLB+"Status", zone, status, id)
+	s.setWithID(ResourceProxyLB+"Status", sacloud.APIDefaultZone, status, id)
 
 	return value, nil
 }
 
 // Delete is fake implementation
-func (o *ProxyLBOp) Delete(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *ProxyLBOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	s.delete(ResourceProxyLB+"Status", zone, id)
-	s.delete(ResourceProxyLB+"Certs", zone, id)
+	s.delete(ResourceProxyLB+"Status", sacloud.APIDefaultZone, id)
+	s.delete(ResourceProxyLB+"Certs", sacloud.APIDefaultZone, id)
 	s.delete(o.key, sacloud.APIDefaultZone, id)
 
 	return nil
 }
 
 // ChangePlan is fake implementation
-func (o *ProxyLBOp) ChangePlan(ctx context.Context, zone string, id types.ID, param *sacloud.ProxyLBChangePlanRequest) (*sacloud.ProxyLB, error) {
-	value, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *ProxyLBOp) ChangePlan(ctx context.Context, id types.ID, param *sacloud.ProxyLBChangePlanRequest) (*sacloud.ProxyLB, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -124,13 +124,13 @@ func (o *ProxyLBOp) ChangePlan(ctx context.Context, zone string, id types.ID, pa
 }
 
 // GetCertificates is fake implementation
-func (o *ProxyLBOp) GetCertificates(ctx context.Context, zone string, id types.ID) (*sacloud.ProxyLBCertificates, error) {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *ProxyLBOp) GetCertificates(ctx context.Context, id types.ID) (*sacloud.ProxyLBCertificates, error) {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	v := s.getByID(ResourceProxyLB+"Certs", zone, id)
+	v := s.getByID(ResourceProxyLB+"Certs", sacloud.APIDefaultZone, id)
 	if v != nil {
 		return v.(*sacloud.ProxyLBCertificates), nil
 	}
@@ -139,8 +139,8 @@ func (o *ProxyLBOp) GetCertificates(ctx context.Context, zone string, id types.I
 }
 
 // SetCertificates is fake implementation
-func (o *ProxyLBOp) SetCertificates(ctx context.Context, zone string, id types.ID, param *sacloud.ProxyLBSetCertificatesRequest) (*sacloud.ProxyLBCertificates, error) {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *ProxyLBOp) SetCertificates(ctx context.Context, id types.ID, param *sacloud.ProxyLBSetCertificatesRequest) (*sacloud.ProxyLBCertificates, error) {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -150,35 +150,35 @@ func (o *ProxyLBOp) SetCertificates(ctx context.Context, zone string, id types.I
 	cert.CertificateCommonName = "dummy-common-name.org"
 	cert.CertificateEndDate = time.Now().Add(365 * 24 * time.Hour)
 
-	s.set(ResourceProxyLB+"Certs", zone, cert)
+	s.set(ResourceProxyLB+"Certs", sacloud.APIDefaultZone, cert)
 	return cert, nil
 }
 
 // DeleteCertificates is fake implementation
-func (o *ProxyLBOp) DeleteCertificates(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *ProxyLBOp) DeleteCertificates(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	v := s.getByID(ResourceProxyLB+"Certs", zone, id)
+	v := s.getByID(ResourceProxyLB+"Certs", sacloud.APIDefaultZone, id)
 	if v != nil {
-		s.delete(ResourceProxyLB+"Certs", zone, id)
+		s.delete(ResourceProxyLB+"Certs", sacloud.APIDefaultZone, id)
 	}
 	return nil
 }
 
 // RenewLetsEncryptCert is fake implementation
-func (o *ProxyLBOp) RenewLetsEncryptCert(ctx context.Context, zone string, id types.ID) error {
+func (o *ProxyLBOp) RenewLetsEncryptCert(ctx context.Context, id types.ID) error {
 	return nil
 }
 
 // HealthStatus is fake implementation
-func (o *ProxyLBOp) HealthStatus(ctx context.Context, zone string, id types.ID) (*sacloud.ProxyLBHealth, error) {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *ProxyLBOp) HealthStatus(ctx context.Context, id types.ID) (*sacloud.ProxyLBHealth, error) {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	return s.getByID(ResourceProxyLB+"Status", zone, id).(*sacloud.ProxyLBHealth), nil
+	return s.getByID(ResourceProxyLB+"Status", sacloud.APIDefaultZone, id).(*sacloud.ProxyLBHealth), nil
 }

--- a/sacloud/fake/ops_region.go
+++ b/sacloud/fake/ops_region.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *RegionOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.RegionFindResult, error) {
+func (o *RegionOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.RegionFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.Region
 	for _, res := range results {
@@ -25,7 +25,7 @@ func (o *RegionOp) Find(ctx context.Context, zone string, conditions *sacloud.Fi
 }
 
 // Read is fake implementation
-func (o *RegionOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Region, error) {
+func (o *RegionOp) Read(ctx context.Context, id types.ID) (*sacloud.Region, error) {
 	value := s.getRegionByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)

--- a/sacloud/fake/ops_sim.go
+++ b/sacloud/fake/ops_sim.go
@@ -11,8 +11,8 @@ import (
 )
 
 // Find is fake implementation
-func (o *SIMOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SIMFindResult, error) {
-	results, _ := find(o.key, zone, conditions)
+func (o *SIMOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.SIMFindResult, error) {
+	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.SIM
 	for _, res := range results {
 		dest := &sacloud.SIM{}
@@ -28,7 +28,7 @@ func (o *SIMOp) Find(ctx context.Context, zone string, conditions *sacloud.FindC
 }
 
 // Create is fake implementation
-func (o *SIMOp) Create(ctx context.Context, zone string, param *sacloud.SIMCreateRequest) (*sacloud.SIM, error) {
+func (o *SIMOp) Create(ctx context.Context, param *sacloud.SIMCreateRequest) (*sacloud.SIM, error) {
 	result := &sacloud.SIM{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt, fillModifiedAt)
@@ -39,13 +39,13 @@ func (o *SIMOp) Create(ctx context.Context, zone string, param *sacloud.SIMCreat
 		ICCID: param.ICCID,
 	}
 
-	s.setSIM(zone, result)
+	s.setSIM(sacloud.APIDefaultZone, result)
 	return result, nil
 }
 
 // Read is fake implementation
-func (o *SIMOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SIM, error) {
-	value := s.getSIMByID(zone, id)
+func (o *SIMOp) Read(ctx context.Context, id types.ID) (*sacloud.SIM, error) {
+	value := s.getSIMByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
 	}
@@ -55,8 +55,8 @@ func (o *SIMOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SI
 }
 
 // Update is fake implementation
-func (o *SIMOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SIMUpdateRequest) (*sacloud.SIM, error) {
-	value, err := o.Read(ctx, zone, id)
+func (o *SIMOp) Update(ctx context.Context, id types.ID, param *sacloud.SIMUpdateRequest) (*sacloud.SIM, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -67,19 +67,19 @@ func (o *SIMOp) Update(ctx context.Context, zone string, id types.ID, param *sac
 }
 
 // Delete is fake implementation
-func (o *SIMOp) Delete(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, zone, id)
+func (o *SIMOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
 
-	s.delete(o.key, zone, id)
+	s.delete(o.key, sacloud.APIDefaultZone, id)
 	return nil
 }
 
 // Activate is fake implementation
-func (o *SIMOp) Activate(ctx context.Context, zone string, id types.ID) error {
-	value, err := o.Read(ctx, zone, id)
+func (o *SIMOp) Activate(ctx context.Context, id types.ID) error {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -93,8 +93,8 @@ func (o *SIMOp) Activate(ctx context.Context, zone string, id types.ID) error {
 }
 
 // Deactivate is fake implementation
-func (o *SIMOp) Deactivate(ctx context.Context, zone string, id types.ID) error {
-	value, err := o.Read(ctx, zone, id)
+func (o *SIMOp) Deactivate(ctx context.Context, id types.ID) error {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -108,8 +108,8 @@ func (o *SIMOp) Deactivate(ctx context.Context, zone string, id types.ID) error 
 }
 
 // AssignIP is fake implementation
-func (o *SIMOp) AssignIP(ctx context.Context, zone string, id types.ID, param *sacloud.SIMAssignIPRequest) error {
-	value, err := o.Read(ctx, zone, id)
+func (o *SIMOp) AssignIP(ctx context.Context, id types.ID, param *sacloud.SIMAssignIPRequest) error {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -121,8 +121,8 @@ func (o *SIMOp) AssignIP(ctx context.Context, zone string, id types.ID, param *s
 }
 
 // ClearIP is fake implementation
-func (o *SIMOp) ClearIP(ctx context.Context, zone string, id types.ID) error {
-	value, err := o.Read(ctx, zone, id)
+func (o *SIMOp) ClearIP(ctx context.Context, id types.ID) error {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -134,8 +134,8 @@ func (o *SIMOp) ClearIP(ctx context.Context, zone string, id types.ID) error {
 }
 
 // IMEILock is fake implementation
-func (o *SIMOp) IMEILock(ctx context.Context, zone string, id types.ID, param *sacloud.SIMIMEILockRequest) error {
-	value, err := o.Read(ctx, zone, id)
+func (o *SIMOp) IMEILock(ctx context.Context, id types.ID, param *sacloud.SIMIMEILockRequest) error {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -148,8 +148,8 @@ func (o *SIMOp) IMEILock(ctx context.Context, zone string, id types.ID, param *s
 }
 
 // IMEIUnlock is fake implementation
-func (o *SIMOp) IMEIUnlock(ctx context.Context, zone string, id types.ID) error {
-	value, err := o.Read(ctx, zone, id)
+func (o *SIMOp) IMEIUnlock(ctx context.Context, id types.ID) error {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -162,8 +162,8 @@ func (o *SIMOp) IMEIUnlock(ctx context.Context, zone string, id types.ID) error 
 }
 
 // Logs is fake implementation
-func (o *SIMOp) Logs(ctx context.Context, zone string, id types.ID) (*sacloud.SIMLogsResult, error) {
-	value, err := o.Read(ctx, zone, id)
+func (o *SIMOp) Logs(ctx context.Context, id types.ID) (*sacloud.SIMLogsResult, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +185,8 @@ func (o *SIMOp) Logs(ctx context.Context, zone string, id types.ID) (*sacloud.SI
 }
 
 // GetNetworkOperator is fake implementation
-func (o *SIMOp) GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*sacloud.SIMNetworkOperatorConfig, error) {
-	_, err := o.Read(ctx, zone, id)
+func (o *SIMOp) GetNetworkOperator(ctx context.Context, id types.ID) ([]*sacloud.SIMNetworkOperatorConfig, error) {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -200,8 +200,8 @@ func (o *SIMOp) GetNetworkOperator(ctx context.Context, zone string, id types.ID
 }
 
 // SetNetworkOperator is fake implementation
-func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*sacloud.SIMNetworkOperatorConfig) error {
-	_, err := o.Read(ctx, zone, id)
+func (o *SIMOp) SetNetworkOperator(ctx context.Context, id types.ID, configs []*sacloud.SIMNetworkOperatorConfig) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -209,8 +209,8 @@ func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID
 }
 
 // MonitorSIM is fake implementation
-func (o *SIMOp) MonitorSIM(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LinkActivity, error) {
-	_, err := o.Read(ctx, zone, id)
+func (o *SIMOp) MonitorSIM(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LinkActivity, error) {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -233,8 +233,8 @@ func (o *SIMOp) MonitorSIM(ctx context.Context, zone string, id types.ID, condit
 }
 
 // Status is fake implementation
-func (o *SIMOp) Status(ctx context.Context, zone string, id types.ID) (*sacloud.SIMInfo, error) {
-	v, err := o.Read(ctx, zone, id)
+func (o *SIMOp) Status(ctx context.Context, id types.ID) (*sacloud.SIMInfo, error) {
+	v, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/sacloud/fake/ops_simple_monitor.go
+++ b/sacloud/fake/ops_simple_monitor.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *SimpleMonitorOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SimpleMonitorFindResult, error) {
+func (o *SimpleMonitorOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.SimpleMonitorFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.SimpleMonitor
 	for _, res := range results {
@@ -26,7 +26,7 @@ func (o *SimpleMonitorOp) Find(ctx context.Context, zone string, conditions *sac
 }
 
 // Create is fake implementation
-func (o *SimpleMonitorOp) Create(ctx context.Context, zone string, param *sacloud.SimpleMonitorCreateRequest) (*sacloud.SimpleMonitor, error) {
+func (o *SimpleMonitorOp) Create(ctx context.Context, param *sacloud.SimpleMonitorCreateRequest) (*sacloud.SimpleMonitor, error) {
 	result := &sacloud.SimpleMonitor{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt)
@@ -41,7 +41,7 @@ func (o *SimpleMonitorOp) Create(ctx context.Context, zone string, param *saclou
 }
 
 // Read is fake implementation
-func (o *SimpleMonitorOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SimpleMonitor, error) {
+func (o *SimpleMonitorOp) Read(ctx context.Context, id types.ID) (*sacloud.SimpleMonitor, error) {
 	value := s.getSimpleMonitorByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
@@ -52,8 +52,8 @@ func (o *SimpleMonitorOp) Read(ctx context.Context, zone string, id types.ID) (*
 }
 
 // Update is fake implementation
-func (o *SimpleMonitorOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SimpleMonitorUpdateRequest) (*sacloud.SimpleMonitor, error) {
-	value, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *SimpleMonitorOp) Update(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorUpdateRequest) (*sacloud.SimpleMonitor, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -64,8 +64,8 @@ func (o *SimpleMonitorOp) Update(ctx context.Context, zone string, id types.ID, 
 }
 
 // Delete is fake implementation
-func (o *SimpleMonitorOp) Delete(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *SimpleMonitorOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -75,8 +75,8 @@ func (o *SimpleMonitorOp) Delete(ctx context.Context, zone string, id types.ID) 
 }
 
 // MonitorResponseTime is fake implementation
-func (o *SimpleMonitorOp) MonitorResponseTime(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.ResponseTimeSecActivity, error) {
-	_, err := o.Read(ctx, zone, id)
+func (o *SimpleMonitorOp) MonitorResponseTime(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.ResponseTimeSecActivity, error) {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -98,8 +98,8 @@ func (o *SimpleMonitorOp) MonitorResponseTime(ctx context.Context, zone string, 
 }
 
 // HealthStatus is fake implementation
-func (o *SimpleMonitorOp) HealthStatus(ctx context.Context, zone string, id types.ID) (*sacloud.SimpleMonitorHealthStatus, error) {
-	_, err := o.Read(ctx, zone, id)
+func (o *SimpleMonitorOp) HealthStatus(ctx context.Context, id types.ID) (*sacloud.SimpleMonitorHealthStatus, error) {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/sacloud/fake/ops_ssh_key.go
+++ b/sacloud/fake/ops_ssh_key.go
@@ -17,7 +17,7 @@ var (
 )
 
 // Find is fake implementation
-func (o *SSHKeyOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SSHKeyFindResult, error) {
+func (o *SSHKeyOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.SSHKeyFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.SSHKey
 	for _, res := range results {
@@ -34,7 +34,7 @@ func (o *SSHKeyOp) Find(ctx context.Context, zone string, conditions *sacloud.Fi
 }
 
 // Create is fake implementation
-func (o *SSHKeyOp) Create(ctx context.Context, zone string, param *sacloud.SSHKeyCreateRequest) (*sacloud.SSHKey, error) {
+func (o *SSHKeyOp) Create(ctx context.Context, param *sacloud.SSHKeyCreateRequest) (*sacloud.SSHKey, error) {
 	result := &sacloud.SSHKey{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt)
@@ -46,7 +46,7 @@ func (o *SSHKeyOp) Create(ctx context.Context, zone string, param *sacloud.SSHKe
 }
 
 // Generate is fake implementation
-func (o *SSHKeyOp) Generate(ctx context.Context, zone string, param *sacloud.SSHKeyGenerateRequest) (*sacloud.SSHKeyGenerated, error) {
+func (o *SSHKeyOp) Generate(ctx context.Context, param *sacloud.SSHKeyGenerateRequest) (*sacloud.SSHKeyGenerated, error) {
 	key := &sacloud.SSHKey{}
 	copySameNameField(param, key)
 	fill(key, fillID, fillCreatedAt)
@@ -63,7 +63,7 @@ func (o *SSHKeyOp) Generate(ctx context.Context, zone string, param *sacloud.SSH
 }
 
 // Read is fake implementation
-func (o *SSHKeyOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SSHKey, error) {
+func (o *SSHKeyOp) Read(ctx context.Context, id types.ID) (*sacloud.SSHKey, error) {
 	value := s.getSSHKeyByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
@@ -74,8 +74,8 @@ func (o *SSHKeyOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud
 }
 
 // Update is fake implementation
-func (o *SSHKeyOp) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SSHKeyUpdateRequest) (*sacloud.SSHKey, error) {
-	value, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *SSHKeyOp) Update(ctx context.Context, id types.ID, param *sacloud.SSHKeyUpdateRequest) (*sacloud.SSHKey, error) {
+	value, err := o.Read(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -84,8 +84,8 @@ func (o *SSHKeyOp) Update(ctx context.Context, zone string, id types.ID, param *
 }
 
 // Delete is fake implementation
-func (o *SSHKeyOp) Delete(ctx context.Context, zone string, id types.ID) error {
-	_, err := o.Read(ctx, sacloud.APIDefaultZone, id)
+func (o *SSHKeyOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
 	if err != nil {
 		return err
 	}

--- a/sacloud/fake/ops_web_accel.go
+++ b/sacloud/fake/ops_web_accel.go
@@ -9,7 +9,7 @@ import (
 )
 
 // List is fake implementation
-func (o *WebAccelOp) List(ctx context.Context, zone string) (*sacloud.WebAccelListResult, error) {
+func (o *WebAccelOp) List(ctx context.Context) (*sacloud.WebAccelListResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, nil)
 	var values []*sacloud.WebAccel
 	for _, res := range results {
@@ -26,7 +26,7 @@ func (o *WebAccelOp) List(ctx context.Context, zone string) (*sacloud.WebAccelLi
 }
 
 // Read is fake implementation
-func (o *WebAccelOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.WebAccel, error) {
+func (o *WebAccelOp) Read(ctx context.Context, id types.ID) (*sacloud.WebAccel, error) {
 	value := s.getWebAccelByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)
@@ -37,26 +37,26 @@ func (o *WebAccelOp) Read(ctx context.Context, zone string, id types.ID) (*saclo
 }
 
 // ReadCertificate is fake implementation
-func (o *WebAccelOp) ReadCertificate(ctx context.Context, zone string, id types.ID) (*sacloud.WebAccelCerts, error) {
+func (o *WebAccelOp) ReadCertificate(ctx context.Context, id types.ID) (*sacloud.WebAccelCerts, error) {
 	// valid only when running acc test
 	err := errors.New("not implements")
 	return nil, err
 }
 
 // UpdateCertificate is fake implementation
-func (o *WebAccelOp) UpdateCertificate(ctx context.Context, zone string, id types.ID, param *sacloud.WebAccelCertUpdateRequest) (*sacloud.WebAccelCerts, error) {
+func (o *WebAccelOp) UpdateCertificate(ctx context.Context, id types.ID, param *sacloud.WebAccelCertUpdateRequest) (*sacloud.WebAccelCerts, error) {
 	// valid only when running acc test
 	err := errors.New("not implements")
 	return nil, err
 }
 
 // DeleteAllCache is fake implementation
-func (o *WebAccelOp) DeleteAllCache(ctx context.Context, zone string, param *sacloud.WebAccelDeleteAllCacheRequest) error {
+func (o *WebAccelOp) DeleteAllCache(ctx context.Context, param *sacloud.WebAccelDeleteAllCacheRequest) error {
 	return nil
 }
 
 // DeleteCache is fake implementation
-func (o *WebAccelOp) DeleteCache(ctx context.Context, zone string, param *sacloud.WebAccelDeleteCacheRequest) ([]*sacloud.WebAccelDeleteCacheResult, error) {
+func (o *WebAccelOp) DeleteCache(ctx context.Context, param *sacloud.WebAccelDeleteCacheRequest) ([]*sacloud.WebAccelDeleteCacheResult, error) {
 	var result []*sacloud.WebAccelDeleteCacheResult
 	for _, url := range param.URL {
 		result = append(result, &sacloud.WebAccelDeleteCacheResult{

--- a/sacloud/fake/ops_zone.go
+++ b/sacloud/fake/ops_zone.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Find is fake implementation
-func (o *ZoneOp) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ZoneFindResult, error) {
+func (o *ZoneOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.ZoneFindResult, error) {
 	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
 	var values []*sacloud.Zone
 	for _, res := range results {
@@ -25,7 +25,7 @@ func (o *ZoneOp) Find(ctx context.Context, zone string, conditions *sacloud.Find
 }
 
 // Read is fake implementation
-func (o *ZoneOp) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Zone, error) {
+func (o *ZoneOp) Read(ctx context.Context, id types.ID) (*sacloud.Zone, error) {
 	value := s.getZoneByID(sacloud.APIDefaultZone, id)
 	if value == nil {
 		return nil, newErrorNotFound(o.key, id)

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -163,7 +163,7 @@ func NewAuthStatusStub(caller sacloud.APICaller) sacloud.AuthStatusAPI {
 }
 
 // Read is API call with trace log
-func (s *AuthStatusStub) Read(ctx context.Context, zone string) (*sacloud.AuthStatus, error) {
+func (s *AuthStatusStub) Read(ctx context.Context) (*sacloud.AuthStatus, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("AuthStatusStub.ReadStubResult is not set")
 	}
@@ -313,7 +313,7 @@ func NewBillStub(caller sacloud.APICaller) sacloud.BillAPI {
 }
 
 // ByContract is API call with trace log
-func (s *BillStub) ByContract(ctx context.Context, zone string, accountID types.ID) (*sacloud.BillByContractResult, error) {
+func (s *BillStub) ByContract(ctx context.Context, accountID types.ID) (*sacloud.BillByContractResult, error) {
 	if s.ByContractStubResult == nil {
 		log.Fatal("BillStub.ByContractStubResult is not set")
 	}
@@ -321,7 +321,7 @@ func (s *BillStub) ByContract(ctx context.Context, zone string, accountID types.
 }
 
 // ByContractYear is API call with trace log
-func (s *BillStub) ByContractYear(ctx context.Context, zone string, accountID types.ID, year int) (*sacloud.BillByContractYearResult, error) {
+func (s *BillStub) ByContractYear(ctx context.Context, accountID types.ID, year int) (*sacloud.BillByContractYearResult, error) {
 	if s.ByContractYearStubResult == nil {
 		log.Fatal("BillStub.ByContractYearStubResult is not set")
 	}
@@ -329,7 +329,7 @@ func (s *BillStub) ByContractYear(ctx context.Context, zone string, accountID ty
 }
 
 // ByContractYearMonth is API call with trace log
-func (s *BillStub) ByContractYearMonth(ctx context.Context, zone string, accountID types.ID, year int, month int) (*sacloud.BillByContractYearMonthResult, error) {
+func (s *BillStub) ByContractYearMonth(ctx context.Context, accountID types.ID, year int, month int) (*sacloud.BillByContractYearMonthResult, error) {
 	if s.ByContractYearMonthStubResult == nil {
 		log.Fatal("BillStub.ByContractYearMonthStubResult is not set")
 	}
@@ -337,7 +337,7 @@ func (s *BillStub) ByContractYearMonth(ctx context.Context, zone string, account
 }
 
 // Read is API call with trace log
-func (s *BillStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.BillReadResult, error) {
+func (s *BillStub) Read(ctx context.Context, id types.ID) (*sacloud.BillReadResult, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("BillStub.ReadStubResult is not set")
 	}
@@ -345,7 +345,7 @@ func (s *BillStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud
 }
 
 // Details is API call with trace log
-func (s *BillStub) Details(ctx context.Context, zone string, MemberCode string, id types.ID) (*sacloud.BillDetailsResult, error) {
+func (s *BillStub) Details(ctx context.Context, MemberCode string, id types.ID) (*sacloud.BillDetailsResult, error) {
 	if s.DetailsStubResult == nil {
 		log.Fatal("BillStub.DetailsStubResult is not set")
 	}
@@ -353,7 +353,7 @@ func (s *BillStub) Details(ctx context.Context, zone string, MemberCode string, 
 }
 
 // DetailsCSV is API call with trace log
-func (s *BillStub) DetailsCSV(ctx context.Context, zone string, MemberCode string, id types.ID) (*sacloud.BillDetailCSV, error) {
+func (s *BillStub) DetailsCSV(ctx context.Context, MemberCode string, id types.ID) (*sacloud.BillDetailCSV, error) {
 	if s.DetailsCSVStubResult == nil {
 		log.Fatal("BillStub.DetailsCSVStubResult is not set")
 	}
@@ -585,7 +585,7 @@ func NewCouponStub(caller sacloud.APICaller) sacloud.CouponAPI {
 }
 
 // Find is API call with trace log
-func (s *CouponStub) Find(ctx context.Context, zone string, accountID types.ID) (*sacloud.CouponFindResult, error) {
+func (s *CouponStub) Find(ctx context.Context, accountID types.ID) (*sacloud.CouponFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("CouponStub.FindStubResult is not set")
 	}
@@ -1148,7 +1148,7 @@ func NewDNSStub(caller sacloud.APICaller) sacloud.DNSAPI {
 }
 
 // Find is API call with trace log
-func (s *DNSStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.DNSFindResult, error) {
+func (s *DNSStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.DNSFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("DNSStub.FindStubResult is not set")
 	}
@@ -1156,7 +1156,7 @@ func (s *DNSStub) Find(ctx context.Context, zone string, conditions *sacloud.Fin
 }
 
 // Create is API call with trace log
-func (s *DNSStub) Create(ctx context.Context, zone string, param *sacloud.DNSCreateRequest) (*sacloud.DNS, error) {
+func (s *DNSStub) Create(ctx context.Context, param *sacloud.DNSCreateRequest) (*sacloud.DNS, error) {
 	if s.CreateStubResult == nil {
 		log.Fatal("DNSStub.CreateStubResult is not set")
 	}
@@ -1164,7 +1164,7 @@ func (s *DNSStub) Create(ctx context.Context, zone string, param *sacloud.DNSCre
 }
 
 // Read is API call with trace log
-func (s *DNSStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.DNS, error) {
+func (s *DNSStub) Read(ctx context.Context, id types.ID) (*sacloud.DNS, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("DNSStub.ReadStubResult is not set")
 	}
@@ -1172,7 +1172,7 @@ func (s *DNSStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.
 }
 
 // Update is API call with trace log
-func (s *DNSStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.DNSUpdateRequest) (*sacloud.DNS, error) {
+func (s *DNSStub) Update(ctx context.Context, id types.ID, param *sacloud.DNSUpdateRequest) (*sacloud.DNS, error) {
 	if s.UpdateStubResult == nil {
 		log.Fatal("DNSStub.UpdateStubResult is not set")
 	}
@@ -1180,7 +1180,7 @@ func (s *DNSStub) Update(ctx context.Context, zone string, id types.ID, param *s
 }
 
 // Delete is API call with trace log
-func (s *DNSStub) Delete(ctx context.Context, zone string, id types.ID) error {
+func (s *DNSStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
 		log.Fatal("DNSStub.DeleteStubResult is not set")
 	}
@@ -1235,7 +1235,7 @@ func NewGSLBStub(caller sacloud.APICaller) sacloud.GSLBAPI {
 }
 
 // Find is API call with trace log
-func (s *GSLBStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.GSLBFindResult, error) {
+func (s *GSLBStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.GSLBFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("GSLBStub.FindStubResult is not set")
 	}
@@ -1243,7 +1243,7 @@ func (s *GSLBStub) Find(ctx context.Context, zone string, conditions *sacloud.Fi
 }
 
 // Create is API call with trace log
-func (s *GSLBStub) Create(ctx context.Context, zone string, param *sacloud.GSLBCreateRequest) (*sacloud.GSLB, error) {
+func (s *GSLBStub) Create(ctx context.Context, param *sacloud.GSLBCreateRequest) (*sacloud.GSLB, error) {
 	if s.CreateStubResult == nil {
 		log.Fatal("GSLBStub.CreateStubResult is not set")
 	}
@@ -1251,7 +1251,7 @@ func (s *GSLBStub) Create(ctx context.Context, zone string, param *sacloud.GSLBC
 }
 
 // Read is API call with trace log
-func (s *GSLBStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.GSLB, error) {
+func (s *GSLBStub) Read(ctx context.Context, id types.ID) (*sacloud.GSLB, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("GSLBStub.ReadStubResult is not set")
 	}
@@ -1259,7 +1259,7 @@ func (s *GSLBStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud
 }
 
 // Update is API call with trace log
-func (s *GSLBStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.GSLBUpdateRequest) (*sacloud.GSLB, error) {
+func (s *GSLBStub) Update(ctx context.Context, id types.ID, param *sacloud.GSLBUpdateRequest) (*sacloud.GSLB, error) {
 	if s.UpdateStubResult == nil {
 		log.Fatal("GSLBStub.UpdateStubResult is not set")
 	}
@@ -1267,7 +1267,7 @@ func (s *GSLBStub) Update(ctx context.Context, zone string, id types.ID, param *
 }
 
 // Delete is API call with trace log
-func (s *GSLBStub) Delete(ctx context.Context, zone string, id types.ID) error {
+func (s *GSLBStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
 		log.Fatal("GSLBStub.DeleteStubResult is not set")
 	}
@@ -1322,7 +1322,7 @@ func NewIconStub(caller sacloud.APICaller) sacloud.IconAPI {
 }
 
 // Find is API call with trace log
-func (s *IconStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.IconFindResult, error) {
+func (s *IconStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.IconFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("IconStub.FindStubResult is not set")
 	}
@@ -1330,7 +1330,7 @@ func (s *IconStub) Find(ctx context.Context, zone string, conditions *sacloud.Fi
 }
 
 // Create is API call with trace log
-func (s *IconStub) Create(ctx context.Context, zone string, param *sacloud.IconCreateRequest) (*sacloud.Icon, error) {
+func (s *IconStub) Create(ctx context.Context, param *sacloud.IconCreateRequest) (*sacloud.Icon, error) {
 	if s.CreateStubResult == nil {
 		log.Fatal("IconStub.CreateStubResult is not set")
 	}
@@ -1338,7 +1338,7 @@ func (s *IconStub) Create(ctx context.Context, zone string, param *sacloud.IconC
 }
 
 // Read is API call with trace log
-func (s *IconStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Icon, error) {
+func (s *IconStub) Read(ctx context.Context, id types.ID) (*sacloud.Icon, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("IconStub.ReadStubResult is not set")
 	}
@@ -1346,7 +1346,7 @@ func (s *IconStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud
 }
 
 // Update is API call with trace log
-func (s *IconStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.IconUpdateRequest) (*sacloud.Icon, error) {
+func (s *IconStub) Update(ctx context.Context, id types.ID, param *sacloud.IconUpdateRequest) (*sacloud.Icon, error) {
 	if s.UpdateStubResult == nil {
 		log.Fatal("IconStub.UpdateStubResult is not set")
 	}
@@ -1354,7 +1354,7 @@ func (s *IconStub) Update(ctx context.Context, zone string, id types.ID, param *
 }
 
 // Delete is API call with trace log
-func (s *IconStub) Delete(ctx context.Context, zone string, id types.ID) error {
+func (s *IconStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
 		log.Fatal("IconStub.DeleteStubResult is not set")
 	}
@@ -2002,7 +2002,7 @@ func NewLicenseStub(caller sacloud.APICaller) sacloud.LicenseAPI {
 }
 
 // Find is API call with trace log
-func (s *LicenseStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.LicenseFindResult, error) {
+func (s *LicenseStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LicenseFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("LicenseStub.FindStubResult is not set")
 	}
@@ -2010,7 +2010,7 @@ func (s *LicenseStub) Find(ctx context.Context, zone string, conditions *sacloud
 }
 
 // Create is API call with trace log
-func (s *LicenseStub) Create(ctx context.Context, zone string, param *sacloud.LicenseCreateRequest) (*sacloud.License, error) {
+func (s *LicenseStub) Create(ctx context.Context, param *sacloud.LicenseCreateRequest) (*sacloud.License, error) {
 	if s.CreateStubResult == nil {
 		log.Fatal("LicenseStub.CreateStubResult is not set")
 	}
@@ -2018,7 +2018,7 @@ func (s *LicenseStub) Create(ctx context.Context, zone string, param *sacloud.Li
 }
 
 // Read is API call with trace log
-func (s *LicenseStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.License, error) {
+func (s *LicenseStub) Read(ctx context.Context, id types.ID) (*sacloud.License, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("LicenseStub.ReadStubResult is not set")
 	}
@@ -2026,7 +2026,7 @@ func (s *LicenseStub) Read(ctx context.Context, zone string, id types.ID) (*sacl
 }
 
 // Update is API call with trace log
-func (s *LicenseStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.LicenseUpdateRequest) (*sacloud.License, error) {
+func (s *LicenseStub) Update(ctx context.Context, id types.ID, param *sacloud.LicenseUpdateRequest) (*sacloud.License, error) {
 	if s.UpdateStubResult == nil {
 		log.Fatal("LicenseStub.UpdateStubResult is not set")
 	}
@@ -2034,7 +2034,7 @@ func (s *LicenseStub) Update(ctx context.Context, zone string, id types.ID, para
 }
 
 // Delete is API call with trace log
-func (s *LicenseStub) Delete(ctx context.Context, zone string, id types.ID) error {
+func (s *LicenseStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
 		log.Fatal("LicenseStub.DeleteStubResult is not set")
 	}
@@ -2069,7 +2069,7 @@ func NewLicenseInfoStub(caller sacloud.APICaller) sacloud.LicenseInfoAPI {
 }
 
 // Find is API call with trace log
-func (s *LicenseInfoStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.LicenseInfoFindResult, error) {
+func (s *LicenseInfoStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LicenseInfoFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("LicenseInfoStub.FindStubResult is not set")
 	}
@@ -2077,7 +2077,7 @@ func (s *LicenseInfoStub) Find(ctx context.Context, zone string, conditions *sac
 }
 
 // Read is API call with trace log
-func (s *LicenseInfoStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.LicenseInfo, error) {
+func (s *LicenseInfoStub) Read(ctx context.Context, id types.ID) (*sacloud.LicenseInfo, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("LicenseInfoStub.ReadStubResult is not set")
 	}
@@ -2824,7 +2824,7 @@ func NewNoteStub(caller sacloud.APICaller) sacloud.NoteAPI {
 }
 
 // Find is API call with trace log
-func (s *NoteStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.NoteFindResult, error) {
+func (s *NoteStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.NoteFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("NoteStub.FindStubResult is not set")
 	}
@@ -2832,7 +2832,7 @@ func (s *NoteStub) Find(ctx context.Context, zone string, conditions *sacloud.Fi
 }
 
 // Create is API call with trace log
-func (s *NoteStub) Create(ctx context.Context, zone string, param *sacloud.NoteCreateRequest) (*sacloud.Note, error) {
+func (s *NoteStub) Create(ctx context.Context, param *sacloud.NoteCreateRequest) (*sacloud.Note, error) {
 	if s.CreateStubResult == nil {
 		log.Fatal("NoteStub.CreateStubResult is not set")
 	}
@@ -2840,7 +2840,7 @@ func (s *NoteStub) Create(ctx context.Context, zone string, param *sacloud.NoteC
 }
 
 // Read is API call with trace log
-func (s *NoteStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Note, error) {
+func (s *NoteStub) Read(ctx context.Context, id types.ID) (*sacloud.Note, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("NoteStub.ReadStubResult is not set")
 	}
@@ -2848,7 +2848,7 @@ func (s *NoteStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud
 }
 
 // Update is API call with trace log
-func (s *NoteStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.NoteUpdateRequest) (*sacloud.Note, error) {
+func (s *NoteStub) Update(ctx context.Context, id types.ID, param *sacloud.NoteUpdateRequest) (*sacloud.Note, error) {
 	if s.UpdateStubResult == nil {
 		log.Fatal("NoteStub.UpdateStubResult is not set")
 	}
@@ -2856,7 +2856,7 @@ func (s *NoteStub) Update(ctx context.Context, zone string, id types.ID, param *
 }
 
 // Delete is API call with trace log
-func (s *NoteStub) Delete(ctx context.Context, zone string, id types.ID) error {
+func (s *NoteStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
 		log.Fatal("NoteStub.DeleteStubResult is not set")
 	}
@@ -3168,7 +3168,7 @@ func NewProxyLBStub(caller sacloud.APICaller) sacloud.ProxyLBAPI {
 }
 
 // Find is API call with trace log
-func (s *ProxyLBStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ProxyLBFindResult, error) {
+func (s *ProxyLBStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.ProxyLBFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("ProxyLBStub.FindStubResult is not set")
 	}
@@ -3176,7 +3176,7 @@ func (s *ProxyLBStub) Find(ctx context.Context, zone string, conditions *sacloud
 }
 
 // Create is API call with trace log
-func (s *ProxyLBStub) Create(ctx context.Context, zone string, param *sacloud.ProxyLBCreateRequest) (*sacloud.ProxyLB, error) {
+func (s *ProxyLBStub) Create(ctx context.Context, param *sacloud.ProxyLBCreateRequest) (*sacloud.ProxyLB, error) {
 	if s.CreateStubResult == nil {
 		log.Fatal("ProxyLBStub.CreateStubResult is not set")
 	}
@@ -3184,7 +3184,7 @@ func (s *ProxyLBStub) Create(ctx context.Context, zone string, param *sacloud.Pr
 }
 
 // Read is API call with trace log
-func (s *ProxyLBStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.ProxyLB, error) {
+func (s *ProxyLBStub) Read(ctx context.Context, id types.ID) (*sacloud.ProxyLB, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("ProxyLBStub.ReadStubResult is not set")
 	}
@@ -3192,7 +3192,7 @@ func (s *ProxyLBStub) Read(ctx context.Context, zone string, id types.ID) (*sacl
 }
 
 // Update is API call with trace log
-func (s *ProxyLBStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.ProxyLBUpdateRequest) (*sacloud.ProxyLB, error) {
+func (s *ProxyLBStub) Update(ctx context.Context, id types.ID, param *sacloud.ProxyLBUpdateRequest) (*sacloud.ProxyLB, error) {
 	if s.UpdateStubResult == nil {
 		log.Fatal("ProxyLBStub.UpdateStubResult is not set")
 	}
@@ -3200,7 +3200,7 @@ func (s *ProxyLBStub) Update(ctx context.Context, zone string, id types.ID, para
 }
 
 // Delete is API call with trace log
-func (s *ProxyLBStub) Delete(ctx context.Context, zone string, id types.ID) error {
+func (s *ProxyLBStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
 		log.Fatal("ProxyLBStub.DeleteStubResult is not set")
 	}
@@ -3208,7 +3208,7 @@ func (s *ProxyLBStub) Delete(ctx context.Context, zone string, id types.ID) erro
 }
 
 // ChangePlan is API call with trace log
-func (s *ProxyLBStub) ChangePlan(ctx context.Context, zone string, id types.ID, param *sacloud.ProxyLBChangePlanRequest) (*sacloud.ProxyLB, error) {
+func (s *ProxyLBStub) ChangePlan(ctx context.Context, id types.ID, param *sacloud.ProxyLBChangePlanRequest) (*sacloud.ProxyLB, error) {
 	if s.ChangePlanStubResult == nil {
 		log.Fatal("ProxyLBStub.ChangePlanStubResult is not set")
 	}
@@ -3216,7 +3216,7 @@ func (s *ProxyLBStub) ChangePlan(ctx context.Context, zone string, id types.ID, 
 }
 
 // GetCertificates is API call with trace log
-func (s *ProxyLBStub) GetCertificates(ctx context.Context, zone string, id types.ID) (*sacloud.ProxyLBCertificates, error) {
+func (s *ProxyLBStub) GetCertificates(ctx context.Context, id types.ID) (*sacloud.ProxyLBCertificates, error) {
 	if s.GetCertificatesStubResult == nil {
 		log.Fatal("ProxyLBStub.GetCertificatesStubResult is not set")
 	}
@@ -3224,7 +3224,7 @@ func (s *ProxyLBStub) GetCertificates(ctx context.Context, zone string, id types
 }
 
 // SetCertificates is API call with trace log
-func (s *ProxyLBStub) SetCertificates(ctx context.Context, zone string, id types.ID, param *sacloud.ProxyLBSetCertificatesRequest) (*sacloud.ProxyLBCertificates, error) {
+func (s *ProxyLBStub) SetCertificates(ctx context.Context, id types.ID, param *sacloud.ProxyLBSetCertificatesRequest) (*sacloud.ProxyLBCertificates, error) {
 	if s.SetCertificatesStubResult == nil {
 		log.Fatal("ProxyLBStub.SetCertificatesStubResult is not set")
 	}
@@ -3232,7 +3232,7 @@ func (s *ProxyLBStub) SetCertificates(ctx context.Context, zone string, id types
 }
 
 // DeleteCertificates is API call with trace log
-func (s *ProxyLBStub) DeleteCertificates(ctx context.Context, zone string, id types.ID) error {
+func (s *ProxyLBStub) DeleteCertificates(ctx context.Context, id types.ID) error {
 	if s.DeleteCertificatesStubResult == nil {
 		log.Fatal("ProxyLBStub.DeleteCertificatesStubResult is not set")
 	}
@@ -3240,7 +3240,7 @@ func (s *ProxyLBStub) DeleteCertificates(ctx context.Context, zone string, id ty
 }
 
 // RenewLetsEncryptCert is API call with trace log
-func (s *ProxyLBStub) RenewLetsEncryptCert(ctx context.Context, zone string, id types.ID) error {
+func (s *ProxyLBStub) RenewLetsEncryptCert(ctx context.Context, id types.ID) error {
 	if s.RenewLetsEncryptCertStubResult == nil {
 		log.Fatal("ProxyLBStub.RenewLetsEncryptCertStubResult is not set")
 	}
@@ -3248,7 +3248,7 @@ func (s *ProxyLBStub) RenewLetsEncryptCert(ctx context.Context, zone string, id 
 }
 
 // HealthStatus is API call with trace log
-func (s *ProxyLBStub) HealthStatus(ctx context.Context, zone string, id types.ID) (*sacloud.ProxyLBHealth, error) {
+func (s *ProxyLBStub) HealthStatus(ctx context.Context, id types.ID) (*sacloud.ProxyLBHealth, error) {
 	if s.HealthStatusStubResult == nil {
 		log.Fatal("ProxyLBStub.HealthStatusStubResult is not set")
 	}
@@ -3283,7 +3283,7 @@ func NewRegionStub(caller sacloud.APICaller) sacloud.RegionAPI {
 }
 
 // Find is API call with trace log
-func (s *RegionStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.RegionFindResult, error) {
+func (s *RegionStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.RegionFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("RegionStub.FindStubResult is not set")
 	}
@@ -3291,7 +3291,7 @@ func (s *RegionStub) Find(ctx context.Context, zone string, conditions *sacloud.
 }
 
 // Read is API call with trace log
-func (s *RegionStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Region, error) {
+func (s *RegionStub) Read(ctx context.Context, id types.ID) (*sacloud.Region, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("RegionStub.ReadStubResult is not set")
 	}
@@ -3674,7 +3674,7 @@ func NewSIMStub(caller sacloud.APICaller) sacloud.SIMAPI {
 }
 
 // Find is API call with trace log
-func (s *SIMStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SIMFindResult, error) {
+func (s *SIMStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.SIMFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("SIMStub.FindStubResult is not set")
 	}
@@ -3682,7 +3682,7 @@ func (s *SIMStub) Find(ctx context.Context, zone string, conditions *sacloud.Fin
 }
 
 // Create is API call with trace log
-func (s *SIMStub) Create(ctx context.Context, zone string, param *sacloud.SIMCreateRequest) (*sacloud.SIM, error) {
+func (s *SIMStub) Create(ctx context.Context, param *sacloud.SIMCreateRequest) (*sacloud.SIM, error) {
 	if s.CreateStubResult == nil {
 		log.Fatal("SIMStub.CreateStubResult is not set")
 	}
@@ -3690,7 +3690,7 @@ func (s *SIMStub) Create(ctx context.Context, zone string, param *sacloud.SIMCre
 }
 
 // Read is API call with trace log
-func (s *SIMStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SIM, error) {
+func (s *SIMStub) Read(ctx context.Context, id types.ID) (*sacloud.SIM, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("SIMStub.ReadStubResult is not set")
 	}
@@ -3698,7 +3698,7 @@ func (s *SIMStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.
 }
 
 // Update is API call with trace log
-func (s *SIMStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SIMUpdateRequest) (*sacloud.SIM, error) {
+func (s *SIMStub) Update(ctx context.Context, id types.ID, param *sacloud.SIMUpdateRequest) (*sacloud.SIM, error) {
 	if s.UpdateStubResult == nil {
 		log.Fatal("SIMStub.UpdateStubResult is not set")
 	}
@@ -3706,7 +3706,7 @@ func (s *SIMStub) Update(ctx context.Context, zone string, id types.ID, param *s
 }
 
 // Delete is API call with trace log
-func (s *SIMStub) Delete(ctx context.Context, zone string, id types.ID) error {
+func (s *SIMStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
 		log.Fatal("SIMStub.DeleteStubResult is not set")
 	}
@@ -3714,7 +3714,7 @@ func (s *SIMStub) Delete(ctx context.Context, zone string, id types.ID) error {
 }
 
 // Activate is API call with trace log
-func (s *SIMStub) Activate(ctx context.Context, zone string, id types.ID) error {
+func (s *SIMStub) Activate(ctx context.Context, id types.ID) error {
 	if s.ActivateStubResult == nil {
 		log.Fatal("SIMStub.ActivateStubResult is not set")
 	}
@@ -3722,7 +3722,7 @@ func (s *SIMStub) Activate(ctx context.Context, zone string, id types.ID) error 
 }
 
 // Deactivate is API call with trace log
-func (s *SIMStub) Deactivate(ctx context.Context, zone string, id types.ID) error {
+func (s *SIMStub) Deactivate(ctx context.Context, id types.ID) error {
 	if s.DeactivateStubResult == nil {
 		log.Fatal("SIMStub.DeactivateStubResult is not set")
 	}
@@ -3730,7 +3730,7 @@ func (s *SIMStub) Deactivate(ctx context.Context, zone string, id types.ID) erro
 }
 
 // AssignIP is API call with trace log
-func (s *SIMStub) AssignIP(ctx context.Context, zone string, id types.ID, param *sacloud.SIMAssignIPRequest) error {
+func (s *SIMStub) AssignIP(ctx context.Context, id types.ID, param *sacloud.SIMAssignIPRequest) error {
 	if s.AssignIPStubResult == nil {
 		log.Fatal("SIMStub.AssignIPStubResult is not set")
 	}
@@ -3738,7 +3738,7 @@ func (s *SIMStub) AssignIP(ctx context.Context, zone string, id types.ID, param 
 }
 
 // ClearIP is API call with trace log
-func (s *SIMStub) ClearIP(ctx context.Context, zone string, id types.ID) error {
+func (s *SIMStub) ClearIP(ctx context.Context, id types.ID) error {
 	if s.ClearIPStubResult == nil {
 		log.Fatal("SIMStub.ClearIPStubResult is not set")
 	}
@@ -3746,7 +3746,7 @@ func (s *SIMStub) ClearIP(ctx context.Context, zone string, id types.ID) error {
 }
 
 // IMEILock is API call with trace log
-func (s *SIMStub) IMEILock(ctx context.Context, zone string, id types.ID, param *sacloud.SIMIMEILockRequest) error {
+func (s *SIMStub) IMEILock(ctx context.Context, id types.ID, param *sacloud.SIMIMEILockRequest) error {
 	if s.IMEILockStubResult == nil {
 		log.Fatal("SIMStub.IMEILockStubResult is not set")
 	}
@@ -3754,7 +3754,7 @@ func (s *SIMStub) IMEILock(ctx context.Context, zone string, id types.ID, param 
 }
 
 // IMEIUnlock is API call with trace log
-func (s *SIMStub) IMEIUnlock(ctx context.Context, zone string, id types.ID) error {
+func (s *SIMStub) IMEIUnlock(ctx context.Context, id types.ID) error {
 	if s.IMEIUnlockStubResult == nil {
 		log.Fatal("SIMStub.IMEIUnlockStubResult is not set")
 	}
@@ -3762,7 +3762,7 @@ func (s *SIMStub) IMEIUnlock(ctx context.Context, zone string, id types.ID) erro
 }
 
 // Logs is API call with trace log
-func (s *SIMStub) Logs(ctx context.Context, zone string, id types.ID) (*sacloud.SIMLogsResult, error) {
+func (s *SIMStub) Logs(ctx context.Context, id types.ID) (*sacloud.SIMLogsResult, error) {
 	if s.LogsStubResult == nil {
 		log.Fatal("SIMStub.LogsStubResult is not set")
 	}
@@ -3770,7 +3770,7 @@ func (s *SIMStub) Logs(ctx context.Context, zone string, id types.ID) (*sacloud.
 }
 
 // GetNetworkOperator is API call with trace log
-func (s *SIMStub) GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*sacloud.SIMNetworkOperatorConfig, error) {
+func (s *SIMStub) GetNetworkOperator(ctx context.Context, id types.ID) ([]*sacloud.SIMNetworkOperatorConfig, error) {
 	if s.GetNetworkOperatorStubResult == nil {
 		log.Fatal("SIMStub.GetNetworkOperatorStubResult is not set")
 	}
@@ -3778,7 +3778,7 @@ func (s *SIMStub) GetNetworkOperator(ctx context.Context, zone string, id types.
 }
 
 // SetNetworkOperator is API call with trace log
-func (s *SIMStub) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*sacloud.SIMNetworkOperatorConfig) error {
+func (s *SIMStub) SetNetworkOperator(ctx context.Context, id types.ID, configs []*sacloud.SIMNetworkOperatorConfig) error {
 	if s.SetNetworkOperatorStubResult == nil {
 		log.Fatal("SIMStub.SetNetworkOperatorStubResult is not set")
 	}
@@ -3786,7 +3786,7 @@ func (s *SIMStub) SetNetworkOperator(ctx context.Context, zone string, id types.
 }
 
 // MonitorSIM is API call with trace log
-func (s *SIMStub) MonitorSIM(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LinkActivity, error) {
+func (s *SIMStub) MonitorSIM(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LinkActivity, error) {
 	if s.MonitorSIMStubResult == nil {
 		log.Fatal("SIMStub.MonitorSIMStubResult is not set")
 	}
@@ -3794,7 +3794,7 @@ func (s *SIMStub) MonitorSIM(ctx context.Context, zone string, id types.ID, cond
 }
 
 // Status is API call with trace log
-func (s *SIMStub) Status(ctx context.Context, zone string, id types.ID) (*sacloud.SIMInfo, error) {
+func (s *SIMStub) Status(ctx context.Context, id types.ID) (*sacloud.SIMInfo, error) {
 	if s.StatusStubResult == nil {
 		log.Fatal("SIMStub.StatusStubResult is not set")
 	}
@@ -3863,7 +3863,7 @@ func NewSimpleMonitorStub(caller sacloud.APICaller) sacloud.SimpleMonitorAPI {
 }
 
 // Find is API call with trace log
-func (s *SimpleMonitorStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SimpleMonitorFindResult, error) {
+func (s *SimpleMonitorStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.SimpleMonitorFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("SimpleMonitorStub.FindStubResult is not set")
 	}
@@ -3871,7 +3871,7 @@ func (s *SimpleMonitorStub) Find(ctx context.Context, zone string, conditions *s
 }
 
 // Create is API call with trace log
-func (s *SimpleMonitorStub) Create(ctx context.Context, zone string, param *sacloud.SimpleMonitorCreateRequest) (*sacloud.SimpleMonitor, error) {
+func (s *SimpleMonitorStub) Create(ctx context.Context, param *sacloud.SimpleMonitorCreateRequest) (*sacloud.SimpleMonitor, error) {
 	if s.CreateStubResult == nil {
 		log.Fatal("SimpleMonitorStub.CreateStubResult is not set")
 	}
@@ -3879,7 +3879,7 @@ func (s *SimpleMonitorStub) Create(ctx context.Context, zone string, param *sacl
 }
 
 // Read is API call with trace log
-func (s *SimpleMonitorStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SimpleMonitor, error) {
+func (s *SimpleMonitorStub) Read(ctx context.Context, id types.ID) (*sacloud.SimpleMonitor, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("SimpleMonitorStub.ReadStubResult is not set")
 	}
@@ -3887,7 +3887,7 @@ func (s *SimpleMonitorStub) Read(ctx context.Context, zone string, id types.ID) 
 }
 
 // Update is API call with trace log
-func (s *SimpleMonitorStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SimpleMonitorUpdateRequest) (*sacloud.SimpleMonitor, error) {
+func (s *SimpleMonitorStub) Update(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorUpdateRequest) (*sacloud.SimpleMonitor, error) {
 	if s.UpdateStubResult == nil {
 		log.Fatal("SimpleMonitorStub.UpdateStubResult is not set")
 	}
@@ -3895,7 +3895,7 @@ func (s *SimpleMonitorStub) Update(ctx context.Context, zone string, id types.ID
 }
 
 // Delete is API call with trace log
-func (s *SimpleMonitorStub) Delete(ctx context.Context, zone string, id types.ID) error {
+func (s *SimpleMonitorStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
 		log.Fatal("SimpleMonitorStub.DeleteStubResult is not set")
 	}
@@ -3903,7 +3903,7 @@ func (s *SimpleMonitorStub) Delete(ctx context.Context, zone string, id types.ID
 }
 
 // MonitorResponseTime is API call with trace log
-func (s *SimpleMonitorStub) MonitorResponseTime(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.ResponseTimeSecActivity, error) {
+func (s *SimpleMonitorStub) MonitorResponseTime(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.ResponseTimeSecActivity, error) {
 	if s.MonitorResponseTimeStubResult == nil {
 		log.Fatal("SimpleMonitorStub.MonitorResponseTimeStubResult is not set")
 	}
@@ -3911,7 +3911,7 @@ func (s *SimpleMonitorStub) MonitorResponseTime(ctx context.Context, zone string
 }
 
 // HealthStatus is API call with trace log
-func (s *SimpleMonitorStub) HealthStatus(ctx context.Context, zone string, id types.ID) (*sacloud.SimpleMonitorHealthStatus, error) {
+func (s *SimpleMonitorStub) HealthStatus(ctx context.Context, id types.ID) (*sacloud.SimpleMonitorHealthStatus, error) {
 	if s.HealthStatusStubResult == nil {
 		log.Fatal("SimpleMonitorStub.HealthStatusStubResult is not set")
 	}
@@ -3973,7 +3973,7 @@ func NewSSHKeyStub(caller sacloud.APICaller) sacloud.SSHKeyAPI {
 }
 
 // Find is API call with trace log
-func (s *SSHKeyStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SSHKeyFindResult, error) {
+func (s *SSHKeyStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.SSHKeyFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("SSHKeyStub.FindStubResult is not set")
 	}
@@ -3981,7 +3981,7 @@ func (s *SSHKeyStub) Find(ctx context.Context, zone string, conditions *sacloud.
 }
 
 // Create is API call with trace log
-func (s *SSHKeyStub) Create(ctx context.Context, zone string, param *sacloud.SSHKeyCreateRequest) (*sacloud.SSHKey, error) {
+func (s *SSHKeyStub) Create(ctx context.Context, param *sacloud.SSHKeyCreateRequest) (*sacloud.SSHKey, error) {
 	if s.CreateStubResult == nil {
 		log.Fatal("SSHKeyStub.CreateStubResult is not set")
 	}
@@ -3989,7 +3989,7 @@ func (s *SSHKeyStub) Create(ctx context.Context, zone string, param *sacloud.SSH
 }
 
 // Generate is API call with trace log
-func (s *SSHKeyStub) Generate(ctx context.Context, zone string, param *sacloud.SSHKeyGenerateRequest) (*sacloud.SSHKeyGenerated, error) {
+func (s *SSHKeyStub) Generate(ctx context.Context, param *sacloud.SSHKeyGenerateRequest) (*sacloud.SSHKeyGenerated, error) {
 	if s.GenerateStubResult == nil {
 		log.Fatal("SSHKeyStub.GenerateStubResult is not set")
 	}
@@ -3997,7 +3997,7 @@ func (s *SSHKeyStub) Generate(ctx context.Context, zone string, param *sacloud.S
 }
 
 // Read is API call with trace log
-func (s *SSHKeyStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SSHKey, error) {
+func (s *SSHKeyStub) Read(ctx context.Context, id types.ID) (*sacloud.SSHKey, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("SSHKeyStub.ReadStubResult is not set")
 	}
@@ -4005,7 +4005,7 @@ func (s *SSHKeyStub) Read(ctx context.Context, zone string, id types.ID) (*saclo
 }
 
 // Update is API call with trace log
-func (s *SSHKeyStub) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SSHKeyUpdateRequest) (*sacloud.SSHKey, error) {
+func (s *SSHKeyStub) Update(ctx context.Context, id types.ID, param *sacloud.SSHKeyUpdateRequest) (*sacloud.SSHKey, error) {
 	if s.UpdateStubResult == nil {
 		log.Fatal("SSHKeyStub.UpdateStubResult is not set")
 	}
@@ -4013,7 +4013,7 @@ func (s *SSHKeyStub) Update(ctx context.Context, zone string, id types.ID, param
 }
 
 // Delete is API call with trace log
-func (s *SSHKeyStub) Delete(ctx context.Context, zone string, id types.ID) error {
+func (s *SSHKeyStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
 		log.Fatal("SSHKeyStub.DeleteStubResult is not set")
 	}
@@ -4376,7 +4376,7 @@ func NewWebAccelStub(caller sacloud.APICaller) sacloud.WebAccelAPI {
 }
 
 // List is API call with trace log
-func (s *WebAccelStub) List(ctx context.Context, zone string) (*sacloud.WebAccelListResult, error) {
+func (s *WebAccelStub) List(ctx context.Context) (*sacloud.WebAccelListResult, error) {
 	if s.ListStubResult == nil {
 		log.Fatal("WebAccelStub.ListStubResult is not set")
 	}
@@ -4384,7 +4384,7 @@ func (s *WebAccelStub) List(ctx context.Context, zone string) (*sacloud.WebAccel
 }
 
 // Read is API call with trace log
-func (s *WebAccelStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.WebAccel, error) {
+func (s *WebAccelStub) Read(ctx context.Context, id types.ID) (*sacloud.WebAccel, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("WebAccelStub.ReadStubResult is not set")
 	}
@@ -4392,7 +4392,7 @@ func (s *WebAccelStub) Read(ctx context.Context, zone string, id types.ID) (*sac
 }
 
 // ReadCertificate is API call with trace log
-func (s *WebAccelStub) ReadCertificate(ctx context.Context, zone string, id types.ID) (*sacloud.WebAccelCerts, error) {
+func (s *WebAccelStub) ReadCertificate(ctx context.Context, id types.ID) (*sacloud.WebAccelCerts, error) {
 	if s.ReadCertificateStubResult == nil {
 		log.Fatal("WebAccelStub.ReadCertificateStubResult is not set")
 	}
@@ -4400,7 +4400,7 @@ func (s *WebAccelStub) ReadCertificate(ctx context.Context, zone string, id type
 }
 
 // UpdateCertificate is API call with trace log
-func (s *WebAccelStub) UpdateCertificate(ctx context.Context, zone string, id types.ID, param *sacloud.WebAccelCertUpdateRequest) (*sacloud.WebAccelCerts, error) {
+func (s *WebAccelStub) UpdateCertificate(ctx context.Context, id types.ID, param *sacloud.WebAccelCertUpdateRequest) (*sacloud.WebAccelCerts, error) {
 	if s.UpdateCertificateStubResult == nil {
 		log.Fatal("WebAccelStub.UpdateCertificateStubResult is not set")
 	}
@@ -4408,7 +4408,7 @@ func (s *WebAccelStub) UpdateCertificate(ctx context.Context, zone string, id ty
 }
 
 // DeleteAllCache is API call with trace log
-func (s *WebAccelStub) DeleteAllCache(ctx context.Context, zone string, param *sacloud.WebAccelDeleteAllCacheRequest) error {
+func (s *WebAccelStub) DeleteAllCache(ctx context.Context, param *sacloud.WebAccelDeleteAllCacheRequest) error {
 	if s.DeleteAllCacheStubResult == nil {
 		log.Fatal("WebAccelStub.DeleteAllCacheStubResult is not set")
 	}
@@ -4416,7 +4416,7 @@ func (s *WebAccelStub) DeleteAllCache(ctx context.Context, zone string, param *s
 }
 
 // DeleteCache is API call with trace log
-func (s *WebAccelStub) DeleteCache(ctx context.Context, zone string, param *sacloud.WebAccelDeleteCacheRequest) ([]*sacloud.WebAccelDeleteCacheResult, error) {
+func (s *WebAccelStub) DeleteCache(ctx context.Context, param *sacloud.WebAccelDeleteCacheRequest) ([]*sacloud.WebAccelDeleteCacheResult, error) {
 	if s.DeleteCacheStubResult == nil {
 		log.Fatal("WebAccelStub.DeleteCacheStubResult is not set")
 	}
@@ -4451,7 +4451,7 @@ func NewZoneStub(caller sacloud.APICaller) sacloud.ZoneAPI {
 }
 
 // Find is API call with trace log
-func (s *ZoneStub) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ZoneFindResult, error) {
+func (s *ZoneStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.ZoneFindResult, error) {
 	if s.FindStubResult == nil {
 		log.Fatal("ZoneStub.FindStubResult is not set")
 	}
@@ -4459,7 +4459,7 @@ func (s *ZoneStub) Find(ctx context.Context, zone string, conditions *sacloud.Fi
 }
 
 // Read is API call with trace log
-func (s *ZoneStub) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Zone, error) {
+func (s *ZoneStub) Read(ctx context.Context, id types.ID) (*sacloud.Zone, error) {
 	if s.ReadStubResult == nil {
 		log.Fatal("ZoneStub.ReadStubResult is not set")
 	}

--- a/sacloud/test/auth_status_op_test.go
+++ b/sacloud/test/auth_status_op_test.go
@@ -15,7 +15,7 @@ func TestAuthStatusOp_Read(t *testing.T) {
 		Read: &CRUDTestFunc{
 			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 				client := sacloud.NewAuthStatusOp(singletonAPICaller())
-				authStatus, err := client.Read(context.Background(), sacloud.APIDefaultZone)
+				authStatus, err := client.Read(context.Background())
 
 				assert.NotNil(t, authStatus)
 

--- a/sacloud/test/bill_op_test.go
+++ b/sacloud/test/bill_op_test.go
@@ -15,7 +15,7 @@ func TestBillOp_ByContract(t *testing.T) {
 
 	// get account ID
 	authStatusOp := sacloud.NewAuthStatusOp(singletonAPICaller())
-	authStatus, err := authStatusOp.Read(context.Background(), sacloud.APIDefaultZone)
+	authStatus, err := authStatusOp.Read(context.Background())
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -25,7 +25,7 @@ func TestBillOp_ByContract(t *testing.T) {
 		t.Skip("current account is not permitted to viewing bills")
 	}
 
-	searched, err := client.ByContract(context.Background(), sacloud.APIDefaultZone, authStatus.AccountID)
+	searched, err := client.ByContract(context.Background(), authStatus.AccountID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -39,7 +39,7 @@ func TestBillOp_ByContract(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Details
-	details, err := client.Details(context.Background(), sacloud.APIDefaultZone, authStatus.MemberCode, searched.Bills[0].ID)
+	details, err := client.Details(context.Background(), authStatus.MemberCode, searched.Bills[0].ID)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/sacloud/test/coupon_op_test.go
+++ b/sacloud/test/coupon_op_test.go
@@ -13,7 +13,7 @@ func TestCouponOp_Find(t *testing.T) {
 
 	// get account ID
 	authStatusOp := sacloud.NewAuthStatusOp(singletonAPICaller())
-	authStatus, err := authStatusOp.Read(context.Background(), sacloud.APIDefaultZone)
+	authStatus, err := authStatusOp.Read(context.Background())
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -24,7 +24,7 @@ func TestCouponOp_Find(t *testing.T) {
 	}
 
 	client := sacloud.NewCouponOp(singletonAPICaller())
-	searched, err := client.Find(context.Background(), sacloud.APIDefaultZone, authStatus.AccountID)
+	searched, err := client.Find(context.Background(), authStatus.AccountID)
 	assert.NoError(t, err)
 
 	if searched.Count > 0 {

--- a/sacloud/test/dns_op_test.go
+++ b/sacloud/test/dns_op_test.go
@@ -115,20 +115,20 @@ var (
 
 func testDNSCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewDNSOp(caller)
-	return client.Create(context.Background(), sacloud.APIDefaultZone, createDNSParam)
+	return client.Create(context.Background(), createDNSParam)
 }
 
 func testDNSRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewDNSOp(caller)
-	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Read(context.Background(), testContext.ID)
 }
 
 func testDNSUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewDNSOp(caller)
-	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateDNSParam)
+	return client.Update(context.Background(), testContext.ID, updateDNSParam)
 }
 
 func testDNSDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewDNSOp(caller)
-	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Delete(context.Background(), testContext.ID)
 }

--- a/sacloud/test/functions.go
+++ b/sacloud/test/functions.go
@@ -9,7 +9,7 @@ import (
 
 func lookupDNSByName(caller sacloud.APICaller, zoneName string) (*sacloud.DNS, error) {
 	dnsOp := sacloud.NewDNSOp(caller)
-	searched, err := dnsOp.Find(context.Background(), sacloud.APIDefaultZone, &sacloud.FindCondition{
+	searched, err := dnsOp.Find(context.Background(), &sacloud.FindCondition{
 		Count: 1,
 		Filter: map[string]interface{}{
 			"Name": zoneName,

--- a/sacloud/test/gslb_op_test.go
+++ b/sacloud/test/gslb_op_test.go
@@ -145,20 +145,20 @@ var (
 
 func testGSLBCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewGSLBOp(caller)
-	return client.Create(context.Background(), sacloud.APIDefaultZone, createGSLBParam)
+	return client.Create(context.Background(), createGSLBParam)
 }
 
 func testGSLBRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewGSLBOp(caller)
-	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Read(context.Background(), testContext.ID)
 }
 
 func testGSLBUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewGSLBOp(caller)
-	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateGSLBParam)
+	return client.Update(context.Background(), testContext.ID, updateGSLBParam)
 }
 
 func testGSLBDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewGSLBOp(caller)
-	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Delete(context.Background(), testContext.ID)
 }

--- a/sacloud/test/icon_op_test.go
+++ b/sacloud/test/icon_op_test.go
@@ -74,20 +74,20 @@ var (
 
 func testIconCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewIconOp(caller)
-	return client.Create(context.Background(), sacloud.APIDefaultZone, createIconParam)
+	return client.Create(context.Background(), createIconParam)
 }
 
 func testIconRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewIconOp(caller)
-	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Read(context.Background(), testContext.ID)
 }
 
 func testIconUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewIconOp(caller)
-	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateIconParam)
+	return client.Update(context.Background(), testContext.ID, updateIconParam)
 }
 
 func testIconDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewIconOp(caller)
-	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Delete(context.Background(), testContext.ID)
 }

--- a/sacloud/test/license_info_op_test.go
+++ b/sacloud/test/license_info_op_test.go
@@ -13,7 +13,7 @@ func TestLicenseInfoOp_Find(t *testing.T) {
 
 	client := sacloud.NewLicenseInfoOp(singletonAPICaller())
 
-	searched, err := client.Find(context.Background(), sacloud.APIDefaultZone, &sacloud.FindCondition{Count: 1})
+	searched, err := client.Find(context.Background(), &sacloud.FindCondition{Count: 1})
 	assert.NoError(t, err)
 
 	err = DoAsserts(

--- a/sacloud/test/license_op_test.go
+++ b/sacloud/test/license_op_test.go
@@ -70,20 +70,20 @@ var (
 
 func testLicenseCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewLicenseOp(caller)
-	return client.Create(context.Background(), sacloud.APIDefaultZone, createLicenseParam)
+	return client.Create(context.Background(), createLicenseParam)
 }
 
 func testLicenseRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewLicenseOp(caller)
-	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Read(context.Background(), testContext.ID)
 }
 
 func testLicenseUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewLicenseOp(caller)
-	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateLicenseParam)
+	return client.Update(context.Background(), testContext.ID, updateLicenseParam)
 }
 
 func testLicenseDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewLicenseOp(caller)
-	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Delete(context.Background(), testContext.ID)
 }

--- a/sacloud/test/mobile_gateway_op_test.go
+++ b/sacloud/test/mobile_gateway_op_test.go
@@ -142,7 +142,7 @@ func TestMobileGatewayOpCRUD(t *testing.T) {
 			{
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					simOp := sacloud.NewSIMOp(caller)
-					sim, err := simOp.Create(context.Background(), sacloud.APIDefaultZone, &sacloud.SIMCreateRequest{
+					sim, err := simOp.Create(context.Background(), &sacloud.SIMCreateRequest{
 						Name:     "libsacloud-switch-for-mobile-gateway",
 						ICCID:    iccid,
 						PassCode: passcode,
@@ -174,12 +174,12 @@ func TestMobileGatewayOpCRUD(t *testing.T) {
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					client := sacloud.NewSIMOp(caller)
 					simID := testContext.Values["mobile-gateway/sim"].(types.ID)
-					if err := client.AssignIP(context.Background(), sacloud.APIDefaultZone, simID, &sacloud.SIMAssignIPRequest{
+					if err := client.AssignIP(context.Background(), simID, &sacloud.SIMAssignIPRequest{
 						IP: "192.168.2.1",
 					}); err != nil {
 						return nil, err
 					}
-					return client.Status(context.Background(), sacloud.APIDefaultZone, simID)
+					return client.Status(context.Background(), simID)
 				},
 				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
 					simInfo := v.(*sacloud.SIMInfo)
@@ -194,10 +194,10 @@ func TestMobileGatewayOpCRUD(t *testing.T) {
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					client := sacloud.NewSIMOp(caller)
 					simID := testContext.Values["mobile-gateway/sim"].(types.ID)
-					if err := client.ClearIP(context.Background(), sacloud.APIDefaultZone, simID); err != nil {
+					if err := client.ClearIP(context.Background(), simID); err != nil {
 						return nil, err
 					}
-					return client.Status(context.Background(), sacloud.APIDefaultZone, simID)
+					return client.Status(context.Background(), simID)
 				},
 				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
 					simInfo := v.(*sacloud.SIMInfo)
@@ -317,7 +317,7 @@ func TestMobileGatewayOpCRUD(t *testing.T) {
 					}
 
 					simOp := sacloud.NewSIMOp(caller)
-					if err := simOp.Delete(context.Background(), testZone, simID); err != nil {
+					if err := simOp.Delete(context.Background(), simID); err != nil {
 						return nil, err
 					}
 

--- a/sacloud/test/note_op_test.go
+++ b/sacloud/test/note_op_test.go
@@ -75,20 +75,20 @@ var (
 
 func testNoteCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewNoteOp(caller)
-	return client.Create(context.Background(), sacloud.APIDefaultZone, createNoteParam)
+	return client.Create(context.Background(), createNoteParam)
 }
 
 func testNoteRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewNoteOp(caller)
-	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Read(context.Background(), testContext.ID)
 }
 
 func testNoteUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewNoteOp(caller)
-	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateNoteParam)
+	return client.Update(context.Background(), testContext.ID, updateNoteParam)
 }
 
 func testNoteDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewNoteOp(caller)
-	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Delete(context.Background(), testContext.ID)
 }

--- a/sacloud/test/proxylb_op_test.go
+++ b/sacloud/test/proxylb_op_test.go
@@ -282,22 +282,22 @@ func initProxyLBVariables() {
 
 func testProxyLBCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewProxyLBOp(caller)
-	return client.Create(context.Background(), sacloud.APIDefaultZone, createProxyLBParam)
+	return client.Create(context.Background(), createProxyLBParam)
 }
 
 func testProxyLBRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewProxyLBOp(caller)
-	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Read(context.Background(), testContext.ID)
 }
 
 func testProxyLBUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewProxyLBOp(caller)
-	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateProxyLBParam)
+	return client.Update(context.Background(), testContext.ID, updateProxyLBParam)
 }
 
 func testProxyLBDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewProxyLBOp(caller)
-	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Delete(context.Background(), testContext.ID)
 }
 
 func TestProxyLBOpLetsEncryptAndHealth(t *testing.T) {
@@ -326,12 +326,12 @@ func TestProxyLBOpLetsEncryptAndHealth(t *testing.T) {
 	proxyLBOp := sacloud.NewProxyLBOp(singletonAPICaller())
 
 	// create proxyLB
-	proxyLB, err := proxyLBOp.Create(ctx, sacloud.APIDefaultZone, createProxyLBForACMEParam)
+	proxyLB, err := proxyLBOp.Create(ctx, createProxyLBForACMEParam)
 	if !assert.NoError(t, err) {
 		return
 	}
 	defer func() {
-		proxyLBOp.Delete(ctx, sacloud.APIDefaultZone, proxyLB.ID) // nolint - ignore error
+		proxyLBOp.Delete(ctx, proxyLB.ID) // nolint - ignore error
 	}()
 
 	// read DNS
@@ -349,7 +349,7 @@ func TestProxyLBOpLetsEncryptAndHealth(t *testing.T) {
 
 	// update DNS record
 	dnsOp := sacloud.NewDNSOp(singletonAPICaller())
-	dns, err = dnsOp.Update(ctx, sacloud.APIDefaultZone, dns.ID, &sacloud.DNSUpdateRequest{
+	dns, err = dnsOp.Update(ctx, dns.ID, &sacloud.DNSUpdateRequest{
 		Records: dns.Records,
 	})
 	if !assert.NoError(t, err) {
@@ -362,7 +362,7 @@ func TestProxyLBOpLetsEncryptAndHealth(t *testing.T) {
 				records = append(records, dns.Records[i])
 			}
 		}
-		dnsOp.Update(ctx, sacloud.APIDefaultZone, dns.ID, &sacloud.DNSUpdateRequest{
+		dnsOp.Update(ctx, dns.ID, &sacloud.DNSUpdateRequest{
 			Records: records,
 		}) // nolint - ignore error
 	}()
@@ -374,7 +374,7 @@ func TestProxyLBOpLetsEncryptAndHealth(t *testing.T) {
 	done := false
 
 	for retryMax >= 0 {
-		proxyLB, err = proxyLBOp.Update(ctx, sacloud.APIDefaultZone, proxyLB.ID, updateProxyLBForACMEParam)
+		proxyLB, err = proxyLBOp.Update(ctx, proxyLB.ID, updateProxyLBForACMEParam)
 		if err != nil {
 			t.Log("Update Let's encrypt setting is failed. retry after 10 sec.")
 			time.Sleep(10 * time.Second)
@@ -390,7 +390,7 @@ func TestProxyLBOpLetsEncryptAndHealth(t *testing.T) {
 	}
 
 	// renew certs
-	err = proxyLBOp.RenewLetsEncryptCert(ctx, sacloud.APIDefaultZone, proxyLB.ID)
+	err = proxyLBOp.RenewLetsEncryptCert(ctx, proxyLB.ID)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -398,7 +398,7 @@ func TestProxyLBOpLetsEncryptAndHealth(t *testing.T) {
 	time.Sleep(time.Minute)
 
 	// get cert
-	certs, err := proxyLBOp.GetCertificates(ctx, sacloud.APIDefaultZone, proxyLB.ID)
+	certs, err := proxyLBOp.GetCertificates(ctx, proxyLB.ID)
 
 	if !assert.NoError(t, err) {
 		return
@@ -410,7 +410,7 @@ func TestProxyLBOpLetsEncryptAndHealth(t *testing.T) {
 	assert.NotEmpty(t, certs.CertificateEndDate)
 
 	// check health status
-	status, err := proxyLBOp.HealthStatus(ctx, sacloud.APIDefaultZone, proxyLB.ID)
+	status, err := proxyLBOp.HealthStatus(ctx, proxyLB.ID)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/sacloud/test/region_op_test.go
+++ b/sacloud/test/region_op_test.go
@@ -14,7 +14,7 @@ func TestRegionOp_Find(t *testing.T) {
 
 	client := sacloud.NewRegionOp(singletonAPICaller())
 
-	searched, err := client.Find(context.Background(), sacloud.APIDefaultZone, &sacloud.FindCondition{Count: 1})
+	searched, err := client.Find(context.Background(), &sacloud.FindCondition{Count: 1})
 	assert.NoError(t, err)
 
 	err = DoAsserts(
@@ -33,7 +33,7 @@ func TestRegionOp_Read(t *testing.T) {
 	client := sacloud.NewRegionOp(singletonAPICaller())
 
 	sandboxRegionID := types.ID(290)
-	region, err := client.Read(context.Background(), sacloud.APIDefaultZone, sandboxRegionID)
+	region, err := client.Read(context.Background(), sandboxRegionID)
 	assert.NoError(t, err)
 
 	err = DoAsserts(

--- a/sacloud/test/sim_op_test.go
+++ b/sacloud/test/sim_op_test.go
@@ -50,10 +50,10 @@ func TestSIMOpCRUD(t *testing.T) {
 			{
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					client := sacloud.NewSIMOp(caller)
-					if err := client.Activate(context.Background(), sacloud.APIDefaultZone, testContext.ID); err != nil {
+					if err := client.Activate(context.Background(), testContext.ID); err != nil {
 						return nil, err
 					}
-					return client.Status(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+					return client.Status(context.Background(), testContext.ID)
 				},
 				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
 					simInfo := v.(*sacloud.SIMInfo)
@@ -68,10 +68,10 @@ func TestSIMOpCRUD(t *testing.T) {
 			{
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					client := sacloud.NewSIMOp(caller)
-					if err := client.Deactivate(context.Background(), sacloud.APIDefaultZone, testContext.ID); err != nil {
+					if err := client.Deactivate(context.Background(), testContext.ID); err != nil {
 						return nil, err
 					}
-					return client.Status(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+					return client.Status(context.Background(), testContext.ID)
 				},
 				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
 					simInfo := v.(*sacloud.SIMInfo)
@@ -86,12 +86,12 @@ func TestSIMOpCRUD(t *testing.T) {
 			{
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					client := sacloud.NewSIMOp(caller)
-					if err := client.IMEILock(context.Background(), sacloud.APIDefaultZone, testContext.ID, &sacloud.SIMIMEILockRequest{
+					if err := client.IMEILock(context.Background(), testContext.ID, &sacloud.SIMIMEILockRequest{
 						IMEI: "123456789012345",
 					}); err != nil {
 						return nil, err
 					}
-					return client.Status(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+					return client.Status(context.Background(), testContext.ID)
 				},
 				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
 					simInfo := v.(*sacloud.SIMInfo)
@@ -105,10 +105,10 @@ func TestSIMOpCRUD(t *testing.T) {
 			{
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					client := sacloud.NewSIMOp(caller)
-					if err := client.IMEIUnlock(context.Background(), sacloud.APIDefaultZone, testContext.ID); err != nil {
+					if err := client.IMEIUnlock(context.Background(), testContext.ID); err != nil {
 						return nil, err
 					}
-					return client.Status(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+					return client.Status(context.Background(), testContext.ID)
 				},
 				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
 					simInfo := v.(*sacloud.SIMInfo)
@@ -128,10 +128,10 @@ func TestSIMOpCRUD(t *testing.T) {
 							Allow: true,
 						},
 					}
-					if err := client.SetNetworkOperator(context.Background(), sacloud.APIDefaultZone, testContext.ID, configs); err != nil {
+					if err := client.SetNetworkOperator(context.Background(), testContext.ID, configs); err != nil {
 						return nil, err
 					}
-					return client.GetNetworkOperator(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+					return client.GetNetworkOperator(context.Background(), testContext.ID)
 				},
 				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
 					config := v.([]*sacloud.SIMNetworkOperatorConfig)
@@ -157,7 +157,7 @@ func TestSIMOp_Logs(t *testing.T) {
 	id := types.StringID(os.Getenv("SAKURACLOUD_SIM_ID"))
 
 	client := sacloud.NewSIMOp(singletonAPICaller())
-	logs, err := client.Logs(context.Background(), sacloud.APIDefaultZone, id)
+	logs, err := client.Logs(context.Background(), id)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, logs)
 
@@ -213,20 +213,20 @@ var (
 
 func testSIMCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSIMOp(caller)
-	return client.Create(context.Background(), sacloud.APIDefaultZone, createSIMParam)
+	return client.Create(context.Background(), createSIMParam)
 }
 
 func testSIMRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSIMOp(caller)
-	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Read(context.Background(), testContext.ID)
 }
 
 func testSIMUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSIMOp(caller)
-	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateSIMParam)
+	return client.Update(context.Background(), testContext.ID, updateSIMParam)
 }
 
 func testSIMDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewSIMOp(caller)
-	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Delete(context.Background(), testContext.ID)
 }

--- a/sacloud/test/simple_monitor_op_test.go
+++ b/sacloud/test/simple_monitor_op_test.go
@@ -130,22 +130,22 @@ var (
 
 func testSimpleMonitorCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSimpleMonitorOp(caller)
-	return client.Create(context.Background(), sacloud.APIDefaultZone, createSimpleMonitorParam)
+	return client.Create(context.Background(), createSimpleMonitorParam)
 }
 
 func testSimpleMonitorRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSimpleMonitorOp(caller)
-	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Read(context.Background(), testContext.ID)
 }
 
 func testSimpleMonitorUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSimpleMonitorOp(caller)
-	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateSimpleMonitorParam)
+	return client.Update(context.Background(), testContext.ID, updateSimpleMonitorParam)
 }
 
 func testSimpleMonitorDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewSimpleMonitorOp(caller)
-	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Delete(context.Background(), testContext.ID)
 }
 
 func TestSimpleMonitorOp_StatusAndHealth(t *testing.T) {
@@ -159,7 +159,7 @@ func TestSimpleMonitorOp_StatusAndHealth(t *testing.T) {
 
 		Create: &CRUDTestFunc{
 			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
-				sm, err := client.Create(ctx, sacloud.APIDefaultZone, simpleMonitorStatusAndHealthTargetParam)
+				sm, err := client.Create(ctx, simpleMonitorStatusAndHealthTargetParam)
 				if err != nil {
 					return nil, err
 				}
@@ -177,7 +177,7 @@ func TestSimpleMonitorOp_StatusAndHealth(t *testing.T) {
 		Updates: []*CRUDTestFunc{
 			{
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
-					return client.HealthStatus(ctx, sacloud.APIDefaultZone, testContext.ID)
+					return client.HealthStatus(ctx, testContext.ID)
 				},
 				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
 					healthStatus := v.(*sacloud.SimpleMonitorHealthStatus)
@@ -189,7 +189,7 @@ func TestSimpleMonitorOp_StatusAndHealth(t *testing.T) {
 			},
 			{
 				Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
-					return client.MonitorResponseTime(ctx, sacloud.APIDefaultZone, testContext.ID, &sacloud.MonitorCondition{})
+					return client.MonitorResponseTime(ctx, testContext.ID, &sacloud.MonitorCondition{})
 				},
 				CheckFunc: func(t TestT, testContext *CRUDTestContext, v interface{}) error {
 					monitor := v.(*sacloud.ResponseTimeSecActivity)

--- a/sacloud/test/ssh_key_op_test.go
+++ b/sacloud/test/ssh_key_op_test.go
@@ -49,7 +49,7 @@ func TestSSHKeyOp_Generate(t *testing.T) {
 		Create: &CRUDTestFunc{
 			Func: func(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 				client := sacloud.NewSSHKeyOp(caller)
-				return client.Generate(context.Background(), sacloud.APIDefaultZone, &sacloud.SSHKeyGenerateRequest{
+				return client.Generate(context.Background(), &sacloud.SSHKeyGenerateRequest{
 					Name:        "libsacloud-sshKey-generate",
 					Description: "libsacloud-sshKey-generate",
 					PassPhrase:  "libsacloud-sshKey-passphrase",
@@ -107,20 +107,20 @@ var (
 
 func testSSHKeyCreate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSSHKeyOp(caller)
-	return client.Create(context.Background(), sacloud.APIDefaultZone, createSSHKeyParam)
+	return client.Create(context.Background(), createSSHKeyParam)
 }
 
 func testSSHKeyRead(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSSHKeyOp(caller)
-	return client.Read(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Read(context.Background(), testContext.ID)
 }
 
 func testSSHKeyUpdate(testContext *CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSSHKeyOp(caller)
-	return client.Update(context.Background(), sacloud.APIDefaultZone, testContext.ID, updateSSHKeyParam)
+	return client.Update(context.Background(), testContext.ID, updateSSHKeyParam)
 }
 
 func testSSHKeyDelete(testContext *CRUDTestContext, caller sacloud.APICaller) error {
 	client := sacloud.NewSSHKeyOp(caller)
-	return client.Delete(context.Background(), sacloud.APIDefaultZone, testContext.ID)
+	return client.Delete(context.Background(), testContext.ID)
 }

--- a/sacloud/test/webaccel_op_test.go
+++ b/sacloud/test/webaccel_op_test.go
@@ -24,7 +24,7 @@ func TestWebAccelOp_Find(t *testing.T) {
 	}
 
 	client := sacloud.NewWebAccelOp(singletonAPICaller())
-	searched, err := client.List(context.Background(), sacloud.APIDefaultZone)
+	searched, err := client.List(context.Background())
 	assert.NoError(t, err)
 
 	if searched.Count == 0 {
@@ -51,7 +51,7 @@ func TestWebAccelOp_Find(t *testing.T) {
 	assert.NoError(t, err)
 
 	// read
-	read, err := client.Read(context.Background(), sacloud.APIDefaultZone, site.ID)
+	read, err := client.Read(context.Background(), site.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, site, read)
 }
@@ -77,7 +77,7 @@ func TestWebAccelOp_Cert(t *testing.T) {
 	key := os.Getenv("SAKURACLOUD_WEBACCEL_KEY")
 
 	// update certs
-	certs, err := client.UpdateCertificate(ctx, sacloud.APIDefaultZone, id, &sacloud.WebAccelCertUpdateRequest{
+	certs, err := client.UpdateCertificate(ctx, id, &sacloud.WebAccelCertUpdateRequest{
 		CertificateChain: crt,
 		Key:              key,
 	})
@@ -86,7 +86,7 @@ func TestWebAccelOp_Cert(t *testing.T) {
 	}
 
 	// read cert
-	read, err := client.ReadCertificate(ctx, sacloud.APIDefaultZone, id)
+	read, err := client.ReadCertificate(ctx, id)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -112,7 +112,7 @@ func TestWebAccelOp_DeleteAllCache(t *testing.T) {
 	domain := os.Getenv("SAKURACLOUD_WEBACCEL_DOMAIN")
 
 	// delete cache
-	err = client.DeleteAllCache(ctx, sacloud.APIDefaultZone, &sacloud.WebAccelDeleteAllCacheRequest{
+	err = client.DeleteAllCache(ctx, &sacloud.WebAccelDeleteAllCacheRequest{
 		Domain: domain,
 	})
 	if !assert.NoError(t, err) {
@@ -141,7 +141,7 @@ func TestWebAccelOp_DeleteCache(t *testing.T) {
 	urls := strings.Split(strURLs, ",")
 
 	// delete cache
-	result, err := client.DeleteCache(ctx, sacloud.APIDefaultZone, &sacloud.WebAccelDeleteCacheRequest{
+	result, err := client.DeleteCache(ctx, &sacloud.WebAccelDeleteCacheRequest{
 		URL: urls,
 	})
 	if !assert.NoError(t, err) {
@@ -152,7 +152,7 @@ func TestWebAccelOp_DeleteCache(t *testing.T) {
 
 func hasWebAccelPermission() (bool, error) {
 	authStatusOp := sacloud.NewAuthStatusOp(singletonAPICaller())
-	authStatus, err := authStatusOp.Read(context.Background(), sacloud.APIDefaultZone)
+	authStatus, err := authStatusOp.Read(context.Background())
 	if err != nil {
 		return false, err
 	}

--- a/sacloud/test/zone_op_test.go
+++ b/sacloud/test/zone_op_test.go
@@ -13,7 +13,7 @@ func TestZoneOp_Find(t *testing.T) {
 
 	client := sacloud.NewZoneOp(singletonAPICaller())
 
-	zoneFindResult, err := client.Find(context.Background(), sacloud.APIDefaultZone, &sacloud.FindCondition{Count: 1})
+	zoneFindResult, err := client.Find(context.Background(), &sacloud.FindCondition{Count: 1})
 	assert.NoError(t, err)
 	assert.Len(t, zoneFindResult.Zones, 1)
 }

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -155,7 +155,7 @@ func NewArchiveTracer(in sacloud.ArchiveAPI) sacloud.ArchiveAPI {
 func (t *ArchiveTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ArchiveFindResult, error) {
 	log.Println("[TRACE] ArchiveAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -188,7 +188,7 @@ func (t *ArchiveTracer) Find(ctx context.Context, zone string, conditions *saclo
 func (t *ArchiveTracer) Create(ctx context.Context, zone string, param *sacloud.ArchiveCreateRequest) (*sacloud.Archive, error) {
 	log.Println("[TRACE] ArchiveAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                        `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.ArchiveCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -221,7 +221,7 @@ func (t *ArchiveTracer) Create(ctx context.Context, zone string, param *sacloud.
 func (t *ArchiveTracer) CreateBlank(ctx context.Context, zone string, param *sacloud.ArchiveCreateBlankRequest) (*sacloud.Archive, *sacloud.FTPServer, error) {
 	log.Println("[TRACE] ArchiveAPI.CreateBlank start")
 	targetArguments := struct {
-		Argzone  string                             `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.ArchiveCreateBlankRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -256,7 +256,7 @@ func (t *ArchiveTracer) CreateBlank(ctx context.Context, zone string, param *sac
 func (t *ArchiveTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Archive, error) {
 	log.Println("[TRACE] ArchiveAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -289,7 +289,7 @@ func (t *ArchiveTracer) Read(ctx context.Context, zone string, id types.ID) (*sa
 func (t *ArchiveTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.ArchiveUpdateRequest) (*sacloud.Archive, error) {
 	log.Println("[TRACE] ArchiveAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                        `json:"zone"`
+		Argzone  string
 		Argid    types.ID                      `json:"id"`
 		Argparam *sacloud.ArchiveUpdateRequest `json:"param"`
 	}{
@@ -324,7 +324,7 @@ func (t *ArchiveTracer) Update(ctx context.Context, zone string, id types.ID, pa
 func (t *ArchiveTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] ArchiveAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -355,7 +355,7 @@ func (t *ArchiveTracer) Delete(ctx context.Context, zone string, id types.ID) er
 func (t *ArchiveTracer) OpenFTP(ctx context.Context, zone string, id types.ID, openOption *sacloud.OpenFTPRequest) (*sacloud.FTPServer, error) {
 	log.Println("[TRACE] ArchiveAPI.OpenFTP start")
 	targetArguments := struct {
-		Argzone       string                  `json:"zone"`
+		Argzone       string
 		Argid         types.ID                `json:"id"`
 		ArgopenOption *sacloud.OpenFTPRequest `json:"openOption"`
 	}{
@@ -390,7 +390,7 @@ func (t *ArchiveTracer) OpenFTP(ctx context.Context, zone string, id types.ID, o
 func (t *ArchiveTracer) CloseFTP(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] ArchiveAPI.CloseFTP start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -434,13 +434,10 @@ func NewAuthStatusTracer(in sacloud.AuthStatusAPI) sacloud.AuthStatusAPI {
 }
 
 // Read is API call with trace log
-func (t *AuthStatusTracer) Read(ctx context.Context, zone string) (*sacloud.AuthStatus, error) {
+func (t *AuthStatusTracer) Read(ctx context.Context) (*sacloud.AuthStatus, error) {
 	log.Println("[TRACE] AuthStatusAPI.Read start")
 	targetArguments := struct {
-		Argzone string `json:"zone"`
-	}{
-		Argzone: zone,
-	}
+	}{}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
 	}
@@ -449,7 +446,7 @@ func (t *AuthStatusTracer) Read(ctx context.Context, zone string) (*sacloud.Auth
 		log.Println("[TRACE] AuthStatusAPI.Read end")
 	}()
 
-	resultAuthStatus, err := t.Internal.Read(ctx, zone)
+	resultAuthStatus, err := t.Internal.Read(ctx)
 	targetResults := struct {
 		AuthStatus *sacloud.AuthStatus
 		Error      error
@@ -484,7 +481,7 @@ func NewAutoBackupTracer(in sacloud.AutoBackupAPI) sacloud.AutoBackupAPI {
 func (t *AutoBackupTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.AutoBackupFindResult, error) {
 	log.Println("[TRACE] AutoBackupAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -517,7 +514,7 @@ func (t *AutoBackupTracer) Find(ctx context.Context, zone string, conditions *sa
 func (t *AutoBackupTracer) Create(ctx context.Context, zone string, param *sacloud.AutoBackupCreateRequest) (*sacloud.AutoBackup, error) {
 	log.Println("[TRACE] AutoBackupAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                           `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.AutoBackupCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -550,7 +547,7 @@ func (t *AutoBackupTracer) Create(ctx context.Context, zone string, param *saclo
 func (t *AutoBackupTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.AutoBackup, error) {
 	log.Println("[TRACE] AutoBackupAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -583,7 +580,7 @@ func (t *AutoBackupTracer) Read(ctx context.Context, zone string, id types.ID) (
 func (t *AutoBackupTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.AutoBackupUpdateRequest) (*sacloud.AutoBackup, error) {
 	log.Println("[TRACE] AutoBackupAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                           `json:"zone"`
+		Argzone  string
 		Argid    types.ID                         `json:"id"`
 		Argparam *sacloud.AutoBackupUpdateRequest `json:"param"`
 	}{
@@ -618,7 +615,7 @@ func (t *AutoBackupTracer) Update(ctx context.Context, zone string, id types.ID,
 func (t *AutoBackupTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] AutoBackupAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -662,13 +659,11 @@ func NewBillTracer(in sacloud.BillAPI) sacloud.BillAPI {
 }
 
 // ByContract is API call with trace log
-func (t *BillTracer) ByContract(ctx context.Context, zone string, accountID types.ID) (*sacloud.BillByContractResult, error) {
+func (t *BillTracer) ByContract(ctx context.Context, accountID types.ID) (*sacloud.BillByContractResult, error) {
 	log.Println("[TRACE] BillAPI.ByContract start")
 	targetArguments := struct {
-		Argzone      string   `json:"zone"`
 		ArgaccountID types.ID `json:"accountID"`
 	}{
-		Argzone:      zone,
 		ArgaccountID: accountID,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -679,7 +674,7 @@ func (t *BillTracer) ByContract(ctx context.Context, zone string, accountID type
 		log.Println("[TRACE] BillAPI.ByContract end")
 	}()
 
-	result, err := t.Internal.ByContract(ctx, zone, accountID)
+	result, err := t.Internal.ByContract(ctx, accountID)
 	targetResults := struct {
 		Result *sacloud.BillByContractResult
 		Error  error
@@ -695,14 +690,12 @@ func (t *BillTracer) ByContract(ctx context.Context, zone string, accountID type
 }
 
 // ByContractYear is API call with trace log
-func (t *BillTracer) ByContractYear(ctx context.Context, zone string, accountID types.ID, year int) (*sacloud.BillByContractYearResult, error) {
+func (t *BillTracer) ByContractYear(ctx context.Context, accountID types.ID, year int) (*sacloud.BillByContractYearResult, error) {
 	log.Println("[TRACE] BillAPI.ByContractYear start")
 	targetArguments := struct {
-		Argzone      string   `json:"zone"`
 		ArgaccountID types.ID `json:"accountID"`
 		Argyear      int      `json:"year"`
 	}{
-		Argzone:      zone,
 		ArgaccountID: accountID,
 		Argyear:      year,
 	}
@@ -714,7 +707,7 @@ func (t *BillTracer) ByContractYear(ctx context.Context, zone string, accountID 
 		log.Println("[TRACE] BillAPI.ByContractYear end")
 	}()
 
-	result, err := t.Internal.ByContractYear(ctx, zone, accountID, year)
+	result, err := t.Internal.ByContractYear(ctx, accountID, year)
 	targetResults := struct {
 		Result *sacloud.BillByContractYearResult
 		Error  error
@@ -730,15 +723,13 @@ func (t *BillTracer) ByContractYear(ctx context.Context, zone string, accountID 
 }
 
 // ByContractYearMonth is API call with trace log
-func (t *BillTracer) ByContractYearMonth(ctx context.Context, zone string, accountID types.ID, year int, month int) (*sacloud.BillByContractYearMonthResult, error) {
+func (t *BillTracer) ByContractYearMonth(ctx context.Context, accountID types.ID, year int, month int) (*sacloud.BillByContractYearMonthResult, error) {
 	log.Println("[TRACE] BillAPI.ByContractYearMonth start")
 	targetArguments := struct {
-		Argzone      string   `json:"zone"`
 		ArgaccountID types.ID `json:"accountID"`
 		Argyear      int      `json:"year"`
 		Argmonth     int      `json:"month"`
 	}{
-		Argzone:      zone,
 		ArgaccountID: accountID,
 		Argyear:      year,
 		Argmonth:     month,
@@ -751,7 +742,7 @@ func (t *BillTracer) ByContractYearMonth(ctx context.Context, zone string, accou
 		log.Println("[TRACE] BillAPI.ByContractYearMonth end")
 	}()
 
-	result, err := t.Internal.ByContractYearMonth(ctx, zone, accountID, year, month)
+	result, err := t.Internal.ByContractYearMonth(ctx, accountID, year, month)
 	targetResults := struct {
 		Result *sacloud.BillByContractYearMonthResult
 		Error  error
@@ -767,14 +758,12 @@ func (t *BillTracer) ByContractYearMonth(ctx context.Context, zone string, accou
 }
 
 // Read is API call with trace log
-func (t *BillTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.BillReadResult, error) {
+func (t *BillTracer) Read(ctx context.Context, id types.ID) (*sacloud.BillReadResult, error) {
 	log.Println("[TRACE] BillAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -784,7 +773,7 @@ func (t *BillTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 		log.Println("[TRACE] BillAPI.Read end")
 	}()
 
-	result, err := t.Internal.Read(ctx, zone, id)
+	result, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		Result *sacloud.BillReadResult
 		Error  error
@@ -800,14 +789,12 @@ func (t *BillTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 }
 
 // Details is API call with trace log
-func (t *BillTracer) Details(ctx context.Context, zone string, MemberCode string, id types.ID) (*sacloud.BillDetailsResult, error) {
+func (t *BillTracer) Details(ctx context.Context, MemberCode string, id types.ID) (*sacloud.BillDetailsResult, error) {
 	log.Println("[TRACE] BillAPI.Details start")
 	targetArguments := struct {
-		Argzone       string   `json:"zone"`
 		ArgMemberCode string   `json:"MemberCode"`
 		Argid         types.ID `json:"id"`
 	}{
-		Argzone:       zone,
 		ArgMemberCode: MemberCode,
 		Argid:         id,
 	}
@@ -819,7 +806,7 @@ func (t *BillTracer) Details(ctx context.Context, zone string, MemberCode string
 		log.Println("[TRACE] BillAPI.Details end")
 	}()
 
-	result, err := t.Internal.Details(ctx, zone, MemberCode, id)
+	result, err := t.Internal.Details(ctx, MemberCode, id)
 	targetResults := struct {
 		Result *sacloud.BillDetailsResult
 		Error  error
@@ -835,14 +822,12 @@ func (t *BillTracer) Details(ctx context.Context, zone string, MemberCode string
 }
 
 // DetailsCSV is API call with trace log
-func (t *BillTracer) DetailsCSV(ctx context.Context, zone string, MemberCode string, id types.ID) (*sacloud.BillDetailCSV, error) {
+func (t *BillTracer) DetailsCSV(ctx context.Context, MemberCode string, id types.ID) (*sacloud.BillDetailCSV, error) {
 	log.Println("[TRACE] BillAPI.DetailsCSV start")
 	targetArguments := struct {
-		Argzone       string   `json:"zone"`
 		ArgMemberCode string   `json:"MemberCode"`
 		Argid         types.ID `json:"id"`
 	}{
-		Argzone:       zone,
 		ArgMemberCode: MemberCode,
 		Argid:         id,
 	}
@@ -854,7 +839,7 @@ func (t *BillTracer) DetailsCSV(ctx context.Context, zone string, MemberCode str
 		log.Println("[TRACE] BillAPI.DetailsCSV end")
 	}()
 
-	resultBillDetailCSV, err := t.Internal.DetailsCSV(ctx, zone, MemberCode, id)
+	resultBillDetailCSV, err := t.Internal.DetailsCSV(ctx, MemberCode, id)
 	targetResults := struct {
 		BillDetailCSV *sacloud.BillDetailCSV
 		Error         error
@@ -889,7 +874,7 @@ func NewBridgeTracer(in sacloud.BridgeAPI) sacloud.BridgeAPI {
 func (t *BridgeTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.BridgeFindResult, error) {
 	log.Println("[TRACE] BridgeAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -922,7 +907,7 @@ func (t *BridgeTracer) Find(ctx context.Context, zone string, conditions *saclou
 func (t *BridgeTracer) Create(ctx context.Context, zone string, param *sacloud.BridgeCreateRequest) (*sacloud.Bridge, error) {
 	log.Println("[TRACE] BridgeAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                       `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.BridgeCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -955,7 +940,7 @@ func (t *BridgeTracer) Create(ctx context.Context, zone string, param *sacloud.B
 func (t *BridgeTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Bridge, error) {
 	log.Println("[TRACE] BridgeAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -988,7 +973,7 @@ func (t *BridgeTracer) Read(ctx context.Context, zone string, id types.ID) (*sac
 func (t *BridgeTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.BridgeUpdateRequest) (*sacloud.Bridge, error) {
 	log.Println("[TRACE] BridgeAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                       `json:"zone"`
+		Argzone  string
 		Argid    types.ID                     `json:"id"`
 		Argparam *sacloud.BridgeUpdateRequest `json:"param"`
 	}{
@@ -1023,7 +1008,7 @@ func (t *BridgeTracer) Update(ctx context.Context, zone string, id types.ID, par
 func (t *BridgeTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] BridgeAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1070,7 +1055,7 @@ func NewCDROMTracer(in sacloud.CDROMAPI) sacloud.CDROMAPI {
 func (t *CDROMTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.CDROMFindResult, error) {
 	log.Println("[TRACE] CDROMAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -1103,7 +1088,7 @@ func (t *CDROMTracer) Find(ctx context.Context, zone string, conditions *sacloud
 func (t *CDROMTracer) Create(ctx context.Context, zone string, param *sacloud.CDROMCreateRequest) (*sacloud.CDROM, *sacloud.FTPServer, error) {
 	log.Println("[TRACE] CDROMAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                      `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.CDROMCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -1138,7 +1123,7 @@ func (t *CDROMTracer) Create(ctx context.Context, zone string, param *sacloud.CD
 func (t *CDROMTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.CDROM, error) {
 	log.Println("[TRACE] CDROMAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1171,7 +1156,7 @@ func (t *CDROMTracer) Read(ctx context.Context, zone string, id types.ID) (*sacl
 func (t *CDROMTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.CDROMUpdateRequest) (*sacloud.CDROM, error) {
 	log.Println("[TRACE] CDROMAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                      `json:"zone"`
+		Argzone  string
 		Argid    types.ID                    `json:"id"`
 		Argparam *sacloud.CDROMUpdateRequest `json:"param"`
 	}{
@@ -1206,7 +1191,7 @@ func (t *CDROMTracer) Update(ctx context.Context, zone string, id types.ID, para
 func (t *CDROMTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] CDROMAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1237,7 +1222,7 @@ func (t *CDROMTracer) Delete(ctx context.Context, zone string, id types.ID) erro
 func (t *CDROMTracer) OpenFTP(ctx context.Context, zone string, id types.ID, openOption *sacloud.OpenFTPRequest) (*sacloud.FTPServer, error) {
 	log.Println("[TRACE] CDROMAPI.OpenFTP start")
 	targetArguments := struct {
-		Argzone       string                  `json:"zone"`
+		Argzone       string
 		Argid         types.ID                `json:"id"`
 		ArgopenOption *sacloud.OpenFTPRequest `json:"openOption"`
 	}{
@@ -1272,7 +1257,7 @@ func (t *CDROMTracer) OpenFTP(ctx context.Context, zone string, id types.ID, ope
 func (t *CDROMTracer) CloseFTP(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] CDROMAPI.CloseFTP start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1316,13 +1301,11 @@ func NewCouponTracer(in sacloud.CouponAPI) sacloud.CouponAPI {
 }
 
 // Find is API call with trace log
-func (t *CouponTracer) Find(ctx context.Context, zone string, accountID types.ID) (*sacloud.CouponFindResult, error) {
+func (t *CouponTracer) Find(ctx context.Context, accountID types.ID) (*sacloud.CouponFindResult, error) {
 	log.Println("[TRACE] CouponAPI.Find start")
 	targetArguments := struct {
-		Argzone      string   `json:"zone"`
 		ArgaccountID types.ID `json:"accountID"`
 	}{
-		Argzone:      zone,
 		ArgaccountID: accountID,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -1333,7 +1316,7 @@ func (t *CouponTracer) Find(ctx context.Context, zone string, accountID types.ID
 		log.Println("[TRACE] CouponAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, accountID)
+	result, err := t.Internal.Find(ctx, accountID)
 	targetResults := struct {
 		Result *sacloud.CouponFindResult
 		Error  error
@@ -1368,7 +1351,7 @@ func NewDatabaseTracer(in sacloud.DatabaseAPI) sacloud.DatabaseAPI {
 func (t *DatabaseTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.DatabaseFindResult, error) {
 	log.Println("[TRACE] DatabaseAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -1401,7 +1384,7 @@ func (t *DatabaseTracer) Find(ctx context.Context, zone string, conditions *sacl
 func (t *DatabaseTracer) Create(ctx context.Context, zone string, param *sacloud.DatabaseCreateRequest) (*sacloud.Database, error) {
 	log.Println("[TRACE] DatabaseAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                         `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.DatabaseCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -1434,7 +1417,7 @@ func (t *DatabaseTracer) Create(ctx context.Context, zone string, param *sacloud
 func (t *DatabaseTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Database, error) {
 	log.Println("[TRACE] DatabaseAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1467,7 +1450,7 @@ func (t *DatabaseTracer) Read(ctx context.Context, zone string, id types.ID) (*s
 func (t *DatabaseTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.DatabaseUpdateRequest) (*sacloud.Database, error) {
 	log.Println("[TRACE] DatabaseAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                         `json:"zone"`
+		Argzone  string
 		Argid    types.ID                       `json:"id"`
 		Argparam *sacloud.DatabaseUpdateRequest `json:"param"`
 	}{
@@ -1502,7 +1485,7 @@ func (t *DatabaseTracer) Update(ctx context.Context, zone string, id types.ID, p
 func (t *DatabaseTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] DatabaseAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1533,7 +1516,7 @@ func (t *DatabaseTracer) Delete(ctx context.Context, zone string, id types.ID) e
 func (t *DatabaseTracer) Config(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] DatabaseAPI.Config start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1564,7 +1547,7 @@ func (t *DatabaseTracer) Config(ctx context.Context, zone string, id types.ID) e
 func (t *DatabaseTracer) Boot(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] DatabaseAPI.Boot start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1595,7 +1578,7 @@ func (t *DatabaseTracer) Boot(ctx context.Context, zone string, id types.ID) err
 func (t *DatabaseTracer) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
 	log.Println("[TRACE] DatabaseAPI.Shutdown start")
 	targetArguments := struct {
-		Argzone           string                  `json:"zone"`
+		Argzone           string
 		Argid             types.ID                `json:"id"`
 		ArgshutdownOption *sacloud.ShutdownOption `json:"shutdownOption"`
 	}{
@@ -1628,7 +1611,7 @@ func (t *DatabaseTracer) Shutdown(ctx context.Context, zone string, id types.ID,
 func (t *DatabaseTracer) Reset(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] DatabaseAPI.Reset start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1659,7 +1642,7 @@ func (t *DatabaseTracer) Reset(ctx context.Context, zone string, id types.ID) er
 func (t *DatabaseTracer) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
 	log.Println("[TRACE] DatabaseAPI.MonitorCPU start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -1694,7 +1677,7 @@ func (t *DatabaseTracer) MonitorCPU(ctx context.Context, zone string, id types.I
 func (t *DatabaseTracer) MonitorDisk(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.DiskActivity, error) {
 	log.Println("[TRACE] DatabaseAPI.MonitorDisk start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -1729,7 +1712,7 @@ func (t *DatabaseTracer) MonitorDisk(ctx context.Context, zone string, id types.
 func (t *DatabaseTracer) MonitorInterface(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
 	log.Println("[TRACE] DatabaseAPI.MonitorInterface start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -1764,7 +1747,7 @@ func (t *DatabaseTracer) MonitorInterface(ctx context.Context, zone string, id t
 func (t *DatabaseTracer) MonitorDatabase(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.DatabaseActivity, error) {
 	log.Println("[TRACE] DatabaseAPI.MonitorDatabase start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -1799,7 +1782,7 @@ func (t *DatabaseTracer) MonitorDatabase(ctx context.Context, zone string, id ty
 func (t *DatabaseTracer) Status(ctx context.Context, zone string, id types.ID) (*sacloud.DatabaseStatus, error) {
 	log.Println("[TRACE] DatabaseAPI.Status start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -1848,7 +1831,7 @@ func NewDiskTracer(in sacloud.DiskAPI) sacloud.DiskAPI {
 func (t *DiskTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.DiskFindResult, error) {
 	log.Println("[TRACE] DiskAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -1881,7 +1864,7 @@ func (t *DiskTracer) Find(ctx context.Context, zone string, conditions *sacloud.
 func (t *DiskTracer) Create(ctx context.Context, zone string, param *sacloud.DiskCreateRequest) (*sacloud.Disk, error) {
 	log.Println("[TRACE] DiskAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                     `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.DiskCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -1914,7 +1897,7 @@ func (t *DiskTracer) Create(ctx context.Context, zone string, param *sacloud.Dis
 func (t *DiskTracer) CreateDistantly(ctx context.Context, zone string, createParam *sacloud.DiskCreateRequest, distantFrom []types.ID) (*sacloud.Disk, error) {
 	log.Println("[TRACE] DiskAPI.CreateDistantly start")
 	targetArguments := struct {
-		Argzone        string                     `json:"zone"`
+		Argzone        string
 		ArgcreateParam *sacloud.DiskCreateRequest `json:"createParam"`
 		ArgdistantFrom []types.ID                 `json:"distantFrom"`
 	}{
@@ -1949,7 +1932,7 @@ func (t *DiskTracer) CreateDistantly(ctx context.Context, zone string, createPar
 func (t *DiskTracer) Config(ctx context.Context, zone string, id types.ID, edit *sacloud.DiskEditRequest) error {
 	log.Println("[TRACE] DiskAPI.Config start")
 	targetArguments := struct {
-		Argzone string                   `json:"zone"`
+		Argzone string
 		Argid   types.ID                 `json:"id"`
 		Argedit *sacloud.DiskEditRequest `json:"edit"`
 	}{
@@ -1982,7 +1965,7 @@ func (t *DiskTracer) Config(ctx context.Context, zone string, id types.ID, edit 
 func (t *DiskTracer) CreateWithConfig(ctx context.Context, zone string, createParam *sacloud.DiskCreateRequest, editParam *sacloud.DiskEditRequest, bootAtAvailable bool) (*sacloud.Disk, error) {
 	log.Println("[TRACE] DiskAPI.CreateWithConfig start")
 	targetArguments := struct {
-		Argzone            string                     `json:"zone"`
+		Argzone            string
 		ArgcreateParam     *sacloud.DiskCreateRequest `json:"createParam"`
 		ArgeditParam       *sacloud.DiskEditRequest   `json:"editParam"`
 		ArgbootAtAvailable bool                       `json:"bootAtAvailable"`
@@ -2019,7 +2002,7 @@ func (t *DiskTracer) CreateWithConfig(ctx context.Context, zone string, createPa
 func (t *DiskTracer) CreateWithConfigDistantly(ctx context.Context, zone string, createParam *sacloud.DiskCreateRequest, editParam *sacloud.DiskEditRequest, bootAtAvailable bool, distantFrom []types.ID) (*sacloud.Disk, error) {
 	log.Println("[TRACE] DiskAPI.CreateWithConfigDistantly start")
 	targetArguments := struct {
-		Argzone            string                     `json:"zone"`
+		Argzone            string
 		ArgcreateParam     *sacloud.DiskCreateRequest `json:"createParam"`
 		ArgeditParam       *sacloud.DiskEditRequest   `json:"editParam"`
 		ArgbootAtAvailable bool                       `json:"bootAtAvailable"`
@@ -2058,7 +2041,7 @@ func (t *DiskTracer) CreateWithConfigDistantly(ctx context.Context, zone string,
 func (t *DiskTracer) ToBlank(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] DiskAPI.ToBlank start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -2089,7 +2072,7 @@ func (t *DiskTracer) ToBlank(ctx context.Context, zone string, id types.ID) erro
 func (t *DiskTracer) ResizePartition(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] DiskAPI.ResizePartition start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -2120,7 +2103,7 @@ func (t *DiskTracer) ResizePartition(ctx context.Context, zone string, id types.
 func (t *DiskTracer) ConnectToServer(ctx context.Context, zone string, id types.ID, serverID types.ID) error {
 	log.Println("[TRACE] DiskAPI.ConnectToServer start")
 	targetArguments := struct {
-		Argzone     string   `json:"zone"`
+		Argzone     string
 		Argid       types.ID `json:"id"`
 		ArgserverID types.ID `json:"serverID"`
 	}{
@@ -2153,7 +2136,7 @@ func (t *DiskTracer) ConnectToServer(ctx context.Context, zone string, id types.
 func (t *DiskTracer) DisconnectFromServer(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] DiskAPI.DisconnectFromServer start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -2184,7 +2167,7 @@ func (t *DiskTracer) DisconnectFromServer(ctx context.Context, zone string, id t
 func (t *DiskTracer) InstallDistantFrom(ctx context.Context, zone string, id types.ID, installParam *sacloud.DiskInstallRequest, distantFrom []types.ID) (*sacloud.Disk, error) {
 	log.Println("[TRACE] DiskAPI.InstallDistantFrom start")
 	targetArguments := struct {
-		Argzone         string                      `json:"zone"`
+		Argzone         string
 		Argid           types.ID                    `json:"id"`
 		ArginstallParam *sacloud.DiskInstallRequest `json:"installParam"`
 		ArgdistantFrom  []types.ID                  `json:"distantFrom"`
@@ -2221,7 +2204,7 @@ func (t *DiskTracer) InstallDistantFrom(ctx context.Context, zone string, id typ
 func (t *DiskTracer) Install(ctx context.Context, zone string, id types.ID, installParam *sacloud.DiskInstallRequest) (*sacloud.Disk, error) {
 	log.Println("[TRACE] DiskAPI.Install start")
 	targetArguments := struct {
-		Argzone         string                      `json:"zone"`
+		Argzone         string
 		Argid           types.ID                    `json:"id"`
 		ArginstallParam *sacloud.DiskInstallRequest `json:"installParam"`
 	}{
@@ -2256,7 +2239,7 @@ func (t *DiskTracer) Install(ctx context.Context, zone string, id types.ID, inst
 func (t *DiskTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Disk, error) {
 	log.Println("[TRACE] DiskAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -2289,7 +2272,7 @@ func (t *DiskTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 func (t *DiskTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.DiskUpdateRequest) (*sacloud.Disk, error) {
 	log.Println("[TRACE] DiskAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                     `json:"zone"`
+		Argzone  string
 		Argid    types.ID                   `json:"id"`
 		Argparam *sacloud.DiskUpdateRequest `json:"param"`
 	}{
@@ -2324,7 +2307,7 @@ func (t *DiskTracer) Update(ctx context.Context, zone string, id types.ID, param
 func (t *DiskTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] DiskAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -2355,7 +2338,7 @@ func (t *DiskTracer) Delete(ctx context.Context, zone string, id types.ID) error
 func (t *DiskTracer) Monitor(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.DiskActivity, error) {
 	log.Println("[TRACE] DiskAPI.Monitor start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -2406,7 +2389,7 @@ func NewDiskPlanTracer(in sacloud.DiskPlanAPI) sacloud.DiskPlanAPI {
 func (t *DiskPlanTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.DiskPlanFindResult, error) {
 	log.Println("[TRACE] DiskPlanAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -2439,7 +2422,7 @@ func (t *DiskPlanTracer) Find(ctx context.Context, zone string, conditions *sacl
 func (t *DiskPlanTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.DiskPlan, error) {
 	log.Println("[TRACE] DiskPlanAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -2485,13 +2468,11 @@ func NewDNSTracer(in sacloud.DNSAPI) sacloud.DNSAPI {
 }
 
 // Find is API call with trace log
-func (t *DNSTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.DNSFindResult, error) {
+func (t *DNSTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.DNSFindResult, error) {
 	log.Println("[TRACE] DNSAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -2502,7 +2483,7 @@ func (t *DNSTracer) Find(ctx context.Context, zone string, conditions *sacloud.F
 		log.Println("[TRACE] DNSAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.DNSFindResult
 		Error  error
@@ -2518,13 +2499,11 @@ func (t *DNSTracer) Find(ctx context.Context, zone string, conditions *sacloud.F
 }
 
 // Create is API call with trace log
-func (t *DNSTracer) Create(ctx context.Context, zone string, param *sacloud.DNSCreateRequest) (*sacloud.DNS, error) {
+func (t *DNSTracer) Create(ctx context.Context, param *sacloud.DNSCreateRequest) (*sacloud.DNS, error) {
 	log.Println("[TRACE] DNSAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                    `json:"zone"`
 		Argparam *sacloud.DNSCreateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -2535,7 +2514,7 @@ func (t *DNSTracer) Create(ctx context.Context, zone string, param *sacloud.DNSC
 		log.Println("[TRACE] DNSAPI.Create end")
 	}()
 
-	resultDNS, err := t.Internal.Create(ctx, zone, param)
+	resultDNS, err := t.Internal.Create(ctx, param)
 	targetResults := struct {
 		DNS   *sacloud.DNS
 		Error error
@@ -2551,14 +2530,12 @@ func (t *DNSTracer) Create(ctx context.Context, zone string, param *sacloud.DNSC
 }
 
 // Read is API call with trace log
-func (t *DNSTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.DNS, error) {
+func (t *DNSTracer) Read(ctx context.Context, id types.ID) (*sacloud.DNS, error) {
 	log.Println("[TRACE] DNSAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -2568,7 +2545,7 @@ func (t *DNSTracer) Read(ctx context.Context, zone string, id types.ID) (*saclou
 		log.Println("[TRACE] DNSAPI.Read end")
 	}()
 
-	resultDNS, err := t.Internal.Read(ctx, zone, id)
+	resultDNS, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		DNS   *sacloud.DNS
 		Error error
@@ -2584,14 +2561,12 @@ func (t *DNSTracer) Read(ctx context.Context, zone string, id types.ID) (*saclou
 }
 
 // Update is API call with trace log
-func (t *DNSTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.DNSUpdateRequest) (*sacloud.DNS, error) {
+func (t *DNSTracer) Update(ctx context.Context, id types.ID, param *sacloud.DNSUpdateRequest) (*sacloud.DNS, error) {
 	log.Println("[TRACE] DNSAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                    `json:"zone"`
 		Argid    types.ID                  `json:"id"`
 		Argparam *sacloud.DNSUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -2603,7 +2578,7 @@ func (t *DNSTracer) Update(ctx context.Context, zone string, id types.ID, param 
 		log.Println("[TRACE] DNSAPI.Update end")
 	}()
 
-	resultDNS, err := t.Internal.Update(ctx, zone, id, param)
+	resultDNS, err := t.Internal.Update(ctx, id, param)
 	targetResults := struct {
 		DNS   *sacloud.DNS
 		Error error
@@ -2619,14 +2594,12 @@ func (t *DNSTracer) Update(ctx context.Context, zone string, id types.ID, param 
 }
 
 // Delete is API call with trace log
-func (t *DNSTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+func (t *DNSTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] DNSAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -2636,7 +2609,7 @@ func (t *DNSTracer) Delete(ctx context.Context, zone string, id types.ID) error 
 		log.Println("[TRACE] DNSAPI.Delete end")
 	}()
 
-	err := t.Internal.Delete(ctx, zone, id)
+	err := t.Internal.Delete(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -2666,13 +2639,11 @@ func NewGSLBTracer(in sacloud.GSLBAPI) sacloud.GSLBAPI {
 }
 
 // Find is API call with trace log
-func (t *GSLBTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.GSLBFindResult, error) {
+func (t *GSLBTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.GSLBFindResult, error) {
 	log.Println("[TRACE] GSLBAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -2683,7 +2654,7 @@ func (t *GSLBTracer) Find(ctx context.Context, zone string, conditions *sacloud.
 		log.Println("[TRACE] GSLBAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.GSLBFindResult
 		Error  error
@@ -2699,13 +2670,11 @@ func (t *GSLBTracer) Find(ctx context.Context, zone string, conditions *sacloud.
 }
 
 // Create is API call with trace log
-func (t *GSLBTracer) Create(ctx context.Context, zone string, param *sacloud.GSLBCreateRequest) (*sacloud.GSLB, error) {
+func (t *GSLBTracer) Create(ctx context.Context, param *sacloud.GSLBCreateRequest) (*sacloud.GSLB, error) {
 	log.Println("[TRACE] GSLBAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                     `json:"zone"`
 		Argparam *sacloud.GSLBCreateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -2716,7 +2685,7 @@ func (t *GSLBTracer) Create(ctx context.Context, zone string, param *sacloud.GSL
 		log.Println("[TRACE] GSLBAPI.Create end")
 	}()
 
-	resultGSLB, err := t.Internal.Create(ctx, zone, param)
+	resultGSLB, err := t.Internal.Create(ctx, param)
 	targetResults := struct {
 		GSLB  *sacloud.GSLB
 		Error error
@@ -2732,14 +2701,12 @@ func (t *GSLBTracer) Create(ctx context.Context, zone string, param *sacloud.GSL
 }
 
 // Read is API call with trace log
-func (t *GSLBTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.GSLB, error) {
+func (t *GSLBTracer) Read(ctx context.Context, id types.ID) (*sacloud.GSLB, error) {
 	log.Println("[TRACE] GSLBAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -2749,7 +2716,7 @@ func (t *GSLBTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 		log.Println("[TRACE] GSLBAPI.Read end")
 	}()
 
-	resultGSLB, err := t.Internal.Read(ctx, zone, id)
+	resultGSLB, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		GSLB  *sacloud.GSLB
 		Error error
@@ -2765,14 +2732,12 @@ func (t *GSLBTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 }
 
 // Update is API call with trace log
-func (t *GSLBTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.GSLBUpdateRequest) (*sacloud.GSLB, error) {
+func (t *GSLBTracer) Update(ctx context.Context, id types.ID, param *sacloud.GSLBUpdateRequest) (*sacloud.GSLB, error) {
 	log.Println("[TRACE] GSLBAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                     `json:"zone"`
 		Argid    types.ID                   `json:"id"`
 		Argparam *sacloud.GSLBUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -2784,7 +2749,7 @@ func (t *GSLBTracer) Update(ctx context.Context, zone string, id types.ID, param
 		log.Println("[TRACE] GSLBAPI.Update end")
 	}()
 
-	resultGSLB, err := t.Internal.Update(ctx, zone, id, param)
+	resultGSLB, err := t.Internal.Update(ctx, id, param)
 	targetResults := struct {
 		GSLB  *sacloud.GSLB
 		Error error
@@ -2800,14 +2765,12 @@ func (t *GSLBTracer) Update(ctx context.Context, zone string, id types.ID, param
 }
 
 // Delete is API call with trace log
-func (t *GSLBTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+func (t *GSLBTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] GSLBAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -2817,7 +2780,7 @@ func (t *GSLBTracer) Delete(ctx context.Context, zone string, id types.ID) error
 		log.Println("[TRACE] GSLBAPI.Delete end")
 	}()
 
-	err := t.Internal.Delete(ctx, zone, id)
+	err := t.Internal.Delete(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -2847,13 +2810,11 @@ func NewIconTracer(in sacloud.IconAPI) sacloud.IconAPI {
 }
 
 // Find is API call with trace log
-func (t *IconTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.IconFindResult, error) {
+func (t *IconTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.IconFindResult, error) {
 	log.Println("[TRACE] IconAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -2864,7 +2825,7 @@ func (t *IconTracer) Find(ctx context.Context, zone string, conditions *sacloud.
 		log.Println("[TRACE] IconAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.IconFindResult
 		Error  error
@@ -2880,13 +2841,11 @@ func (t *IconTracer) Find(ctx context.Context, zone string, conditions *sacloud.
 }
 
 // Create is API call with trace log
-func (t *IconTracer) Create(ctx context.Context, zone string, param *sacloud.IconCreateRequest) (*sacloud.Icon, error) {
+func (t *IconTracer) Create(ctx context.Context, param *sacloud.IconCreateRequest) (*sacloud.Icon, error) {
 	log.Println("[TRACE] IconAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                     `json:"zone"`
 		Argparam *sacloud.IconCreateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -2897,7 +2856,7 @@ func (t *IconTracer) Create(ctx context.Context, zone string, param *sacloud.Ico
 		log.Println("[TRACE] IconAPI.Create end")
 	}()
 
-	resultIcon, err := t.Internal.Create(ctx, zone, param)
+	resultIcon, err := t.Internal.Create(ctx, param)
 	targetResults := struct {
 		Icon  *sacloud.Icon
 		Error error
@@ -2913,14 +2872,12 @@ func (t *IconTracer) Create(ctx context.Context, zone string, param *sacloud.Ico
 }
 
 // Read is API call with trace log
-func (t *IconTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Icon, error) {
+func (t *IconTracer) Read(ctx context.Context, id types.ID) (*sacloud.Icon, error) {
 	log.Println("[TRACE] IconAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -2930,7 +2887,7 @@ func (t *IconTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 		log.Println("[TRACE] IconAPI.Read end")
 	}()
 
-	resultIcon, err := t.Internal.Read(ctx, zone, id)
+	resultIcon, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		Icon  *sacloud.Icon
 		Error error
@@ -2946,14 +2903,12 @@ func (t *IconTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 }
 
 // Update is API call with trace log
-func (t *IconTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.IconUpdateRequest) (*sacloud.Icon, error) {
+func (t *IconTracer) Update(ctx context.Context, id types.ID, param *sacloud.IconUpdateRequest) (*sacloud.Icon, error) {
 	log.Println("[TRACE] IconAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                     `json:"zone"`
 		Argid    types.ID                   `json:"id"`
 		Argparam *sacloud.IconUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -2965,7 +2920,7 @@ func (t *IconTracer) Update(ctx context.Context, zone string, id types.ID, param
 		log.Println("[TRACE] IconAPI.Update end")
 	}()
 
-	resultIcon, err := t.Internal.Update(ctx, zone, id, param)
+	resultIcon, err := t.Internal.Update(ctx, id, param)
 	targetResults := struct {
 		Icon  *sacloud.Icon
 		Error error
@@ -2981,14 +2936,12 @@ func (t *IconTracer) Update(ctx context.Context, zone string, id types.ID, param
 }
 
 // Delete is API call with trace log
-func (t *IconTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+func (t *IconTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] IconAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -2998,7 +2951,7 @@ func (t *IconTracer) Delete(ctx context.Context, zone string, id types.ID) error
 		log.Println("[TRACE] IconAPI.Delete end")
 	}()
 
-	err := t.Internal.Delete(ctx, zone, id)
+	err := t.Internal.Delete(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -3031,7 +2984,7 @@ func NewInterfaceTracer(in sacloud.InterfaceAPI) sacloud.InterfaceAPI {
 func (t *InterfaceTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.InterfaceFindResult, error) {
 	log.Println("[TRACE] InterfaceAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -3064,7 +3017,7 @@ func (t *InterfaceTracer) Find(ctx context.Context, zone string, conditions *sac
 func (t *InterfaceTracer) Create(ctx context.Context, zone string, param *sacloud.InterfaceCreateRequest) (*sacloud.Interface, error) {
 	log.Println("[TRACE] InterfaceAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                          `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.InterfaceCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -3097,7 +3050,7 @@ func (t *InterfaceTracer) Create(ctx context.Context, zone string, param *saclou
 func (t *InterfaceTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Interface, error) {
 	log.Println("[TRACE] InterfaceAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -3130,7 +3083,7 @@ func (t *InterfaceTracer) Read(ctx context.Context, zone string, id types.ID) (*
 func (t *InterfaceTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.InterfaceUpdateRequest) (*sacloud.Interface, error) {
 	log.Println("[TRACE] InterfaceAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                          `json:"zone"`
+		Argzone  string
 		Argid    types.ID                        `json:"id"`
 		Argparam *sacloud.InterfaceUpdateRequest `json:"param"`
 	}{
@@ -3165,7 +3118,7 @@ func (t *InterfaceTracer) Update(ctx context.Context, zone string, id types.ID, 
 func (t *InterfaceTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] InterfaceAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -3196,7 +3149,7 @@ func (t *InterfaceTracer) Delete(ctx context.Context, zone string, id types.ID) 
 func (t *InterfaceTracer) Monitor(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
 	log.Println("[TRACE] InterfaceAPI.Monitor start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -3231,7 +3184,7 @@ func (t *InterfaceTracer) Monitor(ctx context.Context, zone string, id types.ID,
 func (t *InterfaceTracer) ConnectToSharedSegment(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] InterfaceAPI.ConnectToSharedSegment start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -3262,7 +3215,7 @@ func (t *InterfaceTracer) ConnectToSharedSegment(ctx context.Context, zone strin
 func (t *InterfaceTracer) ConnectToSwitch(ctx context.Context, zone string, id types.ID, switchID types.ID) error {
 	log.Println("[TRACE] InterfaceAPI.ConnectToSwitch start")
 	targetArguments := struct {
-		Argzone     string   `json:"zone"`
+		Argzone     string
 		Argid       types.ID `json:"id"`
 		ArgswitchID types.ID `json:"switchID"`
 	}{
@@ -3295,7 +3248,7 @@ func (t *InterfaceTracer) ConnectToSwitch(ctx context.Context, zone string, id t
 func (t *InterfaceTracer) DisconnectFromSwitch(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] InterfaceAPI.DisconnectFromSwitch start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -3326,7 +3279,7 @@ func (t *InterfaceTracer) DisconnectFromSwitch(ctx context.Context, zone string,
 func (t *InterfaceTracer) ConnectToPacketFilter(ctx context.Context, zone string, id types.ID, packetFilterID types.ID) error {
 	log.Println("[TRACE] InterfaceAPI.ConnectToPacketFilter start")
 	targetArguments := struct {
-		Argzone           string   `json:"zone"`
+		Argzone           string
 		Argid             types.ID `json:"id"`
 		ArgpacketFilterID types.ID `json:"packetFilterID"`
 	}{
@@ -3359,7 +3312,7 @@ func (t *InterfaceTracer) ConnectToPacketFilter(ctx context.Context, zone string
 func (t *InterfaceTracer) DisconnectFromPacketFilter(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] InterfaceAPI.DisconnectFromPacketFilter start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -3406,7 +3359,7 @@ func NewInternetTracer(in sacloud.InternetAPI) sacloud.InternetAPI {
 func (t *InternetTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.InternetFindResult, error) {
 	log.Println("[TRACE] InternetAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -3439,7 +3392,7 @@ func (t *InternetTracer) Find(ctx context.Context, zone string, conditions *sacl
 func (t *InternetTracer) Create(ctx context.Context, zone string, param *sacloud.InternetCreateRequest) (*sacloud.Internet, error) {
 	log.Println("[TRACE] InternetAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                         `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.InternetCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -3472,7 +3425,7 @@ func (t *InternetTracer) Create(ctx context.Context, zone string, param *sacloud
 func (t *InternetTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Internet, error) {
 	log.Println("[TRACE] InternetAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -3505,7 +3458,7 @@ func (t *InternetTracer) Read(ctx context.Context, zone string, id types.ID) (*s
 func (t *InternetTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.InternetUpdateRequest) (*sacloud.Internet, error) {
 	log.Println("[TRACE] InternetAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                         `json:"zone"`
+		Argzone  string
 		Argid    types.ID                       `json:"id"`
 		Argparam *sacloud.InternetUpdateRequest `json:"param"`
 	}{
@@ -3540,7 +3493,7 @@ func (t *InternetTracer) Update(ctx context.Context, zone string, id types.ID, p
 func (t *InternetTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] InternetAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -3571,7 +3524,7 @@ func (t *InternetTracer) Delete(ctx context.Context, zone string, id types.ID) e
 func (t *InternetTracer) UpdateBandWidth(ctx context.Context, zone string, id types.ID, param *sacloud.InternetUpdateBandWidthRequest) (*sacloud.Internet, error) {
 	log.Println("[TRACE] InternetAPI.UpdateBandWidth start")
 	targetArguments := struct {
-		Argzone  string                                  `json:"zone"`
+		Argzone  string
 		Argid    types.ID                                `json:"id"`
 		Argparam *sacloud.InternetUpdateBandWidthRequest `json:"param"`
 	}{
@@ -3606,7 +3559,7 @@ func (t *InternetTracer) UpdateBandWidth(ctx context.Context, zone string, id ty
 func (t *InternetTracer) AddSubnet(ctx context.Context, zone string, id types.ID, param *sacloud.InternetAddSubnetRequest) (*sacloud.InternetSubnetOperationResult, error) {
 	log.Println("[TRACE] InternetAPI.AddSubnet start")
 	targetArguments := struct {
-		Argzone  string                            `json:"zone"`
+		Argzone  string
 		Argid    types.ID                          `json:"id"`
 		Argparam *sacloud.InternetAddSubnetRequest `json:"param"`
 	}{
@@ -3641,7 +3594,7 @@ func (t *InternetTracer) AddSubnet(ctx context.Context, zone string, id types.ID
 func (t *InternetTracer) UpdateSubnet(ctx context.Context, zone string, id types.ID, subnetID types.ID, param *sacloud.InternetUpdateSubnetRequest) (*sacloud.InternetSubnetOperationResult, error) {
 	log.Println("[TRACE] InternetAPI.UpdateSubnet start")
 	targetArguments := struct {
-		Argzone     string                               `json:"zone"`
+		Argzone     string
 		Argid       types.ID                             `json:"id"`
 		ArgsubnetID types.ID                             `json:"subnetID"`
 		Argparam    *sacloud.InternetUpdateSubnetRequest `json:"param"`
@@ -3678,7 +3631,7 @@ func (t *InternetTracer) UpdateSubnet(ctx context.Context, zone string, id types
 func (t *InternetTracer) DeleteSubnet(ctx context.Context, zone string, id types.ID, subnetID types.ID) error {
 	log.Println("[TRACE] InternetAPI.DeleteSubnet start")
 	targetArguments := struct {
-		Argzone     string   `json:"zone"`
+		Argzone     string
 		Argid       types.ID `json:"id"`
 		ArgsubnetID types.ID `json:"subnetID"`
 	}{
@@ -3711,7 +3664,7 @@ func (t *InternetTracer) DeleteSubnet(ctx context.Context, zone string, id types
 func (t *InternetTracer) Monitor(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.RouterActivity, error) {
 	log.Println("[TRACE] InternetAPI.Monitor start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -3746,7 +3699,7 @@ func (t *InternetTracer) Monitor(ctx context.Context, zone string, id types.ID, 
 func (t *InternetTracer) EnableIPv6(ctx context.Context, zone string, id types.ID) (*sacloud.IPv6NetInfo, error) {
 	log.Println("[TRACE] InternetAPI.EnableIPv6 start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -3779,7 +3732,7 @@ func (t *InternetTracer) EnableIPv6(ctx context.Context, zone string, id types.I
 func (t *InternetTracer) DisableIPv6(ctx context.Context, zone string, id types.ID, ipv6netID types.ID) error {
 	log.Println("[TRACE] InternetAPI.DisableIPv6 start")
 	targetArguments := struct {
-		Argzone      string   `json:"zone"`
+		Argzone      string
 		Argid        types.ID `json:"id"`
 		Argipv6netID types.ID `json:"ipv6netID"`
 	}{
@@ -3828,7 +3781,7 @@ func NewInternetPlanTracer(in sacloud.InternetPlanAPI) sacloud.InternetPlanAPI {
 func (t *InternetPlanTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.InternetPlanFindResult, error) {
 	log.Println("[TRACE] InternetPlanAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -3861,7 +3814,7 @@ func (t *InternetPlanTracer) Find(ctx context.Context, zone string, conditions *
 func (t *InternetPlanTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.InternetPlan, error) {
 	log.Println("[TRACE] InternetPlanAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -3910,7 +3863,7 @@ func NewIPAddressTracer(in sacloud.IPAddressAPI) sacloud.IPAddressAPI {
 func (t *IPAddressTracer) List(ctx context.Context, zone string) (*sacloud.IPAddressListResult, error) {
 	log.Println("[TRACE] IPAddressAPI.List start")
 	targetArguments := struct {
-		Argzone string `json:"zone"`
+		Argzone string
 	}{
 		Argzone: zone,
 	}
@@ -3941,7 +3894,7 @@ func (t *IPAddressTracer) List(ctx context.Context, zone string) (*sacloud.IPAdd
 func (t *IPAddressTracer) Read(ctx context.Context, zone string, ipAddress string) (*sacloud.IPAddress, error) {
 	log.Println("[TRACE] IPAddressAPI.Read start")
 	targetArguments := struct {
-		Argzone      string `json:"zone"`
+		Argzone      string
 		ArgipAddress string `json:"ipAddress"`
 	}{
 		Argzone:      zone,
@@ -3974,7 +3927,7 @@ func (t *IPAddressTracer) Read(ctx context.Context, zone string, ipAddress strin
 func (t *IPAddressTracer) UpdateHostName(ctx context.Context, zone string, ipAddress string, hostName string) (*sacloud.IPAddress, error) {
 	log.Println("[TRACE] IPAddressAPI.UpdateHostName start")
 	targetArguments := struct {
-		Argzone      string `json:"zone"`
+		Argzone      string
 		ArgipAddress string `json:"ipAddress"`
 		ArghostName  string `json:"hostName"`
 	}{
@@ -4025,7 +3978,7 @@ func NewIPv6NetTracer(in sacloud.IPv6NetAPI) sacloud.IPv6NetAPI {
 func (t *IPv6NetTracer) List(ctx context.Context, zone string) (*sacloud.IPv6NetListResult, error) {
 	log.Println("[TRACE] IPv6NetAPI.List start")
 	targetArguments := struct {
-		Argzone string `json:"zone"`
+		Argzone string
 	}{
 		Argzone: zone,
 	}
@@ -4056,7 +4009,7 @@ func (t *IPv6NetTracer) List(ctx context.Context, zone string) (*sacloud.IPv6Net
 func (t *IPv6NetTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.IPv6Net, error) {
 	log.Println("[TRACE] IPv6NetAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -4105,7 +4058,7 @@ func NewIPv6AddrTracer(in sacloud.IPv6AddrAPI) sacloud.IPv6AddrAPI {
 func (t *IPv6AddrTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.IPv6AddrFindResult, error) {
 	log.Println("[TRACE] IPv6AddrAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -4138,7 +4091,7 @@ func (t *IPv6AddrTracer) Find(ctx context.Context, zone string, conditions *sacl
 func (t *IPv6AddrTracer) Create(ctx context.Context, zone string, param *sacloud.IPv6AddrCreateRequest) (*sacloud.IPv6Addr, error) {
 	log.Println("[TRACE] IPv6AddrAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                         `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.IPv6AddrCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -4171,7 +4124,7 @@ func (t *IPv6AddrTracer) Create(ctx context.Context, zone string, param *sacloud
 func (t *IPv6AddrTracer) Read(ctx context.Context, zone string, ipv6addr string) (*sacloud.IPv6Addr, error) {
 	log.Println("[TRACE] IPv6AddrAPI.Read start")
 	targetArguments := struct {
-		Argzone     string `json:"zone"`
+		Argzone     string
 		Argipv6addr string `json:"ipv6addr"`
 	}{
 		Argzone:     zone,
@@ -4204,7 +4157,7 @@ func (t *IPv6AddrTracer) Read(ctx context.Context, zone string, ipv6addr string)
 func (t *IPv6AddrTracer) Update(ctx context.Context, zone string, ipv6addr string, param *sacloud.IPv6AddrUpdateRequest) (*sacloud.IPv6Addr, error) {
 	log.Println("[TRACE] IPv6AddrAPI.Update start")
 	targetArguments := struct {
-		Argzone     string                         `json:"zone"`
+		Argzone     string
 		Argipv6addr string                         `json:"ipv6addr"`
 		Argparam    *sacloud.IPv6AddrUpdateRequest `json:"param"`
 	}{
@@ -4239,7 +4192,7 @@ func (t *IPv6AddrTracer) Update(ctx context.Context, zone string, ipv6addr strin
 func (t *IPv6AddrTracer) Delete(ctx context.Context, zone string, ipv6addr string) error {
 	log.Println("[TRACE] IPv6AddrAPI.Delete start")
 	targetArguments := struct {
-		Argzone     string `json:"zone"`
+		Argzone     string
 		Argipv6addr string `json:"ipv6addr"`
 	}{
 		Argzone:     zone,
@@ -4283,13 +4236,11 @@ func NewLicenseTracer(in sacloud.LicenseAPI) sacloud.LicenseAPI {
 }
 
 // Find is API call with trace log
-func (t *LicenseTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.LicenseFindResult, error) {
+func (t *LicenseTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LicenseFindResult, error) {
 	log.Println("[TRACE] LicenseAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -4300,7 +4251,7 @@ func (t *LicenseTracer) Find(ctx context.Context, zone string, conditions *saclo
 		log.Println("[TRACE] LicenseAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.LicenseFindResult
 		Error  error
@@ -4316,13 +4267,11 @@ func (t *LicenseTracer) Find(ctx context.Context, zone string, conditions *saclo
 }
 
 // Create is API call with trace log
-func (t *LicenseTracer) Create(ctx context.Context, zone string, param *sacloud.LicenseCreateRequest) (*sacloud.License, error) {
+func (t *LicenseTracer) Create(ctx context.Context, param *sacloud.LicenseCreateRequest) (*sacloud.License, error) {
 	log.Println("[TRACE] LicenseAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                        `json:"zone"`
 		Argparam *sacloud.LicenseCreateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -4333,7 +4282,7 @@ func (t *LicenseTracer) Create(ctx context.Context, zone string, param *sacloud.
 		log.Println("[TRACE] LicenseAPI.Create end")
 	}()
 
-	resultLicense, err := t.Internal.Create(ctx, zone, param)
+	resultLicense, err := t.Internal.Create(ctx, param)
 	targetResults := struct {
 		License *sacloud.License
 		Error   error
@@ -4349,14 +4298,12 @@ func (t *LicenseTracer) Create(ctx context.Context, zone string, param *sacloud.
 }
 
 // Read is API call with trace log
-func (t *LicenseTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.License, error) {
+func (t *LicenseTracer) Read(ctx context.Context, id types.ID) (*sacloud.License, error) {
 	log.Println("[TRACE] LicenseAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -4366,7 +4313,7 @@ func (t *LicenseTracer) Read(ctx context.Context, zone string, id types.ID) (*sa
 		log.Println("[TRACE] LicenseAPI.Read end")
 	}()
 
-	resultLicense, err := t.Internal.Read(ctx, zone, id)
+	resultLicense, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		License *sacloud.License
 		Error   error
@@ -4382,14 +4329,12 @@ func (t *LicenseTracer) Read(ctx context.Context, zone string, id types.ID) (*sa
 }
 
 // Update is API call with trace log
-func (t *LicenseTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.LicenseUpdateRequest) (*sacloud.License, error) {
+func (t *LicenseTracer) Update(ctx context.Context, id types.ID, param *sacloud.LicenseUpdateRequest) (*sacloud.License, error) {
 	log.Println("[TRACE] LicenseAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                        `json:"zone"`
 		Argid    types.ID                      `json:"id"`
 		Argparam *sacloud.LicenseUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -4401,7 +4346,7 @@ func (t *LicenseTracer) Update(ctx context.Context, zone string, id types.ID, pa
 		log.Println("[TRACE] LicenseAPI.Update end")
 	}()
 
-	resultLicense, err := t.Internal.Update(ctx, zone, id, param)
+	resultLicense, err := t.Internal.Update(ctx, id, param)
 	targetResults := struct {
 		License *sacloud.License
 		Error   error
@@ -4417,14 +4362,12 @@ func (t *LicenseTracer) Update(ctx context.Context, zone string, id types.ID, pa
 }
 
 // Delete is API call with trace log
-func (t *LicenseTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+func (t *LicenseTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] LicenseAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -4434,7 +4377,7 @@ func (t *LicenseTracer) Delete(ctx context.Context, zone string, id types.ID) er
 		log.Println("[TRACE] LicenseAPI.Delete end")
 	}()
 
-	err := t.Internal.Delete(ctx, zone, id)
+	err := t.Internal.Delete(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -4464,13 +4407,11 @@ func NewLicenseInfoTracer(in sacloud.LicenseInfoAPI) sacloud.LicenseInfoAPI {
 }
 
 // Find is API call with trace log
-func (t *LicenseInfoTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.LicenseInfoFindResult, error) {
+func (t *LicenseInfoTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LicenseInfoFindResult, error) {
 	log.Println("[TRACE] LicenseInfoAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -4481,7 +4422,7 @@ func (t *LicenseInfoTracer) Find(ctx context.Context, zone string, conditions *s
 		log.Println("[TRACE] LicenseInfoAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.LicenseInfoFindResult
 		Error  error
@@ -4497,14 +4438,12 @@ func (t *LicenseInfoTracer) Find(ctx context.Context, zone string, conditions *s
 }
 
 // Read is API call with trace log
-func (t *LicenseInfoTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.LicenseInfo, error) {
+func (t *LicenseInfoTracer) Read(ctx context.Context, id types.ID) (*sacloud.LicenseInfo, error) {
 	log.Println("[TRACE] LicenseInfoAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -4514,7 +4453,7 @@ func (t *LicenseInfoTracer) Read(ctx context.Context, zone string, id types.ID) 
 		log.Println("[TRACE] LicenseInfoAPI.Read end")
 	}()
 
-	resultLicenseInfo, err := t.Internal.Read(ctx, zone, id)
+	resultLicenseInfo, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		LicenseInfo *sacloud.LicenseInfo
 		Error       error
@@ -4549,7 +4488,7 @@ func NewLoadBalancerTracer(in sacloud.LoadBalancerAPI) sacloud.LoadBalancerAPI {
 func (t *LoadBalancerTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.LoadBalancerFindResult, error) {
 	log.Println("[TRACE] LoadBalancerAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -4582,7 +4521,7 @@ func (t *LoadBalancerTracer) Find(ctx context.Context, zone string, conditions *
 func (t *LoadBalancerTracer) Create(ctx context.Context, zone string, param *sacloud.LoadBalancerCreateRequest) (*sacloud.LoadBalancer, error) {
 	log.Println("[TRACE] LoadBalancerAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                             `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.LoadBalancerCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -4615,7 +4554,7 @@ func (t *LoadBalancerTracer) Create(ctx context.Context, zone string, param *sac
 func (t *LoadBalancerTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.LoadBalancer, error) {
 	log.Println("[TRACE] LoadBalancerAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -4648,7 +4587,7 @@ func (t *LoadBalancerTracer) Read(ctx context.Context, zone string, id types.ID)
 func (t *LoadBalancerTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerUpdateRequest) (*sacloud.LoadBalancer, error) {
 	log.Println("[TRACE] LoadBalancerAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                             `json:"zone"`
+		Argzone  string
 		Argid    types.ID                           `json:"id"`
 		Argparam *sacloud.LoadBalancerUpdateRequest `json:"param"`
 	}{
@@ -4683,7 +4622,7 @@ func (t *LoadBalancerTracer) Update(ctx context.Context, zone string, id types.I
 func (t *LoadBalancerTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] LoadBalancerAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -4714,7 +4653,7 @@ func (t *LoadBalancerTracer) Delete(ctx context.Context, zone string, id types.I
 func (t *LoadBalancerTracer) Config(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] LoadBalancerAPI.Config start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -4745,7 +4684,7 @@ func (t *LoadBalancerTracer) Config(ctx context.Context, zone string, id types.I
 func (t *LoadBalancerTracer) Boot(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] LoadBalancerAPI.Boot start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -4776,7 +4715,7 @@ func (t *LoadBalancerTracer) Boot(ctx context.Context, zone string, id types.ID)
 func (t *LoadBalancerTracer) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
 	log.Println("[TRACE] LoadBalancerAPI.Shutdown start")
 	targetArguments := struct {
-		Argzone           string                  `json:"zone"`
+		Argzone           string
 		Argid             types.ID                `json:"id"`
 		ArgshutdownOption *sacloud.ShutdownOption `json:"shutdownOption"`
 	}{
@@ -4809,7 +4748,7 @@ func (t *LoadBalancerTracer) Shutdown(ctx context.Context, zone string, id types
 func (t *LoadBalancerTracer) Reset(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] LoadBalancerAPI.Reset start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -4840,7 +4779,7 @@ func (t *LoadBalancerTracer) Reset(ctx context.Context, zone string, id types.ID
 func (t *LoadBalancerTracer) MonitorInterface(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
 	log.Println("[TRACE] LoadBalancerAPI.MonitorInterface start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -4875,7 +4814,7 @@ func (t *LoadBalancerTracer) MonitorInterface(ctx context.Context, zone string, 
 func (t *LoadBalancerTracer) Status(ctx context.Context, zone string, id types.ID) (*sacloud.LoadBalancerStatusResult, error) {
 	log.Println("[TRACE] LoadBalancerAPI.Status start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -4924,7 +4863,7 @@ func NewMobileGatewayTracer(in sacloud.MobileGatewayAPI) sacloud.MobileGatewayAP
 func (t *MobileGatewayTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.MobileGatewayFindResult, error) {
 	log.Println("[TRACE] MobileGatewayAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -4957,7 +4896,7 @@ func (t *MobileGatewayTracer) Find(ctx context.Context, zone string, conditions 
 func (t *MobileGatewayTracer) Create(ctx context.Context, zone string, param *sacloud.MobileGatewayCreateRequest) (*sacloud.MobileGateway, error) {
 	log.Println("[TRACE] MobileGatewayAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                              `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.MobileGatewayCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -4990,7 +4929,7 @@ func (t *MobileGatewayTracer) Create(ctx context.Context, zone string, param *sa
 func (t *MobileGatewayTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGateway, error) {
 	log.Println("[TRACE] MobileGatewayAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5023,7 +4962,7 @@ func (t *MobileGatewayTracer) Read(ctx context.Context, zone string, id types.ID
 func (t *MobileGatewayTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayUpdateRequest) (*sacloud.MobileGateway, error) {
 	log.Println("[TRACE] MobileGatewayAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                              `json:"zone"`
+		Argzone  string
 		Argid    types.ID                            `json:"id"`
 		Argparam *sacloud.MobileGatewayUpdateRequest `json:"param"`
 	}{
@@ -5058,7 +4997,7 @@ func (t *MobileGatewayTracer) Update(ctx context.Context, zone string, id types.
 func (t *MobileGatewayTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] MobileGatewayAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5089,7 +5028,7 @@ func (t *MobileGatewayTracer) Delete(ctx context.Context, zone string, id types.
 func (t *MobileGatewayTracer) Config(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] MobileGatewayAPI.Config start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5120,7 +5059,7 @@ func (t *MobileGatewayTracer) Config(ctx context.Context, zone string, id types.
 func (t *MobileGatewayTracer) Boot(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] MobileGatewayAPI.Boot start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5151,7 +5090,7 @@ func (t *MobileGatewayTracer) Boot(ctx context.Context, zone string, id types.ID
 func (t *MobileGatewayTracer) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
 	log.Println("[TRACE] MobileGatewayAPI.Shutdown start")
 	targetArguments := struct {
-		Argzone           string                  `json:"zone"`
+		Argzone           string
 		Argid             types.ID                `json:"id"`
 		ArgshutdownOption *sacloud.ShutdownOption `json:"shutdownOption"`
 	}{
@@ -5184,7 +5123,7 @@ func (t *MobileGatewayTracer) Shutdown(ctx context.Context, zone string, id type
 func (t *MobileGatewayTracer) Reset(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] MobileGatewayAPI.Reset start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5215,7 +5154,7 @@ func (t *MobileGatewayTracer) Reset(ctx context.Context, zone string, id types.I
 func (t *MobileGatewayTracer) ConnectToSwitch(ctx context.Context, zone string, id types.ID, switchID types.ID) error {
 	log.Println("[TRACE] MobileGatewayAPI.ConnectToSwitch start")
 	targetArguments := struct {
-		Argzone     string   `json:"zone"`
+		Argzone     string
 		Argid       types.ID `json:"id"`
 		ArgswitchID types.ID `json:"switchID"`
 	}{
@@ -5248,7 +5187,7 @@ func (t *MobileGatewayTracer) ConnectToSwitch(ctx context.Context, zone string, 
 func (t *MobileGatewayTracer) DisconnectFromSwitch(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] MobileGatewayAPI.DisconnectFromSwitch start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5279,7 +5218,7 @@ func (t *MobileGatewayTracer) DisconnectFromSwitch(ctx context.Context, zone str
 func (t *MobileGatewayTracer) GetDNS(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayDNSSetting, error) {
 	log.Println("[TRACE] MobileGatewayAPI.GetDNS start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5312,7 +5251,7 @@ func (t *MobileGatewayTracer) GetDNS(ctx context.Context, zone string, id types.
 func (t *MobileGatewayTracer) SetDNS(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayDNSSetting) error {
 	log.Println("[TRACE] MobileGatewayAPI.SetDNS start")
 	targetArguments := struct {
-		Argzone  string                           `json:"zone"`
+		Argzone  string
 		Argid    types.ID                         `json:"id"`
 		Argparam *sacloud.MobileGatewayDNSSetting `json:"param"`
 	}{
@@ -5345,7 +5284,7 @@ func (t *MobileGatewayTracer) SetDNS(ctx context.Context, zone string, id types.
 func (t *MobileGatewayTracer) GetSIMRoutes(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMRoute, error) {
 	log.Println("[TRACE] MobileGatewayAPI.GetSIMRoutes start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5378,7 +5317,7 @@ func (t *MobileGatewayTracer) GetSIMRoutes(ctx context.Context, zone string, id 
 func (t *MobileGatewayTracer) SetSIMRoutes(ctx context.Context, zone string, id types.ID, param []*sacloud.MobileGatewaySIMRouteParam) error {
 	log.Println("[TRACE] MobileGatewayAPI.SetSIMRoutes start")
 	targetArguments := struct {
-		Argzone  string                                `json:"zone"`
+		Argzone  string
 		Argid    types.ID                              `json:"id"`
 		Argparam []*sacloud.MobileGatewaySIMRouteParam `json:"param"`
 	}{
@@ -5411,7 +5350,7 @@ func (t *MobileGatewayTracer) SetSIMRoutes(ctx context.Context, zone string, id 
 func (t *MobileGatewayTracer) ListSIM(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMInfo, error) {
 	log.Println("[TRACE] MobileGatewayAPI.ListSIM start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5444,7 +5383,7 @@ func (t *MobileGatewayTracer) ListSIM(ctx context.Context, zone string, id types
 func (t *MobileGatewayTracer) AddSIM(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayAddSIMRequest) error {
 	log.Println("[TRACE] MobileGatewayAPI.AddSIM start")
 	targetArguments := struct {
-		Argzone  string                              `json:"zone"`
+		Argzone  string
 		Argid    types.ID                            `json:"id"`
 		Argparam *sacloud.MobileGatewayAddSIMRequest `json:"param"`
 	}{
@@ -5477,7 +5416,7 @@ func (t *MobileGatewayTracer) AddSIM(ctx context.Context, zone string, id types.
 func (t *MobileGatewayTracer) DeleteSIM(ctx context.Context, zone string, id types.ID, simID types.ID) error {
 	log.Println("[TRACE] MobileGatewayAPI.DeleteSIM start")
 	targetArguments := struct {
-		Argzone  string   `json:"zone"`
+		Argzone  string
 		Argid    types.ID `json:"id"`
 		ArgsimID types.ID `json:"simID"`
 	}{
@@ -5510,7 +5449,7 @@ func (t *MobileGatewayTracer) DeleteSIM(ctx context.Context, zone string, id typ
 func (t *MobileGatewayTracer) Logs(ctx context.Context, zone string, id types.ID) ([]*sacloud.MobileGatewaySIMLogs, error) {
 	log.Println("[TRACE] MobileGatewayAPI.Logs start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5543,7 +5482,7 @@ func (t *MobileGatewayTracer) Logs(ctx context.Context, zone string, id types.ID
 func (t *MobileGatewayTracer) GetTrafficConfig(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayTrafficControl, error) {
 	log.Println("[TRACE] MobileGatewayAPI.GetTrafficConfig start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5576,7 +5515,7 @@ func (t *MobileGatewayTracer) GetTrafficConfig(ctx context.Context, zone string,
 func (t *MobileGatewayTracer) SetTrafficConfig(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayTrafficControl) error {
 	log.Println("[TRACE] MobileGatewayAPI.SetTrafficConfig start")
 	targetArguments := struct {
-		Argzone  string                               `json:"zone"`
+		Argzone  string
 		Argid    types.ID                             `json:"id"`
 		Argparam *sacloud.MobileGatewayTrafficControl `json:"param"`
 	}{
@@ -5609,7 +5548,7 @@ func (t *MobileGatewayTracer) SetTrafficConfig(ctx context.Context, zone string,
 func (t *MobileGatewayTracer) DeleteTrafficConfig(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] MobileGatewayAPI.DeleteTrafficConfig start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5640,7 +5579,7 @@ func (t *MobileGatewayTracer) DeleteTrafficConfig(ctx context.Context, zone stri
 func (t *MobileGatewayTracer) TrafficStatus(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGatewayTrafficStatus, error) {
 	log.Println("[TRACE] MobileGatewayAPI.TrafficStatus start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5673,7 +5612,7 @@ func (t *MobileGatewayTracer) TrafficStatus(ctx context.Context, zone string, id
 func (t *MobileGatewayTracer) MonitorInterface(ctx context.Context, zone string, id types.ID, index int, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
 	log.Println("[TRACE] MobileGatewayAPI.MonitorInterface start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argindex     int                       `json:"index"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
@@ -5726,7 +5665,7 @@ func NewNFSTracer(in sacloud.NFSAPI) sacloud.NFSAPI {
 func (t *NFSTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.NFSFindResult, error) {
 	log.Println("[TRACE] NFSAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -5759,7 +5698,7 @@ func (t *NFSTracer) Find(ctx context.Context, zone string, conditions *sacloud.F
 func (t *NFSTracer) Create(ctx context.Context, zone string, param *sacloud.NFSCreateRequest) (*sacloud.NFS, error) {
 	log.Println("[TRACE] NFSAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                    `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.NFSCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -5792,7 +5731,7 @@ func (t *NFSTracer) Create(ctx context.Context, zone string, param *sacloud.NFSC
 func (t *NFSTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.NFS, error) {
 	log.Println("[TRACE] NFSAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5825,7 +5764,7 @@ func (t *NFSTracer) Read(ctx context.Context, zone string, id types.ID) (*saclou
 func (t *NFSTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.NFSUpdateRequest) (*sacloud.NFS, error) {
 	log.Println("[TRACE] NFSAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                    `json:"zone"`
+		Argzone  string
 		Argid    types.ID                  `json:"id"`
 		Argparam *sacloud.NFSUpdateRequest `json:"param"`
 	}{
@@ -5860,7 +5799,7 @@ func (t *NFSTracer) Update(ctx context.Context, zone string, id types.ID, param 
 func (t *NFSTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] NFSAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5891,7 +5830,7 @@ func (t *NFSTracer) Delete(ctx context.Context, zone string, id types.ID) error 
 func (t *NFSTracer) Boot(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] NFSAPI.Boot start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5922,7 +5861,7 @@ func (t *NFSTracer) Boot(ctx context.Context, zone string, id types.ID) error {
 func (t *NFSTracer) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
 	log.Println("[TRACE] NFSAPI.Shutdown start")
 	targetArguments := struct {
-		Argzone           string                  `json:"zone"`
+		Argzone           string
 		Argid             types.ID                `json:"id"`
 		ArgshutdownOption *sacloud.ShutdownOption `json:"shutdownOption"`
 	}{
@@ -5955,7 +5894,7 @@ func (t *NFSTracer) Shutdown(ctx context.Context, zone string, id types.ID, shut
 func (t *NFSTracer) Reset(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] NFSAPI.Reset start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -5986,7 +5925,7 @@ func (t *NFSTracer) Reset(ctx context.Context, zone string, id types.ID) error {
 func (t *NFSTracer) MonitorFreeDiskSize(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.FreeDiskSizeActivity, error) {
 	log.Println("[TRACE] NFSAPI.MonitorFreeDiskSize start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -6021,7 +5960,7 @@ func (t *NFSTracer) MonitorFreeDiskSize(ctx context.Context, zone string, id typ
 func (t *NFSTracer) MonitorInterface(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
 	log.Println("[TRACE] NFSAPI.MonitorInterface start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -6069,13 +6008,11 @@ func NewNoteTracer(in sacloud.NoteAPI) sacloud.NoteAPI {
 }
 
 // Find is API call with trace log
-func (t *NoteTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.NoteFindResult, error) {
+func (t *NoteTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.NoteFindResult, error) {
 	log.Println("[TRACE] NoteAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -6086,7 +6023,7 @@ func (t *NoteTracer) Find(ctx context.Context, zone string, conditions *sacloud.
 		log.Println("[TRACE] NoteAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.NoteFindResult
 		Error  error
@@ -6102,13 +6039,11 @@ func (t *NoteTracer) Find(ctx context.Context, zone string, conditions *sacloud.
 }
 
 // Create is API call with trace log
-func (t *NoteTracer) Create(ctx context.Context, zone string, param *sacloud.NoteCreateRequest) (*sacloud.Note, error) {
+func (t *NoteTracer) Create(ctx context.Context, param *sacloud.NoteCreateRequest) (*sacloud.Note, error) {
 	log.Println("[TRACE] NoteAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                     `json:"zone"`
 		Argparam *sacloud.NoteCreateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -6119,7 +6054,7 @@ func (t *NoteTracer) Create(ctx context.Context, zone string, param *sacloud.Not
 		log.Println("[TRACE] NoteAPI.Create end")
 	}()
 
-	resultNote, err := t.Internal.Create(ctx, zone, param)
+	resultNote, err := t.Internal.Create(ctx, param)
 	targetResults := struct {
 		Note  *sacloud.Note
 		Error error
@@ -6135,14 +6070,12 @@ func (t *NoteTracer) Create(ctx context.Context, zone string, param *sacloud.Not
 }
 
 // Read is API call with trace log
-func (t *NoteTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Note, error) {
+func (t *NoteTracer) Read(ctx context.Context, id types.ID) (*sacloud.Note, error) {
 	log.Println("[TRACE] NoteAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -6152,7 +6085,7 @@ func (t *NoteTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 		log.Println("[TRACE] NoteAPI.Read end")
 	}()
 
-	resultNote, err := t.Internal.Read(ctx, zone, id)
+	resultNote, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		Note  *sacloud.Note
 		Error error
@@ -6168,14 +6101,12 @@ func (t *NoteTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 }
 
 // Update is API call with trace log
-func (t *NoteTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.NoteUpdateRequest) (*sacloud.Note, error) {
+func (t *NoteTracer) Update(ctx context.Context, id types.ID, param *sacloud.NoteUpdateRequest) (*sacloud.Note, error) {
 	log.Println("[TRACE] NoteAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                     `json:"zone"`
 		Argid    types.ID                   `json:"id"`
 		Argparam *sacloud.NoteUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -6187,7 +6118,7 @@ func (t *NoteTracer) Update(ctx context.Context, zone string, id types.ID, param
 		log.Println("[TRACE] NoteAPI.Update end")
 	}()
 
-	resultNote, err := t.Internal.Update(ctx, zone, id, param)
+	resultNote, err := t.Internal.Update(ctx, id, param)
 	targetResults := struct {
 		Note  *sacloud.Note
 		Error error
@@ -6203,14 +6134,12 @@ func (t *NoteTracer) Update(ctx context.Context, zone string, id types.ID, param
 }
 
 // Delete is API call with trace log
-func (t *NoteTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+func (t *NoteTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] NoteAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -6220,7 +6149,7 @@ func (t *NoteTracer) Delete(ctx context.Context, zone string, id types.ID) error
 		log.Println("[TRACE] NoteAPI.Delete end")
 	}()
 
-	err := t.Internal.Delete(ctx, zone, id)
+	err := t.Internal.Delete(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -6253,7 +6182,7 @@ func NewPacketFilterTracer(in sacloud.PacketFilterAPI) sacloud.PacketFilterAPI {
 func (t *PacketFilterTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.PacketFilterFindResult, error) {
 	log.Println("[TRACE] PacketFilterAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -6286,7 +6215,7 @@ func (t *PacketFilterTracer) Find(ctx context.Context, zone string, conditions *
 func (t *PacketFilterTracer) Create(ctx context.Context, zone string, param *sacloud.PacketFilterCreateRequest) (*sacloud.PacketFilter, error) {
 	log.Println("[TRACE] PacketFilterAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                             `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.PacketFilterCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -6319,7 +6248,7 @@ func (t *PacketFilterTracer) Create(ctx context.Context, zone string, param *sac
 func (t *PacketFilterTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.PacketFilter, error) {
 	log.Println("[TRACE] PacketFilterAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -6352,7 +6281,7 @@ func (t *PacketFilterTracer) Read(ctx context.Context, zone string, id types.ID)
 func (t *PacketFilterTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.PacketFilterUpdateRequest) (*sacloud.PacketFilter, error) {
 	log.Println("[TRACE] PacketFilterAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                             `json:"zone"`
+		Argzone  string
 		Argid    types.ID                           `json:"id"`
 		Argparam *sacloud.PacketFilterUpdateRequest `json:"param"`
 	}{
@@ -6387,7 +6316,7 @@ func (t *PacketFilterTracer) Update(ctx context.Context, zone string, id types.I
 func (t *PacketFilterTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] PacketFilterAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -6434,7 +6363,7 @@ func NewPrivateHostTracer(in sacloud.PrivateHostAPI) sacloud.PrivateHostAPI {
 func (t *PrivateHostTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.PrivateHostFindResult, error) {
 	log.Println("[TRACE] PrivateHostAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -6467,7 +6396,7 @@ func (t *PrivateHostTracer) Find(ctx context.Context, zone string, conditions *s
 func (t *PrivateHostTracer) Create(ctx context.Context, zone string, param *sacloud.PrivateHostCreateRequest) (*sacloud.PrivateHost, error) {
 	log.Println("[TRACE] PrivateHostAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                            `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.PrivateHostCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -6500,7 +6429,7 @@ func (t *PrivateHostTracer) Create(ctx context.Context, zone string, param *sacl
 func (t *PrivateHostTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.PrivateHost, error) {
 	log.Println("[TRACE] PrivateHostAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -6533,7 +6462,7 @@ func (t *PrivateHostTracer) Read(ctx context.Context, zone string, id types.ID) 
 func (t *PrivateHostTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.PrivateHostUpdateRequest) (*sacloud.PrivateHost, error) {
 	log.Println("[TRACE] PrivateHostAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                            `json:"zone"`
+		Argzone  string
 		Argid    types.ID                          `json:"id"`
 		Argparam *sacloud.PrivateHostUpdateRequest `json:"param"`
 	}{
@@ -6568,7 +6497,7 @@ func (t *PrivateHostTracer) Update(ctx context.Context, zone string, id types.ID
 func (t *PrivateHostTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] PrivateHostAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -6615,7 +6544,7 @@ func NewPrivateHostPlanTracer(in sacloud.PrivateHostPlanAPI) sacloud.PrivateHost
 func (t *PrivateHostPlanTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.PrivateHostPlanFindResult, error) {
 	log.Println("[TRACE] PrivateHostPlanAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -6648,7 +6577,7 @@ func (t *PrivateHostPlanTracer) Find(ctx context.Context, zone string, condition
 func (t *PrivateHostPlanTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.PrivateHostPlan, error) {
 	log.Println("[TRACE] PrivateHostPlanAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -6694,13 +6623,11 @@ func NewProxyLBTracer(in sacloud.ProxyLBAPI) sacloud.ProxyLBAPI {
 }
 
 // Find is API call with trace log
-func (t *ProxyLBTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ProxyLBFindResult, error) {
+func (t *ProxyLBTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.ProxyLBFindResult, error) {
 	log.Println("[TRACE] ProxyLBAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -6711,7 +6638,7 @@ func (t *ProxyLBTracer) Find(ctx context.Context, zone string, conditions *saclo
 		log.Println("[TRACE] ProxyLBAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.ProxyLBFindResult
 		Error  error
@@ -6727,13 +6654,11 @@ func (t *ProxyLBTracer) Find(ctx context.Context, zone string, conditions *saclo
 }
 
 // Create is API call with trace log
-func (t *ProxyLBTracer) Create(ctx context.Context, zone string, param *sacloud.ProxyLBCreateRequest) (*sacloud.ProxyLB, error) {
+func (t *ProxyLBTracer) Create(ctx context.Context, param *sacloud.ProxyLBCreateRequest) (*sacloud.ProxyLB, error) {
 	log.Println("[TRACE] ProxyLBAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                        `json:"zone"`
 		Argparam *sacloud.ProxyLBCreateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -6744,7 +6669,7 @@ func (t *ProxyLBTracer) Create(ctx context.Context, zone string, param *sacloud.
 		log.Println("[TRACE] ProxyLBAPI.Create end")
 	}()
 
-	resultProxyLB, err := t.Internal.Create(ctx, zone, param)
+	resultProxyLB, err := t.Internal.Create(ctx, param)
 	targetResults := struct {
 		ProxyLB *sacloud.ProxyLB
 		Error   error
@@ -6760,14 +6685,12 @@ func (t *ProxyLBTracer) Create(ctx context.Context, zone string, param *sacloud.
 }
 
 // Read is API call with trace log
-func (t *ProxyLBTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.ProxyLB, error) {
+func (t *ProxyLBTracer) Read(ctx context.Context, id types.ID) (*sacloud.ProxyLB, error) {
 	log.Println("[TRACE] ProxyLBAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -6777,7 +6700,7 @@ func (t *ProxyLBTracer) Read(ctx context.Context, zone string, id types.ID) (*sa
 		log.Println("[TRACE] ProxyLBAPI.Read end")
 	}()
 
-	resultProxyLB, err := t.Internal.Read(ctx, zone, id)
+	resultProxyLB, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		ProxyLB *sacloud.ProxyLB
 		Error   error
@@ -6793,14 +6716,12 @@ func (t *ProxyLBTracer) Read(ctx context.Context, zone string, id types.ID) (*sa
 }
 
 // Update is API call with trace log
-func (t *ProxyLBTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.ProxyLBUpdateRequest) (*sacloud.ProxyLB, error) {
+func (t *ProxyLBTracer) Update(ctx context.Context, id types.ID, param *sacloud.ProxyLBUpdateRequest) (*sacloud.ProxyLB, error) {
 	log.Println("[TRACE] ProxyLBAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                        `json:"zone"`
 		Argid    types.ID                      `json:"id"`
 		Argparam *sacloud.ProxyLBUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -6812,7 +6733,7 @@ func (t *ProxyLBTracer) Update(ctx context.Context, zone string, id types.ID, pa
 		log.Println("[TRACE] ProxyLBAPI.Update end")
 	}()
 
-	resultProxyLB, err := t.Internal.Update(ctx, zone, id, param)
+	resultProxyLB, err := t.Internal.Update(ctx, id, param)
 	targetResults := struct {
 		ProxyLB *sacloud.ProxyLB
 		Error   error
@@ -6828,14 +6749,12 @@ func (t *ProxyLBTracer) Update(ctx context.Context, zone string, id types.ID, pa
 }
 
 // Delete is API call with trace log
-func (t *ProxyLBTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+func (t *ProxyLBTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] ProxyLBAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -6845,7 +6764,7 @@ func (t *ProxyLBTracer) Delete(ctx context.Context, zone string, id types.ID) er
 		log.Println("[TRACE] ProxyLBAPI.Delete end")
 	}()
 
-	err := t.Internal.Delete(ctx, zone, id)
+	err := t.Internal.Delete(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -6859,14 +6778,12 @@ func (t *ProxyLBTracer) Delete(ctx context.Context, zone string, id types.ID) er
 }
 
 // ChangePlan is API call with trace log
-func (t *ProxyLBTracer) ChangePlan(ctx context.Context, zone string, id types.ID, param *sacloud.ProxyLBChangePlanRequest) (*sacloud.ProxyLB, error) {
+func (t *ProxyLBTracer) ChangePlan(ctx context.Context, id types.ID, param *sacloud.ProxyLBChangePlanRequest) (*sacloud.ProxyLB, error) {
 	log.Println("[TRACE] ProxyLBAPI.ChangePlan start")
 	targetArguments := struct {
-		Argzone  string                            `json:"zone"`
 		Argid    types.ID                          `json:"id"`
 		Argparam *sacloud.ProxyLBChangePlanRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -6878,7 +6795,7 @@ func (t *ProxyLBTracer) ChangePlan(ctx context.Context, zone string, id types.ID
 		log.Println("[TRACE] ProxyLBAPI.ChangePlan end")
 	}()
 
-	resultProxyLB, err := t.Internal.ChangePlan(ctx, zone, id, param)
+	resultProxyLB, err := t.Internal.ChangePlan(ctx, id, param)
 	targetResults := struct {
 		ProxyLB *sacloud.ProxyLB
 		Error   error
@@ -6894,14 +6811,12 @@ func (t *ProxyLBTracer) ChangePlan(ctx context.Context, zone string, id types.ID
 }
 
 // GetCertificates is API call with trace log
-func (t *ProxyLBTracer) GetCertificates(ctx context.Context, zone string, id types.ID) (*sacloud.ProxyLBCertificates, error) {
+func (t *ProxyLBTracer) GetCertificates(ctx context.Context, id types.ID) (*sacloud.ProxyLBCertificates, error) {
 	log.Println("[TRACE] ProxyLBAPI.GetCertificates start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -6911,7 +6826,7 @@ func (t *ProxyLBTracer) GetCertificates(ctx context.Context, zone string, id typ
 		log.Println("[TRACE] ProxyLBAPI.GetCertificates end")
 	}()
 
-	resultProxyLBCertificates, err := t.Internal.GetCertificates(ctx, zone, id)
+	resultProxyLBCertificates, err := t.Internal.GetCertificates(ctx, id)
 	targetResults := struct {
 		ProxyLBCertificates *sacloud.ProxyLBCertificates
 		Error               error
@@ -6927,14 +6842,12 @@ func (t *ProxyLBTracer) GetCertificates(ctx context.Context, zone string, id typ
 }
 
 // SetCertificates is API call with trace log
-func (t *ProxyLBTracer) SetCertificates(ctx context.Context, zone string, id types.ID, param *sacloud.ProxyLBSetCertificatesRequest) (*sacloud.ProxyLBCertificates, error) {
+func (t *ProxyLBTracer) SetCertificates(ctx context.Context, id types.ID, param *sacloud.ProxyLBSetCertificatesRequest) (*sacloud.ProxyLBCertificates, error) {
 	log.Println("[TRACE] ProxyLBAPI.SetCertificates start")
 	targetArguments := struct {
-		Argzone  string                                 `json:"zone"`
 		Argid    types.ID                               `json:"id"`
 		Argparam *sacloud.ProxyLBSetCertificatesRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -6946,7 +6859,7 @@ func (t *ProxyLBTracer) SetCertificates(ctx context.Context, zone string, id typ
 		log.Println("[TRACE] ProxyLBAPI.SetCertificates end")
 	}()
 
-	resultProxyLBCertificates, err := t.Internal.SetCertificates(ctx, zone, id, param)
+	resultProxyLBCertificates, err := t.Internal.SetCertificates(ctx, id, param)
 	targetResults := struct {
 		ProxyLBCertificates *sacloud.ProxyLBCertificates
 		Error               error
@@ -6962,14 +6875,12 @@ func (t *ProxyLBTracer) SetCertificates(ctx context.Context, zone string, id typ
 }
 
 // DeleteCertificates is API call with trace log
-func (t *ProxyLBTracer) DeleteCertificates(ctx context.Context, zone string, id types.ID) error {
+func (t *ProxyLBTracer) DeleteCertificates(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] ProxyLBAPI.DeleteCertificates start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -6979,7 +6890,7 @@ func (t *ProxyLBTracer) DeleteCertificates(ctx context.Context, zone string, id 
 		log.Println("[TRACE] ProxyLBAPI.DeleteCertificates end")
 	}()
 
-	err := t.Internal.DeleteCertificates(ctx, zone, id)
+	err := t.Internal.DeleteCertificates(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -6993,14 +6904,12 @@ func (t *ProxyLBTracer) DeleteCertificates(ctx context.Context, zone string, id 
 }
 
 // RenewLetsEncryptCert is API call with trace log
-func (t *ProxyLBTracer) RenewLetsEncryptCert(ctx context.Context, zone string, id types.ID) error {
+func (t *ProxyLBTracer) RenewLetsEncryptCert(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] ProxyLBAPI.RenewLetsEncryptCert start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -7010,7 +6919,7 @@ func (t *ProxyLBTracer) RenewLetsEncryptCert(ctx context.Context, zone string, i
 		log.Println("[TRACE] ProxyLBAPI.RenewLetsEncryptCert end")
 	}()
 
-	err := t.Internal.RenewLetsEncryptCert(ctx, zone, id)
+	err := t.Internal.RenewLetsEncryptCert(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -7024,14 +6933,12 @@ func (t *ProxyLBTracer) RenewLetsEncryptCert(ctx context.Context, zone string, i
 }
 
 // HealthStatus is API call with trace log
-func (t *ProxyLBTracer) HealthStatus(ctx context.Context, zone string, id types.ID) (*sacloud.ProxyLBHealth, error) {
+func (t *ProxyLBTracer) HealthStatus(ctx context.Context, id types.ID) (*sacloud.ProxyLBHealth, error) {
 	log.Println("[TRACE] ProxyLBAPI.HealthStatus start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -7041,7 +6948,7 @@ func (t *ProxyLBTracer) HealthStatus(ctx context.Context, zone string, id types.
 		log.Println("[TRACE] ProxyLBAPI.HealthStatus end")
 	}()
 
-	resultProxyLBHealth, err := t.Internal.HealthStatus(ctx, zone, id)
+	resultProxyLBHealth, err := t.Internal.HealthStatus(ctx, id)
 	targetResults := struct {
 		ProxyLBHealth *sacloud.ProxyLBHealth
 		Error         error
@@ -7073,13 +6980,11 @@ func NewRegionTracer(in sacloud.RegionAPI) sacloud.RegionAPI {
 }
 
 // Find is API call with trace log
-func (t *RegionTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.RegionFindResult, error) {
+func (t *RegionTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.RegionFindResult, error) {
 	log.Println("[TRACE] RegionAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -7090,7 +6995,7 @@ func (t *RegionTracer) Find(ctx context.Context, zone string, conditions *saclou
 		log.Println("[TRACE] RegionAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.RegionFindResult
 		Error  error
@@ -7106,14 +7011,12 @@ func (t *RegionTracer) Find(ctx context.Context, zone string, conditions *saclou
 }
 
 // Read is API call with trace log
-func (t *RegionTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Region, error) {
+func (t *RegionTracer) Read(ctx context.Context, id types.ID) (*sacloud.Region, error) {
 	log.Println("[TRACE] RegionAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -7123,7 +7026,7 @@ func (t *RegionTracer) Read(ctx context.Context, zone string, id types.ID) (*sac
 		log.Println("[TRACE] RegionAPI.Read end")
 	}()
 
-	resultRegion, err := t.Internal.Read(ctx, zone, id)
+	resultRegion, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		Region *sacloud.Region
 		Error  error
@@ -7158,7 +7061,7 @@ func NewServerTracer(in sacloud.ServerAPI) sacloud.ServerAPI {
 func (t *ServerTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ServerFindResult, error) {
 	log.Println("[TRACE] ServerAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -7191,7 +7094,7 @@ func (t *ServerTracer) Find(ctx context.Context, zone string, conditions *saclou
 func (t *ServerTracer) Create(ctx context.Context, zone string, param *sacloud.ServerCreateRequest) (*sacloud.Server, error) {
 	log.Println("[TRACE] ServerAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                       `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.ServerCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -7224,7 +7127,7 @@ func (t *ServerTracer) Create(ctx context.Context, zone string, param *sacloud.S
 func (t *ServerTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Server, error) {
 	log.Println("[TRACE] ServerAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -7257,7 +7160,7 @@ func (t *ServerTracer) Read(ctx context.Context, zone string, id types.ID) (*sac
 func (t *ServerTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.ServerUpdateRequest) (*sacloud.Server, error) {
 	log.Println("[TRACE] ServerAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                       `json:"zone"`
+		Argzone  string
 		Argid    types.ID                     `json:"id"`
 		Argparam *sacloud.ServerUpdateRequest `json:"param"`
 	}{
@@ -7292,7 +7195,7 @@ func (t *ServerTracer) Update(ctx context.Context, zone string, id types.ID, par
 func (t *ServerTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] ServerAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -7323,7 +7226,7 @@ func (t *ServerTracer) Delete(ctx context.Context, zone string, id types.ID) err
 func (t *ServerTracer) ChangePlan(ctx context.Context, zone string, id types.ID, plan *sacloud.ServerChangePlanRequest) (*sacloud.Server, error) {
 	log.Println("[TRACE] ServerAPI.ChangePlan start")
 	targetArguments := struct {
-		Argzone string                           `json:"zone"`
+		Argzone string
 		Argid   types.ID                         `json:"id"`
 		Argplan *sacloud.ServerChangePlanRequest `json:"plan"`
 	}{
@@ -7358,7 +7261,7 @@ func (t *ServerTracer) ChangePlan(ctx context.Context, zone string, id types.ID,
 func (t *ServerTracer) InsertCDROM(ctx context.Context, zone string, id types.ID, insertParam *sacloud.InsertCDROMRequest) error {
 	log.Println("[TRACE] ServerAPI.InsertCDROM start")
 	targetArguments := struct {
-		Argzone        string                      `json:"zone"`
+		Argzone        string
 		Argid          types.ID                    `json:"id"`
 		ArginsertParam *sacloud.InsertCDROMRequest `json:"insertParam"`
 	}{
@@ -7391,7 +7294,7 @@ func (t *ServerTracer) InsertCDROM(ctx context.Context, zone string, id types.ID
 func (t *ServerTracer) EjectCDROM(ctx context.Context, zone string, id types.ID, insertParam *sacloud.EjectCDROMRequest) error {
 	log.Println("[TRACE] ServerAPI.EjectCDROM start")
 	targetArguments := struct {
-		Argzone        string                     `json:"zone"`
+		Argzone        string
 		Argid          types.ID                   `json:"id"`
 		ArginsertParam *sacloud.EjectCDROMRequest `json:"insertParam"`
 	}{
@@ -7424,7 +7327,7 @@ func (t *ServerTracer) EjectCDROM(ctx context.Context, zone string, id types.ID,
 func (t *ServerTracer) Boot(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] ServerAPI.Boot start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -7455,7 +7358,7 @@ func (t *ServerTracer) Boot(ctx context.Context, zone string, id types.ID) error
 func (t *ServerTracer) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
 	log.Println("[TRACE] ServerAPI.Shutdown start")
 	targetArguments := struct {
-		Argzone           string                  `json:"zone"`
+		Argzone           string
 		Argid             types.ID                `json:"id"`
 		ArgshutdownOption *sacloud.ShutdownOption `json:"shutdownOption"`
 	}{
@@ -7488,7 +7391,7 @@ func (t *ServerTracer) Shutdown(ctx context.Context, zone string, id types.ID, s
 func (t *ServerTracer) Reset(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] ServerAPI.Reset start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -7519,7 +7422,7 @@ func (t *ServerTracer) Reset(ctx context.Context, zone string, id types.ID) erro
 func (t *ServerTracer) Monitor(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
 	log.Println("[TRACE] ServerAPI.Monitor start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
@@ -7570,7 +7473,7 @@ func NewServerPlanTracer(in sacloud.ServerPlanAPI) sacloud.ServerPlanAPI {
 func (t *ServerPlanTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ServerPlanFindResult, error) {
 	log.Println("[TRACE] ServerPlanAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -7603,7 +7506,7 @@ func (t *ServerPlanTracer) Find(ctx context.Context, zone string, conditions *sa
 func (t *ServerPlanTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.ServerPlan, error) {
 	log.Println("[TRACE] ServerPlanAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -7652,7 +7555,7 @@ func NewServiceClassTracer(in sacloud.ServiceClassAPI) sacloud.ServiceClassAPI {
 func (t *ServiceClassTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ServiceClassFindResult, error) {
 	log.Println("[TRACE] ServiceClassAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -7698,13 +7601,11 @@ func NewSIMTracer(in sacloud.SIMAPI) sacloud.SIMAPI {
 }
 
 // Find is API call with trace log
-func (t *SIMTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SIMFindResult, error) {
+func (t *SIMTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.SIMFindResult, error) {
 	log.Println("[TRACE] SIMAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -7715,7 +7616,7 @@ func (t *SIMTracer) Find(ctx context.Context, zone string, conditions *sacloud.F
 		log.Println("[TRACE] SIMAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.SIMFindResult
 		Error  error
@@ -7731,13 +7632,11 @@ func (t *SIMTracer) Find(ctx context.Context, zone string, conditions *sacloud.F
 }
 
 // Create is API call with trace log
-func (t *SIMTracer) Create(ctx context.Context, zone string, param *sacloud.SIMCreateRequest) (*sacloud.SIM, error) {
+func (t *SIMTracer) Create(ctx context.Context, param *sacloud.SIMCreateRequest) (*sacloud.SIM, error) {
 	log.Println("[TRACE] SIMAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                    `json:"zone"`
 		Argparam *sacloud.SIMCreateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -7748,7 +7647,7 @@ func (t *SIMTracer) Create(ctx context.Context, zone string, param *sacloud.SIMC
 		log.Println("[TRACE] SIMAPI.Create end")
 	}()
 
-	resultSIM, err := t.Internal.Create(ctx, zone, param)
+	resultSIM, err := t.Internal.Create(ctx, param)
 	targetResults := struct {
 		SIM   *sacloud.SIM
 		Error error
@@ -7764,14 +7663,12 @@ func (t *SIMTracer) Create(ctx context.Context, zone string, param *sacloud.SIMC
 }
 
 // Read is API call with trace log
-func (t *SIMTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SIM, error) {
+func (t *SIMTracer) Read(ctx context.Context, id types.ID) (*sacloud.SIM, error) {
 	log.Println("[TRACE] SIMAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -7781,7 +7678,7 @@ func (t *SIMTracer) Read(ctx context.Context, zone string, id types.ID) (*saclou
 		log.Println("[TRACE] SIMAPI.Read end")
 	}()
 
-	resultSIM, err := t.Internal.Read(ctx, zone, id)
+	resultSIM, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		SIM   *sacloud.SIM
 		Error error
@@ -7797,14 +7694,12 @@ func (t *SIMTracer) Read(ctx context.Context, zone string, id types.ID) (*saclou
 }
 
 // Update is API call with trace log
-func (t *SIMTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SIMUpdateRequest) (*sacloud.SIM, error) {
+func (t *SIMTracer) Update(ctx context.Context, id types.ID, param *sacloud.SIMUpdateRequest) (*sacloud.SIM, error) {
 	log.Println("[TRACE] SIMAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                    `json:"zone"`
 		Argid    types.ID                  `json:"id"`
 		Argparam *sacloud.SIMUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -7816,7 +7711,7 @@ func (t *SIMTracer) Update(ctx context.Context, zone string, id types.ID, param 
 		log.Println("[TRACE] SIMAPI.Update end")
 	}()
 
-	resultSIM, err := t.Internal.Update(ctx, zone, id, param)
+	resultSIM, err := t.Internal.Update(ctx, id, param)
 	targetResults := struct {
 		SIM   *sacloud.SIM
 		Error error
@@ -7832,14 +7727,12 @@ func (t *SIMTracer) Update(ctx context.Context, zone string, id types.ID, param 
 }
 
 // Delete is API call with trace log
-func (t *SIMTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+func (t *SIMTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SIMAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -7849,7 +7742,7 @@ func (t *SIMTracer) Delete(ctx context.Context, zone string, id types.ID) error 
 		log.Println("[TRACE] SIMAPI.Delete end")
 	}()
 
-	err := t.Internal.Delete(ctx, zone, id)
+	err := t.Internal.Delete(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -7863,14 +7756,12 @@ func (t *SIMTracer) Delete(ctx context.Context, zone string, id types.ID) error 
 }
 
 // Activate is API call with trace log
-func (t *SIMTracer) Activate(ctx context.Context, zone string, id types.ID) error {
+func (t *SIMTracer) Activate(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SIMAPI.Activate start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -7880,7 +7771,7 @@ func (t *SIMTracer) Activate(ctx context.Context, zone string, id types.ID) erro
 		log.Println("[TRACE] SIMAPI.Activate end")
 	}()
 
-	err := t.Internal.Activate(ctx, zone, id)
+	err := t.Internal.Activate(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -7894,14 +7785,12 @@ func (t *SIMTracer) Activate(ctx context.Context, zone string, id types.ID) erro
 }
 
 // Deactivate is API call with trace log
-func (t *SIMTracer) Deactivate(ctx context.Context, zone string, id types.ID) error {
+func (t *SIMTracer) Deactivate(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SIMAPI.Deactivate start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -7911,7 +7800,7 @@ func (t *SIMTracer) Deactivate(ctx context.Context, zone string, id types.ID) er
 		log.Println("[TRACE] SIMAPI.Deactivate end")
 	}()
 
-	err := t.Internal.Deactivate(ctx, zone, id)
+	err := t.Internal.Deactivate(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -7925,14 +7814,12 @@ func (t *SIMTracer) Deactivate(ctx context.Context, zone string, id types.ID) er
 }
 
 // AssignIP is API call with trace log
-func (t *SIMTracer) AssignIP(ctx context.Context, zone string, id types.ID, param *sacloud.SIMAssignIPRequest) error {
+func (t *SIMTracer) AssignIP(ctx context.Context, id types.ID, param *sacloud.SIMAssignIPRequest) error {
 	log.Println("[TRACE] SIMAPI.AssignIP start")
 	targetArguments := struct {
-		Argzone  string                      `json:"zone"`
 		Argid    types.ID                    `json:"id"`
 		Argparam *sacloud.SIMAssignIPRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -7944,7 +7831,7 @@ func (t *SIMTracer) AssignIP(ctx context.Context, zone string, id types.ID, para
 		log.Println("[TRACE] SIMAPI.AssignIP end")
 	}()
 
-	err := t.Internal.AssignIP(ctx, zone, id, param)
+	err := t.Internal.AssignIP(ctx, id, param)
 	targetResults := struct {
 		Error error
 	}{
@@ -7958,14 +7845,12 @@ func (t *SIMTracer) AssignIP(ctx context.Context, zone string, id types.ID, para
 }
 
 // ClearIP is API call with trace log
-func (t *SIMTracer) ClearIP(ctx context.Context, zone string, id types.ID) error {
+func (t *SIMTracer) ClearIP(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SIMAPI.ClearIP start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -7975,7 +7860,7 @@ func (t *SIMTracer) ClearIP(ctx context.Context, zone string, id types.ID) error
 		log.Println("[TRACE] SIMAPI.ClearIP end")
 	}()
 
-	err := t.Internal.ClearIP(ctx, zone, id)
+	err := t.Internal.ClearIP(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -7989,14 +7874,12 @@ func (t *SIMTracer) ClearIP(ctx context.Context, zone string, id types.ID) error
 }
 
 // IMEILock is API call with trace log
-func (t *SIMTracer) IMEILock(ctx context.Context, zone string, id types.ID, param *sacloud.SIMIMEILockRequest) error {
+func (t *SIMTracer) IMEILock(ctx context.Context, id types.ID, param *sacloud.SIMIMEILockRequest) error {
 	log.Println("[TRACE] SIMAPI.IMEILock start")
 	targetArguments := struct {
-		Argzone  string                      `json:"zone"`
 		Argid    types.ID                    `json:"id"`
 		Argparam *sacloud.SIMIMEILockRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -8008,7 +7891,7 @@ func (t *SIMTracer) IMEILock(ctx context.Context, zone string, id types.ID, para
 		log.Println("[TRACE] SIMAPI.IMEILock end")
 	}()
 
-	err := t.Internal.IMEILock(ctx, zone, id, param)
+	err := t.Internal.IMEILock(ctx, id, param)
 	targetResults := struct {
 		Error error
 	}{
@@ -8022,14 +7905,12 @@ func (t *SIMTracer) IMEILock(ctx context.Context, zone string, id types.ID, para
 }
 
 // IMEIUnlock is API call with trace log
-func (t *SIMTracer) IMEIUnlock(ctx context.Context, zone string, id types.ID) error {
+func (t *SIMTracer) IMEIUnlock(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SIMAPI.IMEIUnlock start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -8039,7 +7920,7 @@ func (t *SIMTracer) IMEIUnlock(ctx context.Context, zone string, id types.ID) er
 		log.Println("[TRACE] SIMAPI.IMEIUnlock end")
 	}()
 
-	err := t.Internal.IMEIUnlock(ctx, zone, id)
+	err := t.Internal.IMEIUnlock(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -8053,14 +7934,12 @@ func (t *SIMTracer) IMEIUnlock(ctx context.Context, zone string, id types.ID) er
 }
 
 // Logs is API call with trace log
-func (t *SIMTracer) Logs(ctx context.Context, zone string, id types.ID) (*sacloud.SIMLogsResult, error) {
+func (t *SIMTracer) Logs(ctx context.Context, id types.ID) (*sacloud.SIMLogsResult, error) {
 	log.Println("[TRACE] SIMAPI.Logs start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -8070,7 +7949,7 @@ func (t *SIMTracer) Logs(ctx context.Context, zone string, id types.ID) (*saclou
 		log.Println("[TRACE] SIMAPI.Logs end")
 	}()
 
-	result, err := t.Internal.Logs(ctx, zone, id)
+	result, err := t.Internal.Logs(ctx, id)
 	targetResults := struct {
 		Result *sacloud.SIMLogsResult
 		Error  error
@@ -8086,14 +7965,12 @@ func (t *SIMTracer) Logs(ctx context.Context, zone string, id types.ID) (*saclou
 }
 
 // GetNetworkOperator is API call with trace log
-func (t *SIMTracer) GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*sacloud.SIMNetworkOperatorConfig, error) {
+func (t *SIMTracer) GetNetworkOperator(ctx context.Context, id types.ID) ([]*sacloud.SIMNetworkOperatorConfig, error) {
 	log.Println("[TRACE] SIMAPI.GetNetworkOperator start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -8103,7 +7980,7 @@ func (t *SIMTracer) GetNetworkOperator(ctx context.Context, zone string, id type
 		log.Println("[TRACE] SIMAPI.GetNetworkOperator end")
 	}()
 
-	resultConfigs, err := t.Internal.GetNetworkOperator(ctx, zone, id)
+	resultConfigs, err := t.Internal.GetNetworkOperator(ctx, id)
 	targetResults := struct {
 		Configs []*sacloud.SIMNetworkOperatorConfig
 		Error   error
@@ -8119,14 +7996,12 @@ func (t *SIMTracer) GetNetworkOperator(ctx context.Context, zone string, id type
 }
 
 // SetNetworkOperator is API call with trace log
-func (t *SIMTracer) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*sacloud.SIMNetworkOperatorConfig) error {
+func (t *SIMTracer) SetNetworkOperator(ctx context.Context, id types.ID, configs []*sacloud.SIMNetworkOperatorConfig) error {
 	log.Println("[TRACE] SIMAPI.SetNetworkOperator start")
 	targetArguments := struct {
-		Argzone    string                              `json:"zone"`
 		Argid      types.ID                            `json:"id"`
 		Argconfigs []*sacloud.SIMNetworkOperatorConfig `json:"configs"`
 	}{
-		Argzone:    zone,
 		Argid:      id,
 		Argconfigs: configs,
 	}
@@ -8138,7 +8013,7 @@ func (t *SIMTracer) SetNetworkOperator(ctx context.Context, zone string, id type
 		log.Println("[TRACE] SIMAPI.SetNetworkOperator end")
 	}()
 
-	err := t.Internal.SetNetworkOperator(ctx, zone, id, configs)
+	err := t.Internal.SetNetworkOperator(ctx, id, configs)
 	targetResults := struct {
 		Error error
 	}{
@@ -8152,14 +8027,12 @@ func (t *SIMTracer) SetNetworkOperator(ctx context.Context, zone string, id type
 }
 
 // MonitorSIM is API call with trace log
-func (t *SIMTracer) MonitorSIM(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LinkActivity, error) {
+func (t *SIMTracer) MonitorSIM(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LinkActivity, error) {
 	log.Println("[TRACE] SIMAPI.MonitorSIM start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -8171,7 +8044,7 @@ func (t *SIMTracer) MonitorSIM(ctx context.Context, zone string, id types.ID, co
 		log.Println("[TRACE] SIMAPI.MonitorSIM end")
 	}()
 
-	resultLinkActivity, err := t.Internal.MonitorSIM(ctx, zone, id, condition)
+	resultLinkActivity, err := t.Internal.MonitorSIM(ctx, id, condition)
 	targetResults := struct {
 		LinkActivity *sacloud.LinkActivity
 		Error        error
@@ -8187,14 +8060,12 @@ func (t *SIMTracer) MonitorSIM(ctx context.Context, zone string, id types.ID, co
 }
 
 // Status is API call with trace log
-func (t *SIMTracer) Status(ctx context.Context, zone string, id types.ID) (*sacloud.SIMInfo, error) {
+func (t *SIMTracer) Status(ctx context.Context, id types.ID) (*sacloud.SIMInfo, error) {
 	log.Println("[TRACE] SIMAPI.Status start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -8204,7 +8075,7 @@ func (t *SIMTracer) Status(ctx context.Context, zone string, id types.ID) (*sacl
 		log.Println("[TRACE] SIMAPI.Status end")
 	}()
 
-	resultSIM, err := t.Internal.Status(ctx, zone, id)
+	resultSIM, err := t.Internal.Status(ctx, id)
 	targetResults := struct {
 		SIM   *sacloud.SIMInfo
 		Error error
@@ -8236,13 +8107,11 @@ func NewSimpleMonitorTracer(in sacloud.SimpleMonitorAPI) sacloud.SimpleMonitorAP
 }
 
 // Find is API call with trace log
-func (t *SimpleMonitorTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SimpleMonitorFindResult, error) {
+func (t *SimpleMonitorTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.SimpleMonitorFindResult, error) {
 	log.Println("[TRACE] SimpleMonitorAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -8253,7 +8122,7 @@ func (t *SimpleMonitorTracer) Find(ctx context.Context, zone string, conditions 
 		log.Println("[TRACE] SimpleMonitorAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.SimpleMonitorFindResult
 		Error  error
@@ -8269,13 +8138,11 @@ func (t *SimpleMonitorTracer) Find(ctx context.Context, zone string, conditions 
 }
 
 // Create is API call with trace log
-func (t *SimpleMonitorTracer) Create(ctx context.Context, zone string, param *sacloud.SimpleMonitorCreateRequest) (*sacloud.SimpleMonitor, error) {
+func (t *SimpleMonitorTracer) Create(ctx context.Context, param *sacloud.SimpleMonitorCreateRequest) (*sacloud.SimpleMonitor, error) {
 	log.Println("[TRACE] SimpleMonitorAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                              `json:"zone"`
 		Argparam *sacloud.SimpleMonitorCreateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -8286,7 +8153,7 @@ func (t *SimpleMonitorTracer) Create(ctx context.Context, zone string, param *sa
 		log.Println("[TRACE] SimpleMonitorAPI.Create end")
 	}()
 
-	resultSimpleMonitor, err := t.Internal.Create(ctx, zone, param)
+	resultSimpleMonitor, err := t.Internal.Create(ctx, param)
 	targetResults := struct {
 		SimpleMonitor *sacloud.SimpleMonitor
 		Error         error
@@ -8302,14 +8169,12 @@ func (t *SimpleMonitorTracer) Create(ctx context.Context, zone string, param *sa
 }
 
 // Read is API call with trace log
-func (t *SimpleMonitorTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SimpleMonitor, error) {
+func (t *SimpleMonitorTracer) Read(ctx context.Context, id types.ID) (*sacloud.SimpleMonitor, error) {
 	log.Println("[TRACE] SimpleMonitorAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -8319,7 +8184,7 @@ func (t *SimpleMonitorTracer) Read(ctx context.Context, zone string, id types.ID
 		log.Println("[TRACE] SimpleMonitorAPI.Read end")
 	}()
 
-	resultSimpleMonitor, err := t.Internal.Read(ctx, zone, id)
+	resultSimpleMonitor, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		SimpleMonitor *sacloud.SimpleMonitor
 		Error         error
@@ -8335,14 +8200,12 @@ func (t *SimpleMonitorTracer) Read(ctx context.Context, zone string, id types.ID
 }
 
 // Update is API call with trace log
-func (t *SimpleMonitorTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SimpleMonitorUpdateRequest) (*sacloud.SimpleMonitor, error) {
+func (t *SimpleMonitorTracer) Update(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorUpdateRequest) (*sacloud.SimpleMonitor, error) {
 	log.Println("[TRACE] SimpleMonitorAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                              `json:"zone"`
 		Argid    types.ID                            `json:"id"`
 		Argparam *sacloud.SimpleMonitorUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -8354,7 +8217,7 @@ func (t *SimpleMonitorTracer) Update(ctx context.Context, zone string, id types.
 		log.Println("[TRACE] SimpleMonitorAPI.Update end")
 	}()
 
-	resultSimpleMonitor, err := t.Internal.Update(ctx, zone, id, param)
+	resultSimpleMonitor, err := t.Internal.Update(ctx, id, param)
 	targetResults := struct {
 		SimpleMonitor *sacloud.SimpleMonitor
 		Error         error
@@ -8370,14 +8233,12 @@ func (t *SimpleMonitorTracer) Update(ctx context.Context, zone string, id types.
 }
 
 // Delete is API call with trace log
-func (t *SimpleMonitorTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+func (t *SimpleMonitorTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SimpleMonitorAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -8387,7 +8248,7 @@ func (t *SimpleMonitorTracer) Delete(ctx context.Context, zone string, id types.
 		log.Println("[TRACE] SimpleMonitorAPI.Delete end")
 	}()
 
-	err := t.Internal.Delete(ctx, zone, id)
+	err := t.Internal.Delete(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -8401,14 +8262,12 @@ func (t *SimpleMonitorTracer) Delete(ctx context.Context, zone string, id types.
 }
 
 // MonitorResponseTime is API call with trace log
-func (t *SimpleMonitorTracer) MonitorResponseTime(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.ResponseTimeSecActivity, error) {
+func (t *SimpleMonitorTracer) MonitorResponseTime(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.ResponseTimeSecActivity, error) {
 	log.Println("[TRACE] SimpleMonitorAPI.MonitorResponseTime start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
 		Argid        types.ID                  `json:"id"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -8420,7 +8279,7 @@ func (t *SimpleMonitorTracer) MonitorResponseTime(ctx context.Context, zone stri
 		log.Println("[TRACE] SimpleMonitorAPI.MonitorResponseTime end")
 	}()
 
-	resultResponseTimeSecActivity, err := t.Internal.MonitorResponseTime(ctx, zone, id, condition)
+	resultResponseTimeSecActivity, err := t.Internal.MonitorResponseTime(ctx, id, condition)
 	targetResults := struct {
 		ResponseTimeSecActivity *sacloud.ResponseTimeSecActivity
 		Error                   error
@@ -8436,14 +8295,12 @@ func (t *SimpleMonitorTracer) MonitorResponseTime(ctx context.Context, zone stri
 }
 
 // HealthStatus is API call with trace log
-func (t *SimpleMonitorTracer) HealthStatus(ctx context.Context, zone string, id types.ID) (*sacloud.SimpleMonitorHealthStatus, error) {
+func (t *SimpleMonitorTracer) HealthStatus(ctx context.Context, id types.ID) (*sacloud.SimpleMonitorHealthStatus, error) {
 	log.Println("[TRACE] SimpleMonitorAPI.HealthStatus start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -8453,7 +8310,7 @@ func (t *SimpleMonitorTracer) HealthStatus(ctx context.Context, zone string, id 
 		log.Println("[TRACE] SimpleMonitorAPI.HealthStatus end")
 	}()
 
-	resultSimpleMonitorHealthStatus, err := t.Internal.HealthStatus(ctx, zone, id)
+	resultSimpleMonitorHealthStatus, err := t.Internal.HealthStatus(ctx, id)
 	targetResults := struct {
 		SimpleMonitorHealthStatus *sacloud.SimpleMonitorHealthStatus
 		Error                     error
@@ -8485,13 +8342,11 @@ func NewSSHKeyTracer(in sacloud.SSHKeyAPI) sacloud.SSHKeyAPI {
 }
 
 // Find is API call with trace log
-func (t *SSHKeyTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SSHKeyFindResult, error) {
+func (t *SSHKeyTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.SSHKeyFindResult, error) {
 	log.Println("[TRACE] SSHKeyAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -8502,7 +8357,7 @@ func (t *SSHKeyTracer) Find(ctx context.Context, zone string, conditions *saclou
 		log.Println("[TRACE] SSHKeyAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.SSHKeyFindResult
 		Error  error
@@ -8518,13 +8373,11 @@ func (t *SSHKeyTracer) Find(ctx context.Context, zone string, conditions *saclou
 }
 
 // Create is API call with trace log
-func (t *SSHKeyTracer) Create(ctx context.Context, zone string, param *sacloud.SSHKeyCreateRequest) (*sacloud.SSHKey, error) {
+func (t *SSHKeyTracer) Create(ctx context.Context, param *sacloud.SSHKeyCreateRequest) (*sacloud.SSHKey, error) {
 	log.Println("[TRACE] SSHKeyAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                       `json:"zone"`
 		Argparam *sacloud.SSHKeyCreateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -8535,7 +8388,7 @@ func (t *SSHKeyTracer) Create(ctx context.Context, zone string, param *sacloud.S
 		log.Println("[TRACE] SSHKeyAPI.Create end")
 	}()
 
-	resultSSHKey, err := t.Internal.Create(ctx, zone, param)
+	resultSSHKey, err := t.Internal.Create(ctx, param)
 	targetResults := struct {
 		SSHKey *sacloud.SSHKey
 		Error  error
@@ -8551,13 +8404,11 @@ func (t *SSHKeyTracer) Create(ctx context.Context, zone string, param *sacloud.S
 }
 
 // Generate is API call with trace log
-func (t *SSHKeyTracer) Generate(ctx context.Context, zone string, param *sacloud.SSHKeyGenerateRequest) (*sacloud.SSHKeyGenerated, error) {
+func (t *SSHKeyTracer) Generate(ctx context.Context, param *sacloud.SSHKeyGenerateRequest) (*sacloud.SSHKeyGenerated, error) {
 	log.Println("[TRACE] SSHKeyAPI.Generate start")
 	targetArguments := struct {
-		Argzone  string                         `json:"zone"`
 		Argparam *sacloud.SSHKeyGenerateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -8568,7 +8419,7 @@ func (t *SSHKeyTracer) Generate(ctx context.Context, zone string, param *sacloud
 		log.Println("[TRACE] SSHKeyAPI.Generate end")
 	}()
 
-	resultSSHKeyGenerated, err := t.Internal.Generate(ctx, zone, param)
+	resultSSHKeyGenerated, err := t.Internal.Generate(ctx, param)
 	targetResults := struct {
 		SSHKeyGenerated *sacloud.SSHKeyGenerated
 		Error           error
@@ -8584,14 +8435,12 @@ func (t *SSHKeyTracer) Generate(ctx context.Context, zone string, param *sacloud
 }
 
 // Read is API call with trace log
-func (t *SSHKeyTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.SSHKey, error) {
+func (t *SSHKeyTracer) Read(ctx context.Context, id types.ID) (*sacloud.SSHKey, error) {
 	log.Println("[TRACE] SSHKeyAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -8601,7 +8450,7 @@ func (t *SSHKeyTracer) Read(ctx context.Context, zone string, id types.ID) (*sac
 		log.Println("[TRACE] SSHKeyAPI.Read end")
 	}()
 
-	resultSSHKey, err := t.Internal.Read(ctx, zone, id)
+	resultSSHKey, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		SSHKey *sacloud.SSHKey
 		Error  error
@@ -8617,14 +8466,12 @@ func (t *SSHKeyTracer) Read(ctx context.Context, zone string, id types.ID) (*sac
 }
 
 // Update is API call with trace log
-func (t *SSHKeyTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SSHKeyUpdateRequest) (*sacloud.SSHKey, error) {
+func (t *SSHKeyTracer) Update(ctx context.Context, id types.ID, param *sacloud.SSHKeyUpdateRequest) (*sacloud.SSHKey, error) {
 	log.Println("[TRACE] SSHKeyAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                       `json:"zone"`
 		Argid    types.ID                     `json:"id"`
 		Argparam *sacloud.SSHKeyUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -8636,7 +8483,7 @@ func (t *SSHKeyTracer) Update(ctx context.Context, zone string, id types.ID, par
 		log.Println("[TRACE] SSHKeyAPI.Update end")
 	}()
 
-	resultSSHKey, err := t.Internal.Update(ctx, zone, id, param)
+	resultSSHKey, err := t.Internal.Update(ctx, id, param)
 	targetResults := struct {
 		SSHKey *sacloud.SSHKey
 		Error  error
@@ -8652,14 +8499,12 @@ func (t *SSHKeyTracer) Update(ctx context.Context, zone string, id types.ID, par
 }
 
 // Delete is API call with trace log
-func (t *SSHKeyTracer) Delete(ctx context.Context, zone string, id types.ID) error {
+func (t *SSHKeyTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SSHKeyAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -8669,7 +8514,7 @@ func (t *SSHKeyTracer) Delete(ctx context.Context, zone string, id types.ID) err
 		log.Println("[TRACE] SSHKeyAPI.Delete end")
 	}()
 
-	err := t.Internal.Delete(ctx, zone, id)
+	err := t.Internal.Delete(ctx, id)
 	targetResults := struct {
 		Error error
 	}{
@@ -8702,7 +8547,7 @@ func NewSwitchTracer(in sacloud.SwitchAPI) sacloud.SwitchAPI {
 func (t *SwitchTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.SwitchFindResult, error) {
 	log.Println("[TRACE] SwitchAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -8735,7 +8580,7 @@ func (t *SwitchTracer) Find(ctx context.Context, zone string, conditions *saclou
 func (t *SwitchTracer) Create(ctx context.Context, zone string, param *sacloud.SwitchCreateRequest) (*sacloud.Switch, error) {
 	log.Println("[TRACE] SwitchAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                       `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.SwitchCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -8768,7 +8613,7 @@ func (t *SwitchTracer) Create(ctx context.Context, zone string, param *sacloud.S
 func (t *SwitchTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Switch, error) {
 	log.Println("[TRACE] SwitchAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -8801,7 +8646,7 @@ func (t *SwitchTracer) Read(ctx context.Context, zone string, id types.ID) (*sac
 func (t *SwitchTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.SwitchUpdateRequest) (*sacloud.Switch, error) {
 	log.Println("[TRACE] SwitchAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                       `json:"zone"`
+		Argzone  string
 		Argid    types.ID                     `json:"id"`
 		Argparam *sacloud.SwitchUpdateRequest `json:"param"`
 	}{
@@ -8836,7 +8681,7 @@ func (t *SwitchTracer) Update(ctx context.Context, zone string, id types.ID, par
 func (t *SwitchTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] SwitchAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -8867,7 +8712,7 @@ func (t *SwitchTracer) Delete(ctx context.Context, zone string, id types.ID) err
 func (t *SwitchTracer) ConnectToBridge(ctx context.Context, zone string, id types.ID, bridgeID types.ID) error {
 	log.Println("[TRACE] SwitchAPI.ConnectToBridge start")
 	targetArguments := struct {
-		Argzone     string   `json:"zone"`
+		Argzone     string
 		Argid       types.ID `json:"id"`
 		ArgbridgeID types.ID `json:"bridgeID"`
 	}{
@@ -8900,7 +8745,7 @@ func (t *SwitchTracer) ConnectToBridge(ctx context.Context, zone string, id type
 func (t *SwitchTracer) DisconnectFromBridge(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] SwitchAPI.DisconnectFromBridge start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -8947,7 +8792,7 @@ func NewVPCRouterTracer(in sacloud.VPCRouterAPI) sacloud.VPCRouterAPI {
 func (t *VPCRouterTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.VPCRouterFindResult, error) {
 	log.Println("[TRACE] VPCRouterAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
+		Argzone       string
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
 		Argzone:       zone,
@@ -8980,7 +8825,7 @@ func (t *VPCRouterTracer) Find(ctx context.Context, zone string, conditions *sac
 func (t *VPCRouterTracer) Create(ctx context.Context, zone string, param *sacloud.VPCRouterCreateRequest) (*sacloud.VPCRouter, error) {
 	log.Println("[TRACE] VPCRouterAPI.Create start")
 	targetArguments := struct {
-		Argzone  string                          `json:"zone"`
+		Argzone  string
 		Argparam *sacloud.VPCRouterCreateRequest `json:"param"`
 	}{
 		Argzone:  zone,
@@ -9013,7 +8858,7 @@ func (t *VPCRouterTracer) Create(ctx context.Context, zone string, param *saclou
 func (t *VPCRouterTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.VPCRouter, error) {
 	log.Println("[TRACE] VPCRouterAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -9046,7 +8891,7 @@ func (t *VPCRouterTracer) Read(ctx context.Context, zone string, id types.ID) (*
 func (t *VPCRouterTracer) Update(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterUpdateRequest) (*sacloud.VPCRouter, error) {
 	log.Println("[TRACE] VPCRouterAPI.Update start")
 	targetArguments := struct {
-		Argzone  string                          `json:"zone"`
+		Argzone  string
 		Argid    types.ID                        `json:"id"`
 		Argparam *sacloud.VPCRouterUpdateRequest `json:"param"`
 	}{
@@ -9081,7 +8926,7 @@ func (t *VPCRouterTracer) Update(ctx context.Context, zone string, id types.ID, 
 func (t *VPCRouterTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] VPCRouterAPI.Delete start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -9112,7 +8957,7 @@ func (t *VPCRouterTracer) Delete(ctx context.Context, zone string, id types.ID) 
 func (t *VPCRouterTracer) Config(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] VPCRouterAPI.Config start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -9143,7 +8988,7 @@ func (t *VPCRouterTracer) Config(ctx context.Context, zone string, id types.ID) 
 func (t *VPCRouterTracer) Boot(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] VPCRouterAPI.Boot start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -9174,7 +9019,7 @@ func (t *VPCRouterTracer) Boot(ctx context.Context, zone string, id types.ID) er
 func (t *VPCRouterTracer) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
 	log.Println("[TRACE] VPCRouterAPI.Shutdown start")
 	targetArguments := struct {
-		Argzone           string                  `json:"zone"`
+		Argzone           string
 		Argid             types.ID                `json:"id"`
 		ArgshutdownOption *sacloud.ShutdownOption `json:"shutdownOption"`
 	}{
@@ -9207,7 +9052,7 @@ func (t *VPCRouterTracer) Shutdown(ctx context.Context, zone string, id types.ID
 func (t *VPCRouterTracer) Reset(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] VPCRouterAPI.Reset start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
+		Argzone string
 		Argid   types.ID `json:"id"`
 	}{
 		Argzone: zone,
@@ -9238,7 +9083,7 @@ func (t *VPCRouterTracer) Reset(ctx context.Context, zone string, id types.ID) e
 func (t *VPCRouterTracer) ConnectToSwitch(ctx context.Context, zone string, id types.ID, nicIndex int, switchID types.ID) error {
 	log.Println("[TRACE] VPCRouterAPI.ConnectToSwitch start")
 	targetArguments := struct {
-		Argzone     string   `json:"zone"`
+		Argzone     string
 		Argid       types.ID `json:"id"`
 		ArgnicIndex int      `json:"nicIndex"`
 		ArgswitchID types.ID `json:"switchID"`
@@ -9273,7 +9118,7 @@ func (t *VPCRouterTracer) ConnectToSwitch(ctx context.Context, zone string, id t
 func (t *VPCRouterTracer) DisconnectFromSwitch(ctx context.Context, zone string, id types.ID, nicIndex int) error {
 	log.Println("[TRACE] VPCRouterAPI.DisconnectFromSwitch start")
 	targetArguments := struct {
-		Argzone     string   `json:"zone"`
+		Argzone     string
 		Argid       types.ID `json:"id"`
 		ArgnicIndex int      `json:"nicIndex"`
 	}{
@@ -9306,7 +9151,7 @@ func (t *VPCRouterTracer) DisconnectFromSwitch(ctx context.Context, zone string,
 func (t *VPCRouterTracer) MonitorInterface(ctx context.Context, zone string, id types.ID, index int, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
 	log.Println("[TRACE] VPCRouterAPI.MonitorInterface start")
 	targetArguments := struct {
-		Argzone      string                    `json:"zone"`
+		Argzone      string
 		Argid        types.ID                  `json:"id"`
 		Argindex     int                       `json:"index"`
 		Argcondition *sacloud.MonitorCondition `json:"condition"`
@@ -9356,13 +9201,10 @@ func NewWebAccelTracer(in sacloud.WebAccelAPI) sacloud.WebAccelAPI {
 }
 
 // List is API call with trace log
-func (t *WebAccelTracer) List(ctx context.Context, zone string) (*sacloud.WebAccelListResult, error) {
+func (t *WebAccelTracer) List(ctx context.Context) (*sacloud.WebAccelListResult, error) {
 	log.Println("[TRACE] WebAccelAPI.List start")
 	targetArguments := struct {
-		Argzone string `json:"zone"`
-	}{
-		Argzone: zone,
-	}
+	}{}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
 	}
@@ -9371,7 +9213,7 @@ func (t *WebAccelTracer) List(ctx context.Context, zone string) (*sacloud.WebAcc
 		log.Println("[TRACE] WebAccelAPI.List end")
 	}()
 
-	result, err := t.Internal.List(ctx, zone)
+	result, err := t.Internal.List(ctx)
 	targetResults := struct {
 		Result *sacloud.WebAccelListResult
 		Error  error
@@ -9387,14 +9229,12 @@ func (t *WebAccelTracer) List(ctx context.Context, zone string) (*sacloud.WebAcc
 }
 
 // Read is API call with trace log
-func (t *WebAccelTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.WebAccel, error) {
+func (t *WebAccelTracer) Read(ctx context.Context, id types.ID) (*sacloud.WebAccel, error) {
 	log.Println("[TRACE] WebAccelAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -9404,7 +9244,7 @@ func (t *WebAccelTracer) Read(ctx context.Context, zone string, id types.ID) (*s
 		log.Println("[TRACE] WebAccelAPI.Read end")
 	}()
 
-	resultWebAccel, err := t.Internal.Read(ctx, zone, id)
+	resultWebAccel, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		WebAccel *sacloud.WebAccel
 		Error    error
@@ -9420,14 +9260,12 @@ func (t *WebAccelTracer) Read(ctx context.Context, zone string, id types.ID) (*s
 }
 
 // ReadCertificate is API call with trace log
-func (t *WebAccelTracer) ReadCertificate(ctx context.Context, zone string, id types.ID) (*sacloud.WebAccelCerts, error) {
+func (t *WebAccelTracer) ReadCertificate(ctx context.Context, id types.ID) (*sacloud.WebAccelCerts, error) {
 	log.Println("[TRACE] WebAccelAPI.ReadCertificate start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -9437,7 +9275,7 @@ func (t *WebAccelTracer) ReadCertificate(ctx context.Context, zone string, id ty
 		log.Println("[TRACE] WebAccelAPI.ReadCertificate end")
 	}()
 
-	resultCertificate, err := t.Internal.ReadCertificate(ctx, zone, id)
+	resultCertificate, err := t.Internal.ReadCertificate(ctx, id)
 	targetResults := struct {
 		Certificate *sacloud.WebAccelCerts
 		Error       error
@@ -9453,14 +9291,12 @@ func (t *WebAccelTracer) ReadCertificate(ctx context.Context, zone string, id ty
 }
 
 // UpdateCertificate is API call with trace log
-func (t *WebAccelTracer) UpdateCertificate(ctx context.Context, zone string, id types.ID, param *sacloud.WebAccelCertUpdateRequest) (*sacloud.WebAccelCerts, error) {
+func (t *WebAccelTracer) UpdateCertificate(ctx context.Context, id types.ID, param *sacloud.WebAccelCertUpdateRequest) (*sacloud.WebAccelCerts, error) {
 	log.Println("[TRACE] WebAccelAPI.UpdateCertificate start")
 	targetArguments := struct {
-		Argzone  string                             `json:"zone"`
 		Argid    types.ID                           `json:"id"`
 		Argparam *sacloud.WebAccelCertUpdateRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -9472,7 +9308,7 @@ func (t *WebAccelTracer) UpdateCertificate(ctx context.Context, zone string, id 
 		log.Println("[TRACE] WebAccelAPI.UpdateCertificate end")
 	}()
 
-	resultCertificate, err := t.Internal.UpdateCertificate(ctx, zone, id, param)
+	resultCertificate, err := t.Internal.UpdateCertificate(ctx, id, param)
 	targetResults := struct {
 		Certificate *sacloud.WebAccelCerts
 		Error       error
@@ -9488,13 +9324,11 @@ func (t *WebAccelTracer) UpdateCertificate(ctx context.Context, zone string, id 
 }
 
 // DeleteAllCache is API call with trace log
-func (t *WebAccelTracer) DeleteAllCache(ctx context.Context, zone string, param *sacloud.WebAccelDeleteAllCacheRequest) error {
+func (t *WebAccelTracer) DeleteAllCache(ctx context.Context, param *sacloud.WebAccelDeleteAllCacheRequest) error {
 	log.Println("[TRACE] WebAccelAPI.DeleteAllCache start")
 	targetArguments := struct {
-		Argzone  string                                 `json:"zone"`
 		Argparam *sacloud.WebAccelDeleteAllCacheRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -9505,7 +9339,7 @@ func (t *WebAccelTracer) DeleteAllCache(ctx context.Context, zone string, param 
 		log.Println("[TRACE] WebAccelAPI.DeleteAllCache end")
 	}()
 
-	err := t.Internal.DeleteAllCache(ctx, zone, param)
+	err := t.Internal.DeleteAllCache(ctx, param)
 	targetResults := struct {
 		Error error
 	}{
@@ -9519,13 +9353,11 @@ func (t *WebAccelTracer) DeleteAllCache(ctx context.Context, zone string, param 
 }
 
 // DeleteCache is API call with trace log
-func (t *WebAccelTracer) DeleteCache(ctx context.Context, zone string, param *sacloud.WebAccelDeleteCacheRequest) ([]*sacloud.WebAccelDeleteCacheResult, error) {
+func (t *WebAccelTracer) DeleteCache(ctx context.Context, param *sacloud.WebAccelDeleteCacheRequest) ([]*sacloud.WebAccelDeleteCacheResult, error) {
 	log.Println("[TRACE] WebAccelAPI.DeleteCache start")
 	targetArguments := struct {
-		Argzone  string                              `json:"zone"`
 		Argparam *sacloud.WebAccelDeleteCacheRequest `json:"param"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -9536,7 +9368,7 @@ func (t *WebAccelTracer) DeleteCache(ctx context.Context, zone string, param *sa
 		log.Println("[TRACE] WebAccelAPI.DeleteCache end")
 	}()
 
-	resultResults, err := t.Internal.DeleteCache(ctx, zone, param)
+	resultResults, err := t.Internal.DeleteCache(ctx, param)
 	targetResults := struct {
 		Results []*sacloud.WebAccelDeleteCacheResult
 		Error   error
@@ -9568,13 +9400,11 @@ func NewZoneTracer(in sacloud.ZoneAPI) sacloud.ZoneAPI {
 }
 
 // Find is API call with trace log
-func (t *ZoneTracer) Find(ctx context.Context, zone string, conditions *sacloud.FindCondition) (*sacloud.ZoneFindResult, error) {
+func (t *ZoneTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.ZoneFindResult, error) {
 	log.Println("[TRACE] ZoneAPI.Find start")
 	targetArguments := struct {
-		Argzone       string                 `json:"zone"`
 		Argconditions *sacloud.FindCondition `json:"conditions"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
@@ -9585,7 +9415,7 @@ func (t *ZoneTracer) Find(ctx context.Context, zone string, conditions *sacloud.
 		log.Println("[TRACE] ZoneAPI.Find end")
 	}()
 
-	result, err := t.Internal.Find(ctx, zone, conditions)
+	result, err := t.Internal.Find(ctx, conditions)
 	targetResults := struct {
 		Result *sacloud.ZoneFindResult
 		Error  error
@@ -9601,14 +9431,12 @@ func (t *ZoneTracer) Find(ctx context.Context, zone string, conditions *sacloud.
 }
 
 // Read is API call with trace log
-func (t *ZoneTracer) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Zone, error) {
+func (t *ZoneTracer) Read(ctx context.Context, id types.ID) (*sacloud.Zone, error) {
 	log.Println("[TRACE] ZoneAPI.Read start")
 	targetArguments := struct {
-		Argzone string   `json:"zone"`
-		Argid   types.ID `json:"id"`
+		Argid types.ID `json:"id"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argid: id,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -9618,7 +9446,7 @@ func (t *ZoneTracer) Read(ctx context.Context, zone string, id types.ID) (*saclo
 		log.Println("[TRACE] ZoneAPI.Read end")
 	}()
 
-	resultZone, err := t.Internal.Read(ctx, zone, id)
+	resultZone, err := t.Internal.Read(ctx, id)
 	targetResults := struct {
 		Zone  *sacloud.Zone
 		Error error

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -358,7 +358,6 @@ func (o *ArchiveOp) Find(ctx context.Context, zone string, conditions *FindCondi
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -367,17 +366,12 @@ func (o *ArchiveOp) Find(ctx context.Context, zone string, conditions *FindCondi
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -410,7 +404,6 @@ func (o *ArchiveOp) Create(ctx context.Context, zone string, param *ArchiveCreat
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -419,17 +412,12 @@ func (o *ArchiveOp) Create(ctx context.Context, zone string, param *ArchiveCreat
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &ArchiveCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *ArchiveCreateRequest `mapconv:"Archive,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -462,7 +450,6 @@ func (o *ArchiveOp) CreateBlank(ctx context.Context, zone string, param *Archive
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -471,17 +458,12 @@ func (o *ArchiveOp) CreateBlank(ctx context.Context, zone string, param *Archive
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &ArchiveCreateBlankRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *ArchiveCreateBlankRequest `mapconv:"Archive,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -514,7 +496,6 @@ func (o *ArchiveOp) Read(ctx context.Context, zone string, id types.ID) (*Archiv
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -546,7 +527,6 @@ func (o *ArchiveOp) Update(ctx context.Context, zone string, id types.ID, param 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -556,9 +536,6 @@ func (o *ArchiveOp) Update(ctx context.Context, zone string, id types.ID, param 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -566,11 +543,9 @@ func (o *ArchiveOp) Update(ctx context.Context, zone string, id types.ID, param 
 		param = &ArchiveUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *ArchiveUpdateRequest `mapconv:"Archive,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -604,7 +579,6 @@ func (o *ArchiveOp) Delete(ctx context.Context, zone string, id types.ID) error 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -627,7 +601,6 @@ func (o *ArchiveOp) OpenFTP(ctx context.Context, zone string, id types.ID, openO
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"openOption": openOption,
 	})
@@ -637,9 +610,6 @@ func (o *ArchiveOp) OpenFTP(ctx context.Context, zone string, id types.ID, openO
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -647,11 +617,9 @@ func (o *ArchiveOp) OpenFTP(ctx context.Context, zone string, id types.ID, openO
 		openOption = &OpenFTPRequest{}
 	}
 	args := &struct {
-		Argzone       string
 		Argid         types.ID
 		ArgopenOption *OpenFTPRequest `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argid:         id,
 		ArgopenOption: openOption,
 	}
@@ -685,7 +653,6 @@ func (o *ArchiveOp) CloseFTP(ctx context.Context, zone string, id types.ID) erro
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -722,12 +689,12 @@ func NewAuthStatusOp(caller APICaller) AuthStatusAPI {
 }
 
 // Read is API call
-func (o *AuthStatusOp) Read(ctx context.Context, zone string) (*AuthStatus, error) {
+func (o *AuthStatusOp) Read(ctx context.Context) (*AuthStatus, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 	})
 	if err != nil {
 		return nil, err
@@ -777,7 +744,6 @@ func (o *AutoBackupOp) Find(ctx context.Context, zone string, conditions *FindCo
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -786,17 +752,12 @@ func (o *AutoBackupOp) Find(ctx context.Context, zone string, conditions *FindCo
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -829,7 +790,6 @@ func (o *AutoBackupOp) Create(ctx context.Context, zone string, param *AutoBacku
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -838,17 +798,12 @@ func (o *AutoBackupOp) Create(ctx context.Context, zone string, param *AutoBacku
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &AutoBackupCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *AutoBackupCreateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -881,7 +836,6 @@ func (o *AutoBackupOp) Read(ctx context.Context, zone string, id types.ID) (*Aut
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -913,7 +867,6 @@ func (o *AutoBackupOp) Update(ctx context.Context, zone string, id types.ID, par
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -923,9 +876,6 @@ func (o *AutoBackupOp) Update(ctx context.Context, zone string, id types.ID, par
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -933,11 +883,9 @@ func (o *AutoBackupOp) Update(ctx context.Context, zone string, id types.ID, par
 		param = &AutoBackupUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *AutoBackupUpdateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -971,7 +919,6 @@ func (o *AutoBackupOp) Delete(ctx context.Context, zone string, id types.ID) err
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1008,12 +955,12 @@ func NewBillOp(caller APICaller) BillAPI {
 }
 
 // ByContract is API call
-func (o *BillOp) ByContract(ctx context.Context, zone string, accountID types.ID) (*BillByContractResult, error) {
+func (o *BillOp) ByContract(ctx context.Context, accountID types.ID) (*BillByContractResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/by-contract/{{.accountID}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"accountID":  accountID,
 	})
 	if err != nil {
@@ -1040,12 +987,12 @@ func (o *BillOp) ByContract(ctx context.Context, zone string, accountID types.ID
 }
 
 // ByContractYear is API call
-func (o *BillOp) ByContractYear(ctx context.Context, zone string, accountID types.ID, year int) (*BillByContractYearResult, error) {
+func (o *BillOp) ByContractYear(ctx context.Context, accountID types.ID, year int) (*BillByContractYearResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/by-contract/{{.accountID}}/{{.year}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"accountID":  accountID,
 		"year":       year,
 	})
@@ -1073,12 +1020,12 @@ func (o *BillOp) ByContractYear(ctx context.Context, zone string, accountID type
 }
 
 // ByContractYearMonth is API call
-func (o *BillOp) ByContractYearMonth(ctx context.Context, zone string, accountID types.ID, year int, month int) (*BillByContractYearMonthResult, error) {
+func (o *BillOp) ByContractYearMonth(ctx context.Context, accountID types.ID, year int, month int) (*BillByContractYearMonthResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/by-contract/{{.accountID}}/{{.year}}/{{.month}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"accountID":  accountID,
 		"year":       year,
 		"month":      month,
@@ -1107,12 +1054,12 @@ func (o *BillOp) ByContractYearMonth(ctx context.Context, zone string, accountID
 }
 
 // Read is API call
-func (o *BillOp) Read(ctx context.Context, zone string, id types.ID) (*BillReadResult, error) {
+func (o *BillOp) Read(ctx context.Context, id types.ID) (*BillReadResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/id/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1139,12 +1086,12 @@ func (o *BillOp) Read(ctx context.Context, zone string, id types.ID) (*BillReadR
 }
 
 // Details is API call
-func (o *BillOp) Details(ctx context.Context, zone string, MemberCode string, id types.ID) (*BillDetailsResult, error) {
+func (o *BillOp) Details(ctx context.Context, MemberCode string, id types.ID) (*BillDetailsResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}detail/{{.MemberCode}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"MemberCode": MemberCode,
 		"id":         id,
 	})
@@ -1172,12 +1119,12 @@ func (o *BillOp) Details(ctx context.Context, zone string, MemberCode string, id
 }
 
 // DetailsCSV is API call
-func (o *BillOp) DetailsCSV(ctx context.Context, zone string, MemberCode string, id types.ID) (*BillDetailCSV, error) {
+func (o *BillOp) DetailsCSV(ctx context.Context, MemberCode string, id types.ID) (*BillDetailCSV, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}detail/{{.MemberCode}}/{{.id}}/csv", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"MemberCode": MemberCode,
 		"id":         id,
 	})
@@ -1229,7 +1176,6 @@ func (o *BridgeOp) Find(ctx context.Context, zone string, conditions *FindCondit
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -1238,17 +1184,12 @@ func (o *BridgeOp) Find(ctx context.Context, zone string, conditions *FindCondit
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -1281,7 +1222,6 @@ func (o *BridgeOp) Create(ctx context.Context, zone string, param *BridgeCreateR
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -1290,17 +1230,12 @@ func (o *BridgeOp) Create(ctx context.Context, zone string, param *BridgeCreateR
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &BridgeCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *BridgeCreateRequest `mapconv:"Bridge,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -1333,7 +1268,6 @@ func (o *BridgeOp) Read(ctx context.Context, zone string, id types.ID) (*Bridge,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1365,7 +1299,6 @@ func (o *BridgeOp) Update(ctx context.Context, zone string, id types.ID, param *
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -1375,9 +1308,6 @@ func (o *BridgeOp) Update(ctx context.Context, zone string, id types.ID, param *
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -1385,11 +1315,9 @@ func (o *BridgeOp) Update(ctx context.Context, zone string, id types.ID, param *
 		param = &BridgeUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *BridgeUpdateRequest `mapconv:"Bridge,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -1423,7 +1351,6 @@ func (o *BridgeOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1465,7 +1392,6 @@ func (o *CDROMOp) Find(ctx context.Context, zone string, conditions *FindConditi
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -1474,17 +1400,12 @@ func (o *CDROMOp) Find(ctx context.Context, zone string, conditions *FindConditi
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -1517,7 +1438,6 @@ func (o *CDROMOp) Create(ctx context.Context, zone string, param *CDROMCreateReq
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -1526,17 +1446,12 @@ func (o *CDROMOp) Create(ctx context.Context, zone string, param *CDROMCreateReq
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &CDROMCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *CDROMCreateRequest `mapconv:"CDROM,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -1569,7 +1484,6 @@ func (o *CDROMOp) Read(ctx context.Context, zone string, id types.ID) (*CDROM, e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1601,7 +1515,6 @@ func (o *CDROMOp) Update(ctx context.Context, zone string, id types.ID, param *C
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -1611,9 +1524,6 @@ func (o *CDROMOp) Update(ctx context.Context, zone string, id types.ID, param *C
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -1621,11 +1531,9 @@ func (o *CDROMOp) Update(ctx context.Context, zone string, id types.ID, param *C
 		param = &CDROMUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *CDROMUpdateRequest `mapconv:"CDROM,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -1659,7 +1567,6 @@ func (o *CDROMOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1682,7 +1589,6 @@ func (o *CDROMOp) OpenFTP(ctx context.Context, zone string, id types.ID, openOpt
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"openOption": openOption,
 	})
@@ -1692,9 +1598,6 @@ func (o *CDROMOp) OpenFTP(ctx context.Context, zone string, id types.ID, openOpt
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -1702,11 +1605,9 @@ func (o *CDROMOp) OpenFTP(ctx context.Context, zone string, id types.ID, openOpt
 		openOption = &OpenFTPRequest{}
 	}
 	args := &struct {
-		Argzone       string
 		Argid         types.ID
 		ArgopenOption *OpenFTPRequest `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argid:         id,
 		ArgopenOption: openOption,
 	}
@@ -1740,7 +1641,6 @@ func (o *CDROMOp) CloseFTP(ctx context.Context, zone string, id types.ID) error 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1777,12 +1677,12 @@ func NewCouponOp(caller APICaller) CouponAPI {
 }
 
 // Find is API call
-func (o *CouponOp) Find(ctx context.Context, zone string, accountID types.ID) (*CouponFindResult, error) {
+func (o *CouponOp) Find(ctx context.Context, accountID types.ID) (*CouponFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.accountID}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"accountID":  accountID,
 	})
 	if err != nil {
@@ -1833,7 +1733,6 @@ func (o *DatabaseOp) Find(ctx context.Context, zone string, conditions *FindCond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -1842,17 +1741,12 @@ func (o *DatabaseOp) Find(ctx context.Context, zone string, conditions *FindCond
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -1885,7 +1779,6 @@ func (o *DatabaseOp) Create(ctx context.Context, zone string, param *DatabaseCre
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -1894,17 +1787,12 @@ func (o *DatabaseOp) Create(ctx context.Context, zone string, param *DatabaseCre
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &DatabaseCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *DatabaseCreateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -1937,7 +1825,6 @@ func (o *DatabaseOp) Read(ctx context.Context, zone string, id types.ID) (*Datab
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1969,7 +1856,6 @@ func (o *DatabaseOp) Update(ctx context.Context, zone string, id types.ID, param
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -1979,9 +1865,6 @@ func (o *DatabaseOp) Update(ctx context.Context, zone string, id types.ID, param
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -1989,11 +1872,9 @@ func (o *DatabaseOp) Update(ctx context.Context, zone string, id types.ID, param
 		param = &DatabaseUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *DatabaseUpdateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -2027,7 +1908,6 @@ func (o *DatabaseOp) Delete(ctx context.Context, zone string, id types.ID) error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2050,7 +1930,6 @@ func (o *DatabaseOp) Config(ctx context.Context, zone string, id types.ID) error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2073,7 +1952,6 @@ func (o *DatabaseOp) Boot(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2096,7 +1974,6 @@ func (o *DatabaseOp) Shutdown(ctx context.Context, zone string, id types.ID, shu
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
-		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -2106,9 +1983,6 @@ func (o *DatabaseOp) Shutdown(ctx context.Context, zone string, id types.ID, shu
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -2116,11 +1990,9 @@ func (o *DatabaseOp) Shutdown(ctx context.Context, zone string, id types.ID, shu
 		shutdownOption = &ShutdownOption{}
 	}
 	args := &struct {
-		Argzone           string
 		Argid             types.ID
 		ArgshutdownOption *ShutdownOption `mapconv:",squash"`
 	}{
-		Argzone:           zone,
 		Argid:             id,
 		ArgshutdownOption: shutdownOption,
 	}
@@ -2145,7 +2017,6 @@ func (o *DatabaseOp) Reset(ctx context.Context, zone string, id types.ID) error 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2168,7 +2039,6 @@ func (o *DatabaseOp) MonitorCPU(ctx context.Context, zone string, id types.ID, c
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -2178,9 +2048,6 @@ func (o *DatabaseOp) MonitorCPU(ctx context.Context, zone string, id types.ID, c
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -2188,11 +2055,9 @@ func (o *DatabaseOp) MonitorCPU(ctx context.Context, zone string, id types.ID, c
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -2226,7 +2091,6 @@ func (o *DatabaseOp) MonitorDisk(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -2236,9 +2100,6 @@ func (o *DatabaseOp) MonitorDisk(ctx context.Context, zone string, id types.ID, 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -2246,11 +2107,9 @@ func (o *DatabaseOp) MonitorDisk(ctx context.Context, zone string, id types.ID, 
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -2284,7 +2143,6 @@ func (o *DatabaseOp) MonitorInterface(ctx context.Context, zone string, id types
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -2294,9 +2152,6 @@ func (o *DatabaseOp) MonitorInterface(ctx context.Context, zone string, id types
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -2304,11 +2159,9 @@ func (o *DatabaseOp) MonitorInterface(ctx context.Context, zone string, id types
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -2342,7 +2195,6 @@ func (o *DatabaseOp) MonitorDatabase(ctx context.Context, zone string, id types.
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -2352,9 +2204,6 @@ func (o *DatabaseOp) MonitorDatabase(ctx context.Context, zone string, id types.
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -2362,11 +2211,9 @@ func (o *DatabaseOp) MonitorDatabase(ctx context.Context, zone string, id types.
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -2400,7 +2247,6 @@ func (o *DatabaseOp) Status(ctx context.Context, zone string, id types.ID) (*Dat
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2451,7 +2297,6 @@ func (o *DiskOp) Find(ctx context.Context, zone string, conditions *FindConditio
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -2460,17 +2305,12 @@ func (o *DiskOp) Find(ctx context.Context, zone string, conditions *FindConditio
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -2503,7 +2343,6 @@ func (o *DiskOp) Create(ctx context.Context, zone string, param *DiskCreateReque
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -2512,17 +2351,12 @@ func (o *DiskOp) Create(ctx context.Context, zone string, param *DiskCreateReque
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &DiskCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *DiskCreateRequest `mapconv:"Disk,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -2555,7 +2389,6 @@ func (o *DiskOp) CreateDistantly(ctx context.Context, zone string, createParam *
 		"rootURL":     SakuraCloudAPIRoot,
 		"pathSuffix":  o.PathSuffix,
 		"pathName":    o.PathName,
-		"zone":        zone,
 		"createParam": createParam,
 		"distantFrom": distantFrom,
 	})
@@ -2565,9 +2398,6 @@ func (o *DiskOp) CreateDistantly(ctx context.Context, zone string, createParam *
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if createParam == nil {
 		createParam = &DiskCreateRequest{}
 	}
@@ -2575,11 +2405,9 @@ func (o *DiskOp) CreateDistantly(ctx context.Context, zone string, createParam *
 		distantFrom = []types.ID{}
 	}
 	args := &struct {
-		Argzone        string
 		ArgcreateParam *DiskCreateRequest `mapconv:"Disk"`
 		ArgdistantFrom []types.ID         `mapconv:"DistantFrom"`
 	}{
-		Argzone:        zone,
 		ArgcreateParam: createParam,
 		ArgdistantFrom: distantFrom,
 	}
@@ -2613,7 +2441,6 @@ func (o *DiskOp) Config(ctx context.Context, zone string, id types.ID, edit *Dis
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"edit":       edit,
 	})
@@ -2623,9 +2450,6 @@ func (o *DiskOp) Config(ctx context.Context, zone string, id types.ID, edit *Dis
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -2633,11 +2457,9 @@ func (o *DiskOp) Config(ctx context.Context, zone string, id types.ID, edit *Dis
 		edit = &DiskEditRequest{}
 	}
 	args := &struct {
-		Argzone string
 		Argid   types.ID
 		Argedit *DiskEditRequest `mapconv:",squash"`
 	}{
-		Argzone: zone,
 		Argid:   id,
 		Argedit: edit,
 	}
@@ -2662,7 +2484,6 @@ func (o *DiskOp) CreateWithConfig(ctx context.Context, zone string, createParam 
 		"rootURL":         SakuraCloudAPIRoot,
 		"pathSuffix":      o.PathSuffix,
 		"pathName":        o.PathName,
-		"zone":            zone,
 		"createParam":     createParam,
 		"editParam":       editParam,
 		"bootAtAvailable": bootAtAvailable,
@@ -2673,9 +2494,6 @@ func (o *DiskOp) CreateWithConfig(ctx context.Context, zone string, createParam 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if createParam == nil {
 		createParam = &DiskCreateRequest{}
 	}
@@ -2686,12 +2504,10 @@ func (o *DiskOp) CreateWithConfig(ctx context.Context, zone string, createParam 
 		bootAtAvailable = false
 	}
 	args := &struct {
-		Argzone            string
 		ArgcreateParam     *DiskCreateRequest `mapconv:"Disk"`
 		ArgeditParam       *DiskEditRequest   `mapconv:"Config"`
 		ArgbootAtAvailable bool               `mapconv:"BootAtAvailable"`
 	}{
-		Argzone:            zone,
 		ArgcreateParam:     createParam,
 		ArgeditParam:       editParam,
 		ArgbootAtAvailable: bootAtAvailable,
@@ -2726,7 +2542,6 @@ func (o *DiskOp) CreateWithConfigDistantly(ctx context.Context, zone string, cre
 		"rootURL":         SakuraCloudAPIRoot,
 		"pathSuffix":      o.PathSuffix,
 		"pathName":        o.PathName,
-		"zone":            zone,
 		"createParam":     createParam,
 		"editParam":       editParam,
 		"bootAtAvailable": bootAtAvailable,
@@ -2738,9 +2553,6 @@ func (o *DiskOp) CreateWithConfigDistantly(ctx context.Context, zone string, cre
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if createParam == nil {
 		createParam = &DiskCreateRequest{}
 	}
@@ -2754,13 +2566,11 @@ func (o *DiskOp) CreateWithConfigDistantly(ctx context.Context, zone string, cre
 		distantFrom = []types.ID{}
 	}
 	args := &struct {
-		Argzone            string
 		ArgcreateParam     *DiskCreateRequest `mapconv:"Disk"`
 		ArgeditParam       *DiskEditRequest   `mapconv:"Config"`
 		ArgbootAtAvailable bool               `mapconv:"BootAtAvailable"`
 		ArgdistantFrom     []types.ID         `mapconv:"DistantFrom"`
 	}{
-		Argzone:            zone,
 		ArgcreateParam:     createParam,
 		ArgeditParam:       editParam,
 		ArgbootAtAvailable: bootAtAvailable,
@@ -2796,7 +2606,6 @@ func (o *DiskOp) ToBlank(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2819,7 +2628,6 @@ func (o *DiskOp) ResizePartition(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2842,7 +2650,6 @@ func (o *DiskOp) ConnectToServer(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"serverID":   serverID,
 	})
@@ -2866,7 +2673,6 @@ func (o *DiskOp) DisconnectFromServer(ctx context.Context, zone string, id types
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2889,7 +2695,6 @@ func (o *DiskOp) InstallDistantFrom(ctx context.Context, zone string, id types.I
 		"rootURL":      SakuraCloudAPIRoot,
 		"pathSuffix":   o.PathSuffix,
 		"pathName":     o.PathName,
-		"zone":         zone,
 		"id":           id,
 		"installParam": installParam,
 		"distantFrom":  distantFrom,
@@ -2900,9 +2705,6 @@ func (o *DiskOp) InstallDistantFrom(ctx context.Context, zone string, id types.I
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -2913,12 +2715,10 @@ func (o *DiskOp) InstallDistantFrom(ctx context.Context, zone string, id types.I
 		distantFrom = []types.ID{}
 	}
 	args := &struct {
-		Argzone         string
 		Argid           types.ID
 		ArginstallParam *DiskInstallRequest `mapconv:"Disk"`
 		ArgdistantFrom  []types.ID          `mapconv:"DistantFrom"`
 	}{
-		Argzone:         zone,
 		Argid:           id,
 		ArginstallParam: installParam,
 		ArgdistantFrom:  distantFrom,
@@ -2953,7 +2753,6 @@ func (o *DiskOp) Install(ctx context.Context, zone string, id types.ID, installP
 		"rootURL":      SakuraCloudAPIRoot,
 		"pathSuffix":   o.PathSuffix,
 		"pathName":     o.PathName,
-		"zone":         zone,
 		"id":           id,
 		"installParam": installParam,
 	})
@@ -2963,9 +2762,6 @@ func (o *DiskOp) Install(ctx context.Context, zone string, id types.ID, installP
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -2973,11 +2769,9 @@ func (o *DiskOp) Install(ctx context.Context, zone string, id types.ID, installP
 		installParam = &DiskInstallRequest{}
 	}
 	args := &struct {
-		Argzone         string
 		Argid           types.ID
 		ArginstallParam *DiskInstallRequest `mapconv:"Disk"`
 	}{
-		Argzone:         zone,
 		Argid:           id,
 		ArginstallParam: installParam,
 	}
@@ -3011,7 +2805,6 @@ func (o *DiskOp) Read(ctx context.Context, zone string, id types.ID) (*Disk, err
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3043,7 +2836,6 @@ func (o *DiskOp) Update(ctx context.Context, zone string, id types.ID, param *Di
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -3053,9 +2845,6 @@ func (o *DiskOp) Update(ctx context.Context, zone string, id types.ID, param *Di
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -3063,11 +2852,9 @@ func (o *DiskOp) Update(ctx context.Context, zone string, id types.ID, param *Di
 		param = &DiskUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *DiskUpdateRequest `mapconv:"Disk,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -3101,7 +2888,6 @@ func (o *DiskOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3124,7 +2910,6 @@ func (o *DiskOp) Monitor(ctx context.Context, zone string, id types.ID, conditio
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -3134,9 +2919,6 @@ func (o *DiskOp) Monitor(ctx context.Context, zone string, id types.ID, conditio
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -3144,11 +2926,9 @@ func (o *DiskOp) Monitor(ctx context.Context, zone string, id types.ID, conditio
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -3201,7 +2981,6 @@ func (o *DiskPlanOp) Find(ctx context.Context, zone string, conditions *FindCond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -3210,17 +2989,12 @@ func (o *DiskPlanOp) Find(ctx context.Context, zone string, conditions *FindCond
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -3253,7 +3027,6 @@ func (o *DiskPlanOp) Read(ctx context.Context, zone string, id types.ID) (*DiskP
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3299,12 +3072,12 @@ func NewDNSOp(caller APICaller) DNSAPI {
 }
 
 // Find is API call
-func (o *DNSOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*DNSFindResult, error) {
+func (o *DNSOp) Find(ctx context.Context, conditions *FindCondition) (*DNSFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -3313,17 +3086,12 @@ func (o *DNSOp) Find(ctx context.Context, zone string, conditions *FindCondition
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -3351,12 +3119,12 @@ func (o *DNSOp) Find(ctx context.Context, zone string, conditions *FindCondition
 }
 
 // Create is API call
-func (o *DNSOp) Create(ctx context.Context, zone string, param *DNSCreateRequest) (*DNS, error) {
+func (o *DNSOp) Create(ctx context.Context, param *DNSCreateRequest) (*DNS, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -3365,17 +3133,12 @@ func (o *DNSOp) Create(ctx context.Context, zone string, param *DNSCreateRequest
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &DNSCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *DNSCreateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -3403,12 +3166,12 @@ func (o *DNSOp) Create(ctx context.Context, zone string, param *DNSCreateRequest
 }
 
 // Read is API call
-func (o *DNSOp) Read(ctx context.Context, zone string, id types.ID) (*DNS, error) {
+func (o *DNSOp) Read(ctx context.Context, id types.ID) (*DNS, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3435,12 +3198,12 @@ func (o *DNSOp) Read(ctx context.Context, zone string, id types.ID) (*DNS, error
 }
 
 // Update is API call
-func (o *DNSOp) Update(ctx context.Context, zone string, id types.ID, param *DNSUpdateRequest) (*DNS, error) {
+func (o *DNSOp) Update(ctx context.Context, id types.ID, param *DNSUpdateRequest) (*DNS, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -3450,9 +3213,6 @@ func (o *DNSOp) Update(ctx context.Context, zone string, id types.ID, param *DNS
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -3460,11 +3220,9 @@ func (o *DNSOp) Update(ctx context.Context, zone string, id types.ID, param *DNS
 		param = &DNSUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *DNSUpdateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -3493,12 +3251,12 @@ func (o *DNSOp) Update(ctx context.Context, zone string, id types.ID, param *DNS
 }
 
 // Delete is API call
-func (o *DNSOp) Delete(ctx context.Context, zone string, id types.ID) error {
+func (o *DNSOp) Delete(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3535,12 +3293,12 @@ func NewGSLBOp(caller APICaller) GSLBAPI {
 }
 
 // Find is API call
-func (o *GSLBOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*GSLBFindResult, error) {
+func (o *GSLBOp) Find(ctx context.Context, conditions *FindCondition) (*GSLBFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -3549,17 +3307,12 @@ func (o *GSLBOp) Find(ctx context.Context, zone string, conditions *FindConditio
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -3587,12 +3340,12 @@ func (o *GSLBOp) Find(ctx context.Context, zone string, conditions *FindConditio
 }
 
 // Create is API call
-func (o *GSLBOp) Create(ctx context.Context, zone string, param *GSLBCreateRequest) (*GSLB, error) {
+func (o *GSLBOp) Create(ctx context.Context, param *GSLBCreateRequest) (*GSLB, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -3601,17 +3354,12 @@ func (o *GSLBOp) Create(ctx context.Context, zone string, param *GSLBCreateReque
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &GSLBCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *GSLBCreateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -3639,12 +3387,12 @@ func (o *GSLBOp) Create(ctx context.Context, zone string, param *GSLBCreateReque
 }
 
 // Read is API call
-func (o *GSLBOp) Read(ctx context.Context, zone string, id types.ID) (*GSLB, error) {
+func (o *GSLBOp) Read(ctx context.Context, id types.ID) (*GSLB, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3671,12 +3419,12 @@ func (o *GSLBOp) Read(ctx context.Context, zone string, id types.ID) (*GSLB, err
 }
 
 // Update is API call
-func (o *GSLBOp) Update(ctx context.Context, zone string, id types.ID, param *GSLBUpdateRequest) (*GSLB, error) {
+func (o *GSLBOp) Update(ctx context.Context, id types.ID, param *GSLBUpdateRequest) (*GSLB, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -3686,9 +3434,6 @@ func (o *GSLBOp) Update(ctx context.Context, zone string, id types.ID, param *GS
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -3696,11 +3441,9 @@ func (o *GSLBOp) Update(ctx context.Context, zone string, id types.ID, param *GS
 		param = &GSLBUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *GSLBUpdateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -3729,12 +3472,12 @@ func (o *GSLBOp) Update(ctx context.Context, zone string, id types.ID, param *GS
 }
 
 // Delete is API call
-func (o *GSLBOp) Delete(ctx context.Context, zone string, id types.ID) error {
+func (o *GSLBOp) Delete(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3771,12 +3514,12 @@ func NewIconOp(caller APICaller) IconAPI {
 }
 
 // Find is API call
-func (o *IconOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*IconFindResult, error) {
+func (o *IconOp) Find(ctx context.Context, conditions *FindCondition) (*IconFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -3785,17 +3528,12 @@ func (o *IconOp) Find(ctx context.Context, zone string, conditions *FindConditio
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -3823,12 +3561,12 @@ func (o *IconOp) Find(ctx context.Context, zone string, conditions *FindConditio
 }
 
 // Create is API call
-func (o *IconOp) Create(ctx context.Context, zone string, param *IconCreateRequest) (*Icon, error) {
+func (o *IconOp) Create(ctx context.Context, param *IconCreateRequest) (*Icon, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -3837,17 +3575,12 @@ func (o *IconOp) Create(ctx context.Context, zone string, param *IconCreateReque
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &IconCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *IconCreateRequest `mapconv:"Icon,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -3875,12 +3608,12 @@ func (o *IconOp) Create(ctx context.Context, zone string, param *IconCreateReque
 }
 
 // Read is API call
-func (o *IconOp) Read(ctx context.Context, zone string, id types.ID) (*Icon, error) {
+func (o *IconOp) Read(ctx context.Context, id types.ID) (*Icon, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3907,12 +3640,12 @@ func (o *IconOp) Read(ctx context.Context, zone string, id types.ID) (*Icon, err
 }
 
 // Update is API call
-func (o *IconOp) Update(ctx context.Context, zone string, id types.ID, param *IconUpdateRequest) (*Icon, error) {
+func (o *IconOp) Update(ctx context.Context, id types.ID, param *IconUpdateRequest) (*Icon, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -3922,9 +3655,6 @@ func (o *IconOp) Update(ctx context.Context, zone string, id types.ID, param *Ic
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -3932,11 +3662,9 @@ func (o *IconOp) Update(ctx context.Context, zone string, id types.ID, param *Ic
 		param = &IconUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *IconUpdateRequest `mapconv:"Icon,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -3965,12 +3693,12 @@ func (o *IconOp) Update(ctx context.Context, zone string, id types.ID, param *Ic
 }
 
 // Delete is API call
-func (o *IconOp) Delete(ctx context.Context, zone string, id types.ID) error {
+func (o *IconOp) Delete(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4012,7 +3740,6 @@ func (o *InterfaceOp) Find(ctx context.Context, zone string, conditions *FindCon
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -4021,17 +3748,12 @@ func (o *InterfaceOp) Find(ctx context.Context, zone string, conditions *FindCon
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -4064,7 +3786,6 @@ func (o *InterfaceOp) Create(ctx context.Context, zone string, param *InterfaceC
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -4073,17 +3794,12 @@ func (o *InterfaceOp) Create(ctx context.Context, zone string, param *InterfaceC
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &InterfaceCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *InterfaceCreateRequest `mapconv:"Interface,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -4116,7 +3832,6 @@ func (o *InterfaceOp) Read(ctx context.Context, zone string, id types.ID) (*Inte
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4148,7 +3863,6 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -4158,9 +3872,6 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -4168,11 +3879,9 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 		param = &InterfaceUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *InterfaceUpdateRequest `mapconv:"Interface,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -4206,7 +3915,6 @@ func (o *InterfaceOp) Delete(ctx context.Context, zone string, id types.ID) erro
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4229,7 +3937,6 @@ func (o *InterfaceOp) Monitor(ctx context.Context, zone string, id types.ID, con
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -4239,9 +3946,6 @@ func (o *InterfaceOp) Monitor(ctx context.Context, zone string, id types.ID, con
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -4249,11 +3953,9 @@ func (o *InterfaceOp) Monitor(ctx context.Context, zone string, id types.ID, con
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -4287,7 +3989,6 @@ func (o *InterfaceOp) ConnectToSharedSegment(ctx context.Context, zone string, i
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4310,7 +4011,6 @@ func (o *InterfaceOp) ConnectToSwitch(ctx context.Context, zone string, id types
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"switchID":   switchID,
 	})
@@ -4334,7 +4034,6 @@ func (o *InterfaceOp) DisconnectFromSwitch(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4357,7 +4056,6 @@ func (o *InterfaceOp) ConnectToPacketFilter(ctx context.Context, zone string, id
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
-		"zone":           zone,
 		"id":             id,
 		"packetFilterID": packetFilterID,
 	})
@@ -4381,7 +4079,6 @@ func (o *InterfaceOp) DisconnectFromPacketFilter(ctx context.Context, zone strin
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4423,7 +4120,6 @@ func (o *InternetOp) Find(ctx context.Context, zone string, conditions *FindCond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -4432,17 +4128,12 @@ func (o *InternetOp) Find(ctx context.Context, zone string, conditions *FindCond
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -4475,7 +4166,6 @@ func (o *InternetOp) Create(ctx context.Context, zone string, param *InternetCre
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -4484,17 +4174,12 @@ func (o *InternetOp) Create(ctx context.Context, zone string, param *InternetCre
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &InternetCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *InternetCreateRequest `mapconv:"Internet,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -4527,7 +4212,6 @@ func (o *InternetOp) Read(ctx context.Context, zone string, id types.ID) (*Inter
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4559,7 +4243,6 @@ func (o *InternetOp) Update(ctx context.Context, zone string, id types.ID, param
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -4569,9 +4252,6 @@ func (o *InternetOp) Update(ctx context.Context, zone string, id types.ID, param
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -4579,11 +4259,9 @@ func (o *InternetOp) Update(ctx context.Context, zone string, id types.ID, param
 		param = &InternetUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *InternetUpdateRequest `mapconv:"Internet,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -4617,7 +4295,6 @@ func (o *InternetOp) Delete(ctx context.Context, zone string, id types.ID) error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4640,7 +4317,6 @@ func (o *InternetOp) UpdateBandWidth(ctx context.Context, zone string, id types.
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -4650,9 +4326,6 @@ func (o *InternetOp) UpdateBandWidth(ctx context.Context, zone string, id types.
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -4660,11 +4333,9 @@ func (o *InternetOp) UpdateBandWidth(ctx context.Context, zone string, id types.
 		param = &InternetUpdateBandWidthRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *InternetUpdateBandWidthRequest `mapconv:"Internet,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -4698,7 +4369,6 @@ func (o *InternetOp) AddSubnet(ctx context.Context, zone string, id types.ID, pa
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -4708,9 +4378,6 @@ func (o *InternetOp) AddSubnet(ctx context.Context, zone string, id types.ID, pa
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -4718,11 +4385,9 @@ func (o *InternetOp) AddSubnet(ctx context.Context, zone string, id types.ID, pa
 		param = &InternetAddSubnetRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *InternetAddSubnetRequest `mapconv:",squash"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -4756,7 +4421,6 @@ func (o *InternetOp) UpdateSubnet(ctx context.Context, zone string, id types.ID,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"subnetID":   subnetID,
 		"param":      param,
@@ -4767,9 +4431,6 @@ func (o *InternetOp) UpdateSubnet(ctx context.Context, zone string, id types.ID,
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -4780,12 +4441,10 @@ func (o *InternetOp) UpdateSubnet(ctx context.Context, zone string, id types.ID,
 		param = &InternetUpdateSubnetRequest{}
 	}
 	args := &struct {
-		Argzone     string
 		Argid       types.ID
 		ArgsubnetID types.ID
 		Argparam    *InternetUpdateSubnetRequest `mapconv:",squash"`
 	}{
-		Argzone:     zone,
 		Argid:       id,
 		ArgsubnetID: subnetID,
 		Argparam:    param,
@@ -4820,7 +4479,6 @@ func (o *InternetOp) DeleteSubnet(ctx context.Context, zone string, id types.ID,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"subnetID":   subnetID,
 	})
@@ -4844,7 +4502,6 @@ func (o *InternetOp) Monitor(ctx context.Context, zone string, id types.ID, cond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -4854,9 +4511,6 @@ func (o *InternetOp) Monitor(ctx context.Context, zone string, id types.ID, cond
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -4864,11 +4518,9 @@ func (o *InternetOp) Monitor(ctx context.Context, zone string, id types.ID, cond
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -4902,7 +4554,6 @@ func (o *InternetOp) EnableIPv6(ctx context.Context, zone string, id types.ID) (
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4934,7 +4585,6 @@ func (o *InternetOp) DisableIPv6(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"ipv6netID":  ipv6netID,
 	})
@@ -4977,7 +4627,6 @@ func (o *InternetPlanOp) Find(ctx context.Context, zone string, conditions *Find
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -4986,17 +4635,12 @@ func (o *InternetPlanOp) Find(ctx context.Context, zone string, conditions *Find
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -5029,7 +4673,6 @@ func (o *InternetPlanOp) Read(ctx context.Context, zone string, id types.ID) (*I
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5080,7 +4723,6 @@ func (o *IPAddressOp) List(ctx context.Context, zone string) (*IPAddressListResu
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 	})
 	if err != nil {
 		return nil, err
@@ -5111,7 +4753,6 @@ func (o *IPAddressOp) Read(ctx context.Context, zone string, ipAddress string) (
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"ipAddress":  ipAddress,
 	})
 	if err != nil {
@@ -5143,7 +4784,6 @@ func (o *IPAddressOp) UpdateHostName(ctx context.Context, zone string, ipAddress
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"ipAddress":  ipAddress,
 		"hostName":   hostName,
 	})
@@ -5153,9 +4793,6 @@ func (o *IPAddressOp) UpdateHostName(ctx context.Context, zone string, ipAddress
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if ipAddress == "" {
 		ipAddress = ""
 	}
@@ -5163,11 +4800,9 @@ func (o *IPAddressOp) UpdateHostName(ctx context.Context, zone string, ipAddress
 		hostName = ""
 	}
 	args := &struct {
-		Argzone      string
 		ArgipAddress string
 		ArghostName  string `mapconv:"IPAddress.HostName"`
 	}{
-		Argzone:      zone,
 		ArgipAddress: ipAddress,
 		ArghostName:  hostName,
 	}
@@ -5220,7 +4855,6 @@ func (o *IPv6NetOp) List(ctx context.Context, zone string) (*IPv6NetListResult, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 	})
 	if err != nil {
 		return nil, err
@@ -5251,7 +4885,6 @@ func (o *IPv6NetOp) Read(ctx context.Context, zone string, id types.ID) (*IPv6Ne
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5302,7 +4935,6 @@ func (o *IPv6AddrOp) Find(ctx context.Context, zone string, conditions *FindCond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -5311,17 +4943,12 @@ func (o *IPv6AddrOp) Find(ctx context.Context, zone string, conditions *FindCond
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -5354,7 +4981,6 @@ func (o *IPv6AddrOp) Create(ctx context.Context, zone string, param *IPv6AddrCre
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -5363,17 +4989,12 @@ func (o *IPv6AddrOp) Create(ctx context.Context, zone string, param *IPv6AddrCre
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &IPv6AddrCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *IPv6AddrCreateRequest `mapconv:"IPv6Addr,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -5406,7 +5027,6 @@ func (o *IPv6AddrOp) Read(ctx context.Context, zone string, ipv6addr string) (*I
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         ipv6addr,
 	})
 	if err != nil {
@@ -5438,7 +5058,6 @@ func (o *IPv6AddrOp) Update(ctx context.Context, zone string, ipv6addr string, p
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         ipv6addr,
 		"param":      param,
 	})
@@ -5448,9 +5067,6 @@ func (o *IPv6AddrOp) Update(ctx context.Context, zone string, ipv6addr string, p
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if ipv6addr == "" {
 		ipv6addr = ""
 	}
@@ -5458,11 +5074,9 @@ func (o *IPv6AddrOp) Update(ctx context.Context, zone string, ipv6addr string, p
 		param = &IPv6AddrUpdateRequest{}
 	}
 	args := &struct {
-		Argzone     string
 		Argipv6addr string
 		Argparam    *IPv6AddrUpdateRequest `mapconv:"IPv6Addr,recursive"`
 	}{
-		Argzone:     zone,
 		Argipv6addr: ipv6addr,
 		Argparam:    param,
 	}
@@ -5496,7 +5110,6 @@ func (o *IPv6AddrOp) Delete(ctx context.Context, zone string, ipv6addr string) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         ipv6addr,
 	})
 	if err != nil {
@@ -5533,12 +5146,12 @@ func NewLicenseOp(caller APICaller) LicenseAPI {
 }
 
 // Find is API call
-func (o *LicenseOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*LicenseFindResult, error) {
+func (o *LicenseOp) Find(ctx context.Context, conditions *FindCondition) (*LicenseFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -5547,17 +5160,12 @@ func (o *LicenseOp) Find(ctx context.Context, zone string, conditions *FindCondi
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -5585,12 +5193,12 @@ func (o *LicenseOp) Find(ctx context.Context, zone string, conditions *FindCondi
 }
 
 // Create is API call
-func (o *LicenseOp) Create(ctx context.Context, zone string, param *LicenseCreateRequest) (*License, error) {
+func (o *LicenseOp) Create(ctx context.Context, param *LicenseCreateRequest) (*License, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -5599,17 +5207,12 @@ func (o *LicenseOp) Create(ctx context.Context, zone string, param *LicenseCreat
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &LicenseCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *LicenseCreateRequest `mapconv:"License,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -5637,12 +5240,12 @@ func (o *LicenseOp) Create(ctx context.Context, zone string, param *LicenseCreat
 }
 
 // Read is API call
-func (o *LicenseOp) Read(ctx context.Context, zone string, id types.ID) (*License, error) {
+func (o *LicenseOp) Read(ctx context.Context, id types.ID) (*License, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5669,12 +5272,12 @@ func (o *LicenseOp) Read(ctx context.Context, zone string, id types.ID) (*Licens
 }
 
 // Update is API call
-func (o *LicenseOp) Update(ctx context.Context, zone string, id types.ID, param *LicenseUpdateRequest) (*License, error) {
+func (o *LicenseOp) Update(ctx context.Context, id types.ID, param *LicenseUpdateRequest) (*License, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -5684,9 +5287,6 @@ func (o *LicenseOp) Update(ctx context.Context, zone string, id types.ID, param 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -5694,11 +5294,9 @@ func (o *LicenseOp) Update(ctx context.Context, zone string, id types.ID, param 
 		param = &LicenseUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *LicenseUpdateRequest `mapconv:"License,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -5727,12 +5325,12 @@ func (o *LicenseOp) Update(ctx context.Context, zone string, id types.ID, param 
 }
 
 // Delete is API call
-func (o *LicenseOp) Delete(ctx context.Context, zone string, id types.ID) error {
+func (o *LicenseOp) Delete(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5769,12 +5367,12 @@ func NewLicenseInfoOp(caller APICaller) LicenseInfoAPI {
 }
 
 // Find is API call
-func (o *LicenseInfoOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*LicenseInfoFindResult, error) {
+func (o *LicenseInfoOp) Find(ctx context.Context, conditions *FindCondition) (*LicenseInfoFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -5783,17 +5381,12 @@ func (o *LicenseInfoOp) Find(ctx context.Context, zone string, conditions *FindC
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -5821,12 +5414,12 @@ func (o *LicenseInfoOp) Find(ctx context.Context, zone string, conditions *FindC
 }
 
 // Read is API call
-func (o *LicenseInfoOp) Read(ctx context.Context, zone string, id types.ID) (*LicenseInfo, error) {
+func (o *LicenseInfoOp) Read(ctx context.Context, id types.ID) (*LicenseInfo, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5877,7 +5470,6 @@ func (o *LoadBalancerOp) Find(ctx context.Context, zone string, conditions *Find
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -5886,17 +5478,12 @@ func (o *LoadBalancerOp) Find(ctx context.Context, zone string, conditions *Find
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -5929,7 +5516,6 @@ func (o *LoadBalancerOp) Create(ctx context.Context, zone string, param *LoadBal
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -5938,17 +5524,12 @@ func (o *LoadBalancerOp) Create(ctx context.Context, zone string, param *LoadBal
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &LoadBalancerCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *LoadBalancerCreateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -5981,7 +5562,6 @@ func (o *LoadBalancerOp) Read(ctx context.Context, zone string, id types.ID) (*L
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6013,7 +5593,6 @@ func (o *LoadBalancerOp) Update(ctx context.Context, zone string, id types.ID, p
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6023,9 +5602,6 @@ func (o *LoadBalancerOp) Update(ctx context.Context, zone string, id types.ID, p
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -6033,11 +5609,9 @@ func (o *LoadBalancerOp) Update(ctx context.Context, zone string, id types.ID, p
 		param = &LoadBalancerUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *LoadBalancerUpdateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -6071,7 +5645,6 @@ func (o *LoadBalancerOp) Delete(ctx context.Context, zone string, id types.ID) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6094,7 +5667,6 @@ func (o *LoadBalancerOp) Config(ctx context.Context, zone string, id types.ID) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6117,7 +5689,6 @@ func (o *LoadBalancerOp) Boot(ctx context.Context, zone string, id types.ID) err
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6140,7 +5711,6 @@ func (o *LoadBalancerOp) Shutdown(ctx context.Context, zone string, id types.ID,
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
-		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -6150,9 +5720,6 @@ func (o *LoadBalancerOp) Shutdown(ctx context.Context, zone string, id types.ID,
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -6160,11 +5727,9 @@ func (o *LoadBalancerOp) Shutdown(ctx context.Context, zone string, id types.ID,
 		shutdownOption = &ShutdownOption{}
 	}
 	args := &struct {
-		Argzone           string
 		Argid             types.ID
 		ArgshutdownOption *ShutdownOption `mapconv:",squash"`
 	}{
-		Argzone:           zone,
 		Argid:             id,
 		ArgshutdownOption: shutdownOption,
 	}
@@ -6189,7 +5754,6 @@ func (o *LoadBalancerOp) Reset(ctx context.Context, zone string, id types.ID) er
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6212,7 +5776,6 @@ func (o *LoadBalancerOp) MonitorInterface(ctx context.Context, zone string, id t
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -6222,9 +5785,6 @@ func (o *LoadBalancerOp) MonitorInterface(ctx context.Context, zone string, id t
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -6232,11 +5792,9 @@ func (o *LoadBalancerOp) MonitorInterface(ctx context.Context, zone string, id t
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -6270,7 +5828,6 @@ func (o *LoadBalancerOp) Status(ctx context.Context, zone string, id types.ID) (
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6321,7 +5878,6 @@ func (o *MobileGatewayOp) Find(ctx context.Context, zone string, conditions *Fin
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -6330,17 +5886,12 @@ func (o *MobileGatewayOp) Find(ctx context.Context, zone string, conditions *Fin
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -6373,7 +5924,6 @@ func (o *MobileGatewayOp) Create(ctx context.Context, zone string, param *Mobile
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -6382,17 +5932,12 @@ func (o *MobileGatewayOp) Create(ctx context.Context, zone string, param *Mobile
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &MobileGatewayCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *MobileGatewayCreateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -6425,7 +5970,6 @@ func (o *MobileGatewayOp) Read(ctx context.Context, zone string, id types.ID) (*
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6457,7 +6001,6 @@ func (o *MobileGatewayOp) Update(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6467,9 +6010,6 @@ func (o *MobileGatewayOp) Update(ctx context.Context, zone string, id types.ID, 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -6477,11 +6017,9 @@ func (o *MobileGatewayOp) Update(ctx context.Context, zone string, id types.ID, 
 		param = &MobileGatewayUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *MobileGatewayUpdateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -6515,7 +6053,6 @@ func (o *MobileGatewayOp) Delete(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6538,7 +6075,6 @@ func (o *MobileGatewayOp) Config(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6561,7 +6097,6 @@ func (o *MobileGatewayOp) Boot(ctx context.Context, zone string, id types.ID) er
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6584,7 +6119,6 @@ func (o *MobileGatewayOp) Shutdown(ctx context.Context, zone string, id types.ID
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
-		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -6594,9 +6128,6 @@ func (o *MobileGatewayOp) Shutdown(ctx context.Context, zone string, id types.ID
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -6604,11 +6135,9 @@ func (o *MobileGatewayOp) Shutdown(ctx context.Context, zone string, id types.ID
 		shutdownOption = &ShutdownOption{}
 	}
 	args := &struct {
-		Argzone           string
 		Argid             types.ID
 		ArgshutdownOption *ShutdownOption `mapconv:",squash"`
 	}{
-		Argzone:           zone,
 		Argid:             id,
 		ArgshutdownOption: shutdownOption,
 	}
@@ -6633,7 +6162,6 @@ func (o *MobileGatewayOp) Reset(ctx context.Context, zone string, id types.ID) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6656,7 +6184,6 @@ func (o *MobileGatewayOp) ConnectToSwitch(ctx context.Context, zone string, id t
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"switchID":   switchID,
 	})
@@ -6680,7 +6207,6 @@ func (o *MobileGatewayOp) DisconnectFromSwitch(ctx context.Context, zone string,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6703,7 +6229,6 @@ func (o *MobileGatewayOp) GetDNS(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6735,7 +6260,6 @@ func (o *MobileGatewayOp) SetDNS(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6745,9 +6269,6 @@ func (o *MobileGatewayOp) SetDNS(ctx context.Context, zone string, id types.ID, 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -6755,11 +6276,9 @@ func (o *MobileGatewayOp) SetDNS(ctx context.Context, zone string, id types.ID, 
 		param = &MobileGatewayDNSSetting{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *MobileGatewayDNSSetting `mapconv:"SIMGroup,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -6784,7 +6303,6 @@ func (o *MobileGatewayOp) GetSIMRoutes(ctx context.Context, zone string, id type
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6816,7 +6334,6 @@ func (o *MobileGatewayOp) SetSIMRoutes(ctx context.Context, zone string, id type
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6826,9 +6343,6 @@ func (o *MobileGatewayOp) SetSIMRoutes(ctx context.Context, zone string, id type
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -6836,11 +6350,9 @@ func (o *MobileGatewayOp) SetSIMRoutes(ctx context.Context, zone string, id type
 		param = []*MobileGatewaySIMRouteParam{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam []*MobileGatewaySIMRouteParam `mapconv:"[]SIMRoutes,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -6865,7 +6377,6 @@ func (o *MobileGatewayOp) ListSIM(ctx context.Context, zone string, id types.ID)
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6897,7 +6408,6 @@ func (o *MobileGatewayOp) AddSIM(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6907,9 +6417,6 @@ func (o *MobileGatewayOp) AddSIM(ctx context.Context, zone string, id types.ID, 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -6917,11 +6424,9 @@ func (o *MobileGatewayOp) AddSIM(ctx context.Context, zone string, id types.ID, 
 		param = &MobileGatewayAddSIMRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *MobileGatewayAddSIMRequest `mapconv:"SIM,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -6946,7 +6451,6 @@ func (o *MobileGatewayOp) DeleteSIM(ctx context.Context, zone string, id types.I
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"simID":      simID,
 	})
@@ -6970,7 +6474,6 @@ func (o *MobileGatewayOp) Logs(ctx context.Context, zone string, id types.ID) ([
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7002,7 +6505,6 @@ func (o *MobileGatewayOp) GetTrafficConfig(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7034,7 +6536,6 @@ func (o *MobileGatewayOp) SetTrafficConfig(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -7044,9 +6545,6 @@ func (o *MobileGatewayOp) SetTrafficConfig(ctx context.Context, zone string, id 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -7054,11 +6552,9 @@ func (o *MobileGatewayOp) SetTrafficConfig(ctx context.Context, zone string, id 
 		param = &MobileGatewayTrafficControl{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *MobileGatewayTrafficControl `mapconv:"TrafficMonitoring,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -7083,7 +6579,6 @@ func (o *MobileGatewayOp) DeleteTrafficConfig(ctx context.Context, zone string, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7106,7 +6601,6 @@ func (o *MobileGatewayOp) TrafficStatus(ctx context.Context, zone string, id typ
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7138,7 +6632,6 @@ func (o *MobileGatewayOp) MonitorInterface(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"index":      index,
 		"condition":  condition,
@@ -7149,9 +6642,6 @@ func (o *MobileGatewayOp) MonitorInterface(ctx context.Context, zone string, id 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -7162,12 +6652,10 @@ func (o *MobileGatewayOp) MonitorInterface(ctx context.Context, zone string, id 
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argindex     int
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argindex:     index,
 		Argcondition: condition,
@@ -7221,7 +6709,6 @@ func (o *NFSOp) Find(ctx context.Context, zone string, conditions *FindCondition
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -7230,17 +6717,12 @@ func (o *NFSOp) Find(ctx context.Context, zone string, conditions *FindCondition
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -7273,7 +6755,6 @@ func (o *NFSOp) Create(ctx context.Context, zone string, param *NFSCreateRequest
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -7282,17 +6763,12 @@ func (o *NFSOp) Create(ctx context.Context, zone string, param *NFSCreateRequest
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &NFSCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *NFSCreateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -7325,7 +6801,6 @@ func (o *NFSOp) Read(ctx context.Context, zone string, id types.ID) (*NFS, error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7357,7 +6832,6 @@ func (o *NFSOp) Update(ctx context.Context, zone string, id types.ID, param *NFS
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -7367,9 +6841,6 @@ func (o *NFSOp) Update(ctx context.Context, zone string, id types.ID, param *NFS
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -7377,11 +6848,9 @@ func (o *NFSOp) Update(ctx context.Context, zone string, id types.ID, param *NFS
 		param = &NFSUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *NFSUpdateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -7415,7 +6884,6 @@ func (o *NFSOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7438,7 +6906,6 @@ func (o *NFSOp) Boot(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7461,7 +6928,6 @@ func (o *NFSOp) Shutdown(ctx context.Context, zone string, id types.ID, shutdown
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
-		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -7471,9 +6937,6 @@ func (o *NFSOp) Shutdown(ctx context.Context, zone string, id types.ID, shutdown
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -7481,11 +6944,9 @@ func (o *NFSOp) Shutdown(ctx context.Context, zone string, id types.ID, shutdown
 		shutdownOption = &ShutdownOption{}
 	}
 	args := &struct {
-		Argzone           string
 		Argid             types.ID
 		ArgshutdownOption *ShutdownOption `mapconv:",squash"`
 	}{
-		Argzone:           zone,
 		Argid:             id,
 		ArgshutdownOption: shutdownOption,
 	}
@@ -7510,7 +6971,6 @@ func (o *NFSOp) Reset(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7533,7 +6993,6 @@ func (o *NFSOp) MonitorFreeDiskSize(ctx context.Context, zone string, id types.I
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -7543,9 +7002,6 @@ func (o *NFSOp) MonitorFreeDiskSize(ctx context.Context, zone string, id types.I
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -7553,11 +7009,9 @@ func (o *NFSOp) MonitorFreeDiskSize(ctx context.Context, zone string, id types.I
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -7591,7 +7045,6 @@ func (o *NFSOp) MonitorInterface(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -7601,9 +7054,6 @@ func (o *NFSOp) MonitorInterface(ctx context.Context, zone string, id types.ID, 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -7611,11 +7061,9 @@ func (o *NFSOp) MonitorInterface(ctx context.Context, zone string, id types.ID, 
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -7663,12 +7111,12 @@ func NewNoteOp(caller APICaller) NoteAPI {
 }
 
 // Find is API call
-func (o *NoteOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*NoteFindResult, error) {
+func (o *NoteOp) Find(ctx context.Context, conditions *FindCondition) (*NoteFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -7677,17 +7125,12 @@ func (o *NoteOp) Find(ctx context.Context, zone string, conditions *FindConditio
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -7715,12 +7158,12 @@ func (o *NoteOp) Find(ctx context.Context, zone string, conditions *FindConditio
 }
 
 // Create is API call
-func (o *NoteOp) Create(ctx context.Context, zone string, param *NoteCreateRequest) (*Note, error) {
+func (o *NoteOp) Create(ctx context.Context, param *NoteCreateRequest) (*Note, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -7729,17 +7172,12 @@ func (o *NoteOp) Create(ctx context.Context, zone string, param *NoteCreateReque
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &NoteCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *NoteCreateRequest `mapconv:"Note,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -7767,12 +7205,12 @@ func (o *NoteOp) Create(ctx context.Context, zone string, param *NoteCreateReque
 }
 
 // Read is API call
-func (o *NoteOp) Read(ctx context.Context, zone string, id types.ID) (*Note, error) {
+func (o *NoteOp) Read(ctx context.Context, id types.ID) (*Note, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7799,12 +7237,12 @@ func (o *NoteOp) Read(ctx context.Context, zone string, id types.ID) (*Note, err
 }
 
 // Update is API call
-func (o *NoteOp) Update(ctx context.Context, zone string, id types.ID, param *NoteUpdateRequest) (*Note, error) {
+func (o *NoteOp) Update(ctx context.Context, id types.ID, param *NoteUpdateRequest) (*Note, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -7814,9 +7252,6 @@ func (o *NoteOp) Update(ctx context.Context, zone string, id types.ID, param *No
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -7824,11 +7259,9 @@ func (o *NoteOp) Update(ctx context.Context, zone string, id types.ID, param *No
 		param = &NoteUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *NoteUpdateRequest `mapconv:"Note,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -7857,12 +7290,12 @@ func (o *NoteOp) Update(ctx context.Context, zone string, id types.ID, param *No
 }
 
 // Delete is API call
-func (o *NoteOp) Delete(ctx context.Context, zone string, id types.ID) error {
+func (o *NoteOp) Delete(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7904,7 +7337,6 @@ func (o *PacketFilterOp) Find(ctx context.Context, zone string, conditions *Find
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -7913,17 +7345,12 @@ func (o *PacketFilterOp) Find(ctx context.Context, zone string, conditions *Find
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -7956,7 +7383,6 @@ func (o *PacketFilterOp) Create(ctx context.Context, zone string, param *PacketF
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -7965,17 +7391,12 @@ func (o *PacketFilterOp) Create(ctx context.Context, zone string, param *PacketF
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &PacketFilterCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *PacketFilterCreateRequest `mapconv:"PacketFilter,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -8008,7 +7429,6 @@ func (o *PacketFilterOp) Read(ctx context.Context, zone string, id types.ID) (*P
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8040,7 +7460,6 @@ func (o *PacketFilterOp) Update(ctx context.Context, zone string, id types.ID, p
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -8050,9 +7469,6 @@ func (o *PacketFilterOp) Update(ctx context.Context, zone string, id types.ID, p
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -8060,11 +7476,9 @@ func (o *PacketFilterOp) Update(ctx context.Context, zone string, id types.ID, p
 		param = &PacketFilterUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *PacketFilterUpdateRequest `mapconv:"PacketFilter,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -8098,7 +7512,6 @@ func (o *PacketFilterOp) Delete(ctx context.Context, zone string, id types.ID) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8140,7 +7553,6 @@ func (o *PrivateHostOp) Find(ctx context.Context, zone string, conditions *FindC
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -8149,17 +7561,12 @@ func (o *PrivateHostOp) Find(ctx context.Context, zone string, conditions *FindC
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -8192,7 +7599,6 @@ func (o *PrivateHostOp) Create(ctx context.Context, zone string, param *PrivateH
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -8201,17 +7607,12 @@ func (o *PrivateHostOp) Create(ctx context.Context, zone string, param *PrivateH
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &PrivateHostCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *PrivateHostCreateRequest `mapconv:"PrivateHost,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -8244,7 +7645,6 @@ func (o *PrivateHostOp) Read(ctx context.Context, zone string, id types.ID) (*Pr
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8276,7 +7676,6 @@ func (o *PrivateHostOp) Update(ctx context.Context, zone string, id types.ID, pa
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -8286,9 +7685,6 @@ func (o *PrivateHostOp) Update(ctx context.Context, zone string, id types.ID, pa
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -8296,11 +7692,9 @@ func (o *PrivateHostOp) Update(ctx context.Context, zone string, id types.ID, pa
 		param = &PrivateHostUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *PrivateHostUpdateRequest `mapconv:"PrivateHost,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -8334,7 +7728,6 @@ func (o *PrivateHostOp) Delete(ctx context.Context, zone string, id types.ID) er
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8376,7 +7769,6 @@ func (o *PrivateHostPlanOp) Find(ctx context.Context, zone string, conditions *F
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -8385,17 +7777,12 @@ func (o *PrivateHostPlanOp) Find(ctx context.Context, zone string, conditions *F
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -8428,7 +7815,6 @@ func (o *PrivateHostPlanOp) Read(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8474,12 +7860,12 @@ func NewProxyLBOp(caller APICaller) ProxyLBAPI {
 }
 
 // Find is API call
-func (o *ProxyLBOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*ProxyLBFindResult, error) {
+func (o *ProxyLBOp) Find(ctx context.Context, conditions *FindCondition) (*ProxyLBFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -8488,17 +7874,12 @@ func (o *ProxyLBOp) Find(ctx context.Context, zone string, conditions *FindCondi
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -8526,12 +7907,12 @@ func (o *ProxyLBOp) Find(ctx context.Context, zone string, conditions *FindCondi
 }
 
 // Create is API call
-func (o *ProxyLBOp) Create(ctx context.Context, zone string, param *ProxyLBCreateRequest) (*ProxyLB, error) {
+func (o *ProxyLBOp) Create(ctx context.Context, param *ProxyLBCreateRequest) (*ProxyLB, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -8540,17 +7921,12 @@ func (o *ProxyLBOp) Create(ctx context.Context, zone string, param *ProxyLBCreat
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &ProxyLBCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *ProxyLBCreateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -8578,12 +7954,12 @@ func (o *ProxyLBOp) Create(ctx context.Context, zone string, param *ProxyLBCreat
 }
 
 // Read is API call
-func (o *ProxyLBOp) Read(ctx context.Context, zone string, id types.ID) (*ProxyLB, error) {
+func (o *ProxyLBOp) Read(ctx context.Context, id types.ID) (*ProxyLB, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8610,12 +7986,12 @@ func (o *ProxyLBOp) Read(ctx context.Context, zone string, id types.ID) (*ProxyL
 }
 
 // Update is API call
-func (o *ProxyLBOp) Update(ctx context.Context, zone string, id types.ID, param *ProxyLBUpdateRequest) (*ProxyLB, error) {
+func (o *ProxyLBOp) Update(ctx context.Context, id types.ID, param *ProxyLBUpdateRequest) (*ProxyLB, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -8625,9 +8001,6 @@ func (o *ProxyLBOp) Update(ctx context.Context, zone string, id types.ID, param 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -8635,11 +8008,9 @@ func (o *ProxyLBOp) Update(ctx context.Context, zone string, id types.ID, param 
 		param = &ProxyLBUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *ProxyLBUpdateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -8668,12 +8039,12 @@ func (o *ProxyLBOp) Update(ctx context.Context, zone string, id types.ID, param 
 }
 
 // Delete is API call
-func (o *ProxyLBOp) Delete(ctx context.Context, zone string, id types.ID) error {
+func (o *ProxyLBOp) Delete(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8691,12 +8062,12 @@ func (o *ProxyLBOp) Delete(ctx context.Context, zone string, id types.ID) error 
 }
 
 // ChangePlan is API call
-func (o *ProxyLBOp) ChangePlan(ctx context.Context, zone string, id types.ID, param *ProxyLBChangePlanRequest) (*ProxyLB, error) {
+func (o *ProxyLBOp) ChangePlan(ctx context.Context, id types.ID, param *ProxyLBChangePlanRequest) (*ProxyLB, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -8706,9 +8077,6 @@ func (o *ProxyLBOp) ChangePlan(ctx context.Context, zone string, id types.ID, pa
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -8716,11 +8084,9 @@ func (o *ProxyLBOp) ChangePlan(ctx context.Context, zone string, id types.ID, pa
 		param = &ProxyLBChangePlanRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *ProxyLBChangePlanRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -8749,12 +8115,12 @@ func (o *ProxyLBOp) ChangePlan(ctx context.Context, zone string, id types.ID, pa
 }
 
 // GetCertificates is API call
-func (o *ProxyLBOp) GetCertificates(ctx context.Context, zone string, id types.ID) (*ProxyLBCertificates, error) {
+func (o *ProxyLBOp) GetCertificates(ctx context.Context, id types.ID) (*ProxyLBCertificates, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/proxylb/sslcertificate", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8781,12 +8147,12 @@ func (o *ProxyLBOp) GetCertificates(ctx context.Context, zone string, id types.I
 }
 
 // SetCertificates is API call
-func (o *ProxyLBOp) SetCertificates(ctx context.Context, zone string, id types.ID, param *ProxyLBSetCertificatesRequest) (*ProxyLBCertificates, error) {
+func (o *ProxyLBOp) SetCertificates(ctx context.Context, id types.ID, param *ProxyLBSetCertificatesRequest) (*ProxyLBCertificates, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/proxylb/sslcertificate", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -8796,9 +8162,6 @@ func (o *ProxyLBOp) SetCertificates(ctx context.Context, zone string, id types.I
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -8806,11 +8169,9 @@ func (o *ProxyLBOp) SetCertificates(ctx context.Context, zone string, id types.I
 		param = &ProxyLBSetCertificatesRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *ProxyLBSetCertificatesRequest `mapconv:"ProxyLB,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -8839,12 +8200,12 @@ func (o *ProxyLBOp) SetCertificates(ctx context.Context, zone string, id types.I
 }
 
 // DeleteCertificates is API call
-func (o *ProxyLBOp) DeleteCertificates(ctx context.Context, zone string, id types.ID) error {
+func (o *ProxyLBOp) DeleteCertificates(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/proxylb/sslcertificate", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8862,12 +8223,12 @@ func (o *ProxyLBOp) DeleteCertificates(ctx context.Context, zone string, id type
 }
 
 // RenewLetsEncryptCert is API call
-func (o *ProxyLBOp) RenewLetsEncryptCert(ctx context.Context, zone string, id types.ID) error {
+func (o *ProxyLBOp) RenewLetsEncryptCert(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/proxylb/letsencryptrenew", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8885,12 +8246,12 @@ func (o *ProxyLBOp) RenewLetsEncryptCert(ctx context.Context, zone string, id ty
 }
 
 // HealthStatus is API call
-func (o *ProxyLBOp) HealthStatus(ctx context.Context, zone string, id types.ID) (*ProxyLBHealth, error) {
+func (o *ProxyLBOp) HealthStatus(ctx context.Context, id types.ID) (*ProxyLBHealth, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/health", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8936,12 +8297,12 @@ func NewRegionOp(caller APICaller) RegionAPI {
 }
 
 // Find is API call
-func (o *RegionOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*RegionFindResult, error) {
+func (o *RegionOp) Find(ctx context.Context, conditions *FindCondition) (*RegionFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -8950,17 +8311,12 @@ func (o *RegionOp) Find(ctx context.Context, zone string, conditions *FindCondit
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -8988,12 +8344,12 @@ func (o *RegionOp) Find(ctx context.Context, zone string, conditions *FindCondit
 }
 
 // Read is API call
-func (o *RegionOp) Read(ctx context.Context, zone string, id types.ID) (*Region, error) {
+func (o *RegionOp) Read(ctx context.Context, id types.ID) (*Region, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -9044,7 +8400,6 @@ func (o *ServerOp) Find(ctx context.Context, zone string, conditions *FindCondit
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -9053,17 +8408,12 @@ func (o *ServerOp) Find(ctx context.Context, zone string, conditions *FindCondit
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -9096,7 +8446,6 @@ func (o *ServerOp) Create(ctx context.Context, zone string, param *ServerCreateR
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -9105,17 +8454,12 @@ func (o *ServerOp) Create(ctx context.Context, zone string, param *ServerCreateR
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &ServerCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *ServerCreateRequest `mapconv:"Server,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -9148,7 +8492,6 @@ func (o *ServerOp) Read(ctx context.Context, zone string, id types.ID) (*Server,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -9180,7 +8523,6 @@ func (o *ServerOp) Update(ctx context.Context, zone string, id types.ID, param *
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -9190,9 +8532,6 @@ func (o *ServerOp) Update(ctx context.Context, zone string, id types.ID, param *
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -9200,11 +8539,9 @@ func (o *ServerOp) Update(ctx context.Context, zone string, id types.ID, param *
 		param = &ServerUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *ServerUpdateRequest `mapconv:"Server,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -9238,7 +8575,6 @@ func (o *ServerOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -9261,7 +8597,6 @@ func (o *ServerOp) ChangePlan(ctx context.Context, zone string, id types.ID, pla
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"plan":       plan,
 	})
@@ -9271,9 +8606,6 @@ func (o *ServerOp) ChangePlan(ctx context.Context, zone string, id types.ID, pla
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -9281,11 +8613,9 @@ func (o *ServerOp) ChangePlan(ctx context.Context, zone string, id types.ID, pla
 		plan = &ServerChangePlanRequest{}
 	}
 	args := &struct {
-		Argzone string
 		Argid   types.ID
 		Argplan *ServerChangePlanRequest `mapconv:",squash"`
 	}{
-		Argzone: zone,
 		Argid:   id,
 		Argplan: plan,
 	}
@@ -9319,7 +8649,6 @@ func (o *ServerOp) InsertCDROM(ctx context.Context, zone string, id types.ID, in
 		"rootURL":     SakuraCloudAPIRoot,
 		"pathSuffix":  o.PathSuffix,
 		"pathName":    o.PathName,
-		"zone":        zone,
 		"id":          id,
 		"insertParam": insertParam,
 	})
@@ -9329,9 +8658,6 @@ func (o *ServerOp) InsertCDROM(ctx context.Context, zone string, id types.ID, in
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -9339,11 +8665,9 @@ func (o *ServerOp) InsertCDROM(ctx context.Context, zone string, id types.ID, in
 		insertParam = &InsertCDROMRequest{}
 	}
 	args := &struct {
-		Argzone        string
 		Argid          types.ID
 		ArginsertParam *InsertCDROMRequest `mapconv:"CDROM"`
 	}{
-		Argzone:        zone,
 		Argid:          id,
 		ArginsertParam: insertParam,
 	}
@@ -9368,7 +8692,6 @@ func (o *ServerOp) EjectCDROM(ctx context.Context, zone string, id types.ID, ins
 		"rootURL":     SakuraCloudAPIRoot,
 		"pathSuffix":  o.PathSuffix,
 		"pathName":    o.PathName,
-		"zone":        zone,
 		"id":          id,
 		"insertParam": insertParam,
 	})
@@ -9378,9 +8701,6 @@ func (o *ServerOp) EjectCDROM(ctx context.Context, zone string, id types.ID, ins
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -9388,11 +8708,9 @@ func (o *ServerOp) EjectCDROM(ctx context.Context, zone string, id types.ID, ins
 		insertParam = &EjectCDROMRequest{}
 	}
 	args := &struct {
-		Argzone        string
 		Argid          types.ID
 		ArginsertParam *EjectCDROMRequest `mapconv:"CDROM"`
 	}{
-		Argzone:        zone,
 		Argid:          id,
 		ArginsertParam: insertParam,
 	}
@@ -9417,7 +8735,6 @@ func (o *ServerOp) Boot(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -9440,7 +8757,6 @@ func (o *ServerOp) Shutdown(ctx context.Context, zone string, id types.ID, shutd
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
-		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -9450,9 +8766,6 @@ func (o *ServerOp) Shutdown(ctx context.Context, zone string, id types.ID, shutd
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -9460,11 +8773,9 @@ func (o *ServerOp) Shutdown(ctx context.Context, zone string, id types.ID, shutd
 		shutdownOption = &ShutdownOption{}
 	}
 	args := &struct {
-		Argzone           string
 		Argid             types.ID
 		ArgshutdownOption *ShutdownOption `mapconv:",squash"`
 	}{
-		Argzone:           zone,
 		Argid:             id,
 		ArgshutdownOption: shutdownOption,
 	}
@@ -9489,7 +8800,6 @@ func (o *ServerOp) Reset(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -9512,7 +8822,6 @@ func (o *ServerOp) Monitor(ctx context.Context, zone string, id types.ID, condit
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -9522,9 +8831,6 @@ func (o *ServerOp) Monitor(ctx context.Context, zone string, id types.ID, condit
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -9532,11 +8838,9 @@ func (o *ServerOp) Monitor(ctx context.Context, zone string, id types.ID, condit
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -9589,7 +8893,6 @@ func (o *ServerPlanOp) Find(ctx context.Context, zone string, conditions *FindCo
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -9598,17 +8901,12 @@ func (o *ServerPlanOp) Find(ctx context.Context, zone string, conditions *FindCo
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -9641,7 +8939,6 @@ func (o *ServerPlanOp) Read(ctx context.Context, zone string, id types.ID) (*Ser
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -9692,7 +8989,6 @@ func (o *ServiceClassOp) Find(ctx context.Context, zone string, conditions *Find
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -9701,17 +8997,12 @@ func (o *ServiceClassOp) Find(ctx context.Context, zone string, conditions *Find
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -9758,12 +9049,12 @@ func NewSIMOp(caller APICaller) SIMAPI {
 }
 
 // Find is API call
-func (o *SIMOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*SIMFindResult, error) {
+func (o *SIMOp) Find(ctx context.Context, conditions *FindCondition) (*SIMFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -9772,17 +9063,12 @@ func (o *SIMOp) Find(ctx context.Context, zone string, conditions *FindCondition
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -9810,12 +9096,12 @@ func (o *SIMOp) Find(ctx context.Context, zone string, conditions *FindCondition
 }
 
 // Create is API call
-func (o *SIMOp) Create(ctx context.Context, zone string, param *SIMCreateRequest) (*SIM, error) {
+func (o *SIMOp) Create(ctx context.Context, param *SIMCreateRequest) (*SIM, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -9824,17 +9110,12 @@ func (o *SIMOp) Create(ctx context.Context, zone string, param *SIMCreateRequest
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &SIMCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *SIMCreateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -9862,12 +9143,12 @@ func (o *SIMOp) Create(ctx context.Context, zone string, param *SIMCreateRequest
 }
 
 // Read is API call
-func (o *SIMOp) Read(ctx context.Context, zone string, id types.ID) (*SIM, error) {
+func (o *SIMOp) Read(ctx context.Context, id types.ID) (*SIM, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -9894,12 +9175,12 @@ func (o *SIMOp) Read(ctx context.Context, zone string, id types.ID) (*SIM, error
 }
 
 // Update is API call
-func (o *SIMOp) Update(ctx context.Context, zone string, id types.ID, param *SIMUpdateRequest) (*SIM, error) {
+func (o *SIMOp) Update(ctx context.Context, id types.ID, param *SIMUpdateRequest) (*SIM, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -9909,9 +9190,6 @@ func (o *SIMOp) Update(ctx context.Context, zone string, id types.ID, param *SIM
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -9919,11 +9197,9 @@ func (o *SIMOp) Update(ctx context.Context, zone string, id types.ID, param *SIM
 		param = &SIMUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *SIMUpdateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -9952,12 +9228,12 @@ func (o *SIMOp) Update(ctx context.Context, zone string, id types.ID, param *SIM
 }
 
 // Delete is API call
-func (o *SIMOp) Delete(ctx context.Context, zone string, id types.ID) error {
+func (o *SIMOp) Delete(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -9975,12 +9251,12 @@ func (o *SIMOp) Delete(ctx context.Context, zone string, id types.ID) error {
 }
 
 // Activate is API call
-func (o *SIMOp) Activate(ctx context.Context, zone string, id types.ID) error {
+func (o *SIMOp) Activate(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/activate", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -9998,12 +9274,12 @@ func (o *SIMOp) Activate(ctx context.Context, zone string, id types.ID) error {
 }
 
 // Deactivate is API call
-func (o *SIMOp) Deactivate(ctx context.Context, zone string, id types.ID) error {
+func (o *SIMOp) Deactivate(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/deactivate", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10021,12 +9297,12 @@ func (o *SIMOp) Deactivate(ctx context.Context, zone string, id types.ID) error 
 }
 
 // AssignIP is API call
-func (o *SIMOp) AssignIP(ctx context.Context, zone string, id types.ID, param *SIMAssignIPRequest) error {
+func (o *SIMOp) AssignIP(ctx context.Context, id types.ID, param *SIMAssignIPRequest) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/ip", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -10036,9 +9312,6 @@ func (o *SIMOp) AssignIP(ctx context.Context, zone string, id types.ID, param *S
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -10046,11 +9319,9 @@ func (o *SIMOp) AssignIP(ctx context.Context, zone string, id types.ID, param *S
 		param = &SIMAssignIPRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *SIMAssignIPRequest `mapconv:"SIM,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -10070,12 +9341,12 @@ func (o *SIMOp) AssignIP(ctx context.Context, zone string, id types.ID, param *S
 }
 
 // ClearIP is API call
-func (o *SIMOp) ClearIP(ctx context.Context, zone string, id types.ID) error {
+func (o *SIMOp) ClearIP(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/ip", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10093,12 +9364,12 @@ func (o *SIMOp) ClearIP(ctx context.Context, zone string, id types.ID) error {
 }
 
 // IMEILock is API call
-func (o *SIMOp) IMEILock(ctx context.Context, zone string, id types.ID, param *SIMIMEILockRequest) error {
+func (o *SIMOp) IMEILock(ctx context.Context, id types.ID, param *SIMIMEILockRequest) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/imeilock", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -10108,9 +9379,6 @@ func (o *SIMOp) IMEILock(ctx context.Context, zone string, id types.ID, param *S
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -10118,11 +9386,9 @@ func (o *SIMOp) IMEILock(ctx context.Context, zone string, id types.ID, param *S
 		param = &SIMIMEILockRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *SIMIMEILockRequest `mapconv:"SIM,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -10142,12 +9408,12 @@ func (o *SIMOp) IMEILock(ctx context.Context, zone string, id types.ID, param *S
 }
 
 // IMEIUnlock is API call
-func (o *SIMOp) IMEIUnlock(ctx context.Context, zone string, id types.ID) error {
+func (o *SIMOp) IMEIUnlock(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/imeilock", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10165,12 +9431,12 @@ func (o *SIMOp) IMEIUnlock(ctx context.Context, zone string, id types.ID) error 
 }
 
 // Logs is API call
-func (o *SIMOp) Logs(ctx context.Context, zone string, id types.ID) (*SIMLogsResult, error) {
+func (o *SIMOp) Logs(ctx context.Context, id types.ID) (*SIMLogsResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/sessionlog", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10197,12 +9463,12 @@ func (o *SIMOp) Logs(ctx context.Context, zone string, id types.ID) (*SIMLogsRes
 }
 
 // GetNetworkOperator is API call
-func (o *SIMOp) GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*SIMNetworkOperatorConfig, error) {
+func (o *SIMOp) GetNetworkOperator(ctx context.Context, id types.ID) ([]*SIMNetworkOperatorConfig, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/network_operator_config", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10229,12 +9495,12 @@ func (o *SIMOp) GetNetworkOperator(ctx context.Context, zone string, id types.ID
 }
 
 // SetNetworkOperator is API call
-func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*SIMNetworkOperatorConfig) error {
+func (o *SIMOp) SetNetworkOperator(ctx context.Context, id types.ID, configs []*SIMNetworkOperatorConfig) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/network_operator_config", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"configs":    configs,
 	})
@@ -10244,9 +9510,6 @@ func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -10254,11 +9517,9 @@ func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID
 		configs = []*SIMNetworkOperatorConfig{}
 	}
 	args := &struct {
-		Argzone    string
 		Argid      types.ID
 		Argconfigs []*SIMNetworkOperatorConfig `mapconv:"[]NetworkOperatorConfigs,recursive"`
 	}{
-		Argzone:    zone,
 		Argid:      id,
 		Argconfigs: configs,
 	}
@@ -10278,12 +9539,12 @@ func (o *SIMOp) SetNetworkOperator(ctx context.Context, zone string, id types.ID
 }
 
 // MonitorSIM is API call
-func (o *SIMOp) MonitorSIM(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*LinkActivity, error) {
+func (o *SIMOp) MonitorSIM(ctx context.Context, id types.ID, condition *MonitorCondition) (*LinkActivity, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/metrics/monitor", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -10293,9 +9554,6 @@ func (o *SIMOp) MonitorSIM(ctx context.Context, zone string, id types.ID, condit
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -10303,11 +9561,9 @@ func (o *SIMOp) MonitorSIM(ctx context.Context, zone string, id types.ID, condit
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -10336,12 +9592,12 @@ func (o *SIMOp) MonitorSIM(ctx context.Context, zone string, id types.ID, condit
 }
 
 // Status is API call
-func (o *SIMOp) Status(ctx context.Context, zone string, id types.ID) (*SIMInfo, error) {
+func (o *SIMOp) Status(ctx context.Context, id types.ID) (*SIMInfo, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/sim/status", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10387,12 +9643,12 @@ func NewSimpleMonitorOp(caller APICaller) SimpleMonitorAPI {
 }
 
 // Find is API call
-func (o *SimpleMonitorOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*SimpleMonitorFindResult, error) {
+func (o *SimpleMonitorOp) Find(ctx context.Context, conditions *FindCondition) (*SimpleMonitorFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -10401,17 +9657,12 @@ func (o *SimpleMonitorOp) Find(ctx context.Context, zone string, conditions *Fin
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -10439,12 +9690,12 @@ func (o *SimpleMonitorOp) Find(ctx context.Context, zone string, conditions *Fin
 }
 
 // Create is API call
-func (o *SimpleMonitorOp) Create(ctx context.Context, zone string, param *SimpleMonitorCreateRequest) (*SimpleMonitor, error) {
+func (o *SimpleMonitorOp) Create(ctx context.Context, param *SimpleMonitorCreateRequest) (*SimpleMonitor, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -10453,17 +9704,12 @@ func (o *SimpleMonitorOp) Create(ctx context.Context, zone string, param *Simple
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &SimpleMonitorCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *SimpleMonitorCreateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -10491,12 +9737,12 @@ func (o *SimpleMonitorOp) Create(ctx context.Context, zone string, param *Simple
 }
 
 // Read is API call
-func (o *SimpleMonitorOp) Read(ctx context.Context, zone string, id types.ID) (*SimpleMonitor, error) {
+func (o *SimpleMonitorOp) Read(ctx context.Context, id types.ID) (*SimpleMonitor, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10523,12 +9769,12 @@ func (o *SimpleMonitorOp) Read(ctx context.Context, zone string, id types.ID) (*
 }
 
 // Update is API call
-func (o *SimpleMonitorOp) Update(ctx context.Context, zone string, id types.ID, param *SimpleMonitorUpdateRequest) (*SimpleMonitor, error) {
+func (o *SimpleMonitorOp) Update(ctx context.Context, id types.ID, param *SimpleMonitorUpdateRequest) (*SimpleMonitor, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -10538,9 +9784,6 @@ func (o *SimpleMonitorOp) Update(ctx context.Context, zone string, id types.ID, 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -10548,11 +9791,9 @@ func (o *SimpleMonitorOp) Update(ctx context.Context, zone string, id types.ID, 
 		param = &SimpleMonitorUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *SimpleMonitorUpdateRequest `mapconv:"CommonServiceItem,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -10581,12 +9822,12 @@ func (o *SimpleMonitorOp) Update(ctx context.Context, zone string, id types.ID, 
 }
 
 // Delete is API call
-func (o *SimpleMonitorOp) Delete(ctx context.Context, zone string, id types.ID) error {
+func (o *SimpleMonitorOp) Delete(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10604,12 +9845,12 @@ func (o *SimpleMonitorOp) Delete(ctx context.Context, zone string, id types.ID) 
 }
 
 // MonitorResponseTime is API call
-func (o *SimpleMonitorOp) MonitorResponseTime(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*ResponseTimeSecActivity, error) {
+func (o *SimpleMonitorOp) MonitorResponseTime(ctx context.Context, id types.ID, condition *MonitorCondition) (*ResponseTimeSecActivity, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}//activity/responsetimesec/monitor", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -10619,9 +9860,6 @@ func (o *SimpleMonitorOp) MonitorResponseTime(ctx context.Context, zone string, 
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -10629,11 +9867,9 @@ func (o *SimpleMonitorOp) MonitorResponseTime(ctx context.Context, zone string, 
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argcondition: condition,
 	}
@@ -10662,12 +9898,12 @@ func (o *SimpleMonitorOp) MonitorResponseTime(ctx context.Context, zone string, 
 }
 
 // HealthStatus is API call
-func (o *SimpleMonitorOp) HealthStatus(ctx context.Context, zone string, id types.ID) (*SimpleMonitorHealthStatus, error) {
+func (o *SimpleMonitorOp) HealthStatus(ctx context.Context, id types.ID) (*SimpleMonitorHealthStatus, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/health", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10713,12 +9949,12 @@ func NewSSHKeyOp(caller APICaller) SSHKeyAPI {
 }
 
 // Find is API call
-func (o *SSHKeyOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*SSHKeyFindResult, error) {
+func (o *SSHKeyOp) Find(ctx context.Context, conditions *FindCondition) (*SSHKeyFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -10727,17 +9963,12 @@ func (o *SSHKeyOp) Find(ctx context.Context, zone string, conditions *FindCondit
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -10765,12 +9996,12 @@ func (o *SSHKeyOp) Find(ctx context.Context, zone string, conditions *FindCondit
 }
 
 // Create is API call
-func (o *SSHKeyOp) Create(ctx context.Context, zone string, param *SSHKeyCreateRequest) (*SSHKey, error) {
+func (o *SSHKeyOp) Create(ctx context.Context, param *SSHKeyCreateRequest) (*SSHKey, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -10779,17 +10010,12 @@ func (o *SSHKeyOp) Create(ctx context.Context, zone string, param *SSHKeyCreateR
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &SSHKeyCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *SSHKeyCreateRequest `mapconv:"SSHKey,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -10817,12 +10043,12 @@ func (o *SSHKeyOp) Create(ctx context.Context, zone string, param *SSHKeyCreateR
 }
 
 // Generate is API call
-func (o *SSHKeyOp) Generate(ctx context.Context, zone string, param *SSHKeyGenerateRequest) (*SSHKeyGenerated, error) {
+func (o *SSHKeyOp) Generate(ctx context.Context, param *SSHKeyGenerateRequest) (*SSHKeyGenerated, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/generate", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -10831,17 +10057,12 @@ func (o *SSHKeyOp) Generate(ctx context.Context, zone string, param *SSHKeyGener
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &SSHKeyGenerateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *SSHKeyGenerateRequest `mapconv:"SSHKey,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -10869,12 +10090,12 @@ func (o *SSHKeyOp) Generate(ctx context.Context, zone string, param *SSHKeyGener
 }
 
 // Read is API call
-func (o *SSHKeyOp) Read(ctx context.Context, zone string, id types.ID) (*SSHKey, error) {
+func (o *SSHKeyOp) Read(ctx context.Context, id types.ID) (*SSHKey, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10901,12 +10122,12 @@ func (o *SSHKeyOp) Read(ctx context.Context, zone string, id types.ID) (*SSHKey,
 }
 
 // Update is API call
-func (o *SSHKeyOp) Update(ctx context.Context, zone string, id types.ID, param *SSHKeyUpdateRequest) (*SSHKey, error) {
+func (o *SSHKeyOp) Update(ctx context.Context, id types.ID, param *SSHKeyUpdateRequest) (*SSHKey, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -10916,9 +10137,6 @@ func (o *SSHKeyOp) Update(ctx context.Context, zone string, id types.ID, param *
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -10926,11 +10144,9 @@ func (o *SSHKeyOp) Update(ctx context.Context, zone string, id types.ID, param *
 		param = &SSHKeyUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *SSHKeyUpdateRequest `mapconv:"SSHKey,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -10959,12 +10175,12 @@ func (o *SSHKeyOp) Update(ctx context.Context, zone string, id types.ID, param *
 }
 
 // Delete is API call
-func (o *SSHKeyOp) Delete(ctx context.Context, zone string, id types.ID) error {
+func (o *SSHKeyOp) Delete(ctx context.Context, id types.ID) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11006,7 +10222,6 @@ func (o *SwitchOp) Find(ctx context.Context, zone string, conditions *FindCondit
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -11015,17 +10230,12 @@ func (o *SwitchOp) Find(ctx context.Context, zone string, conditions *FindCondit
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -11058,7 +10268,6 @@ func (o *SwitchOp) Create(ctx context.Context, zone string, param *SwitchCreateR
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -11067,17 +10276,12 @@ func (o *SwitchOp) Create(ctx context.Context, zone string, param *SwitchCreateR
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &SwitchCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *SwitchCreateRequest `mapconv:"Switch,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -11110,7 +10314,6 @@ func (o *SwitchOp) Read(ctx context.Context, zone string, id types.ID) (*Switch,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11142,7 +10345,6 @@ func (o *SwitchOp) Update(ctx context.Context, zone string, id types.ID, param *
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -11152,9 +10354,6 @@ func (o *SwitchOp) Update(ctx context.Context, zone string, id types.ID, param *
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -11162,11 +10361,9 @@ func (o *SwitchOp) Update(ctx context.Context, zone string, id types.ID, param *
 		param = &SwitchUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *SwitchUpdateRequest `mapconv:"Switch,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -11200,7 +10397,6 @@ func (o *SwitchOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11223,7 +10419,6 @@ func (o *SwitchOp) ConnectToBridge(ctx context.Context, zone string, id types.ID
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"bridgeID":   bridgeID,
 	})
@@ -11247,7 +10442,6 @@ func (o *SwitchOp) DisconnectFromBridge(ctx context.Context, zone string, id typ
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11289,7 +10483,6 @@ func (o *VPCRouterOp) Find(ctx context.Context, zone string, conditions *FindCon
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -11298,17 +10491,12 @@ func (o *VPCRouterOp) Find(ctx context.Context, zone string, conditions *FindCon
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -11341,7 +10529,6 @@ func (o *VPCRouterOp) Create(ctx context.Context, zone string, param *VPCRouterC
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -11350,17 +10537,12 @@ func (o *VPCRouterOp) Create(ctx context.Context, zone string, param *VPCRouterC
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &VPCRouterCreateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *VPCRouterCreateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -11393,7 +10575,6 @@ func (o *VPCRouterOp) Read(ctx context.Context, zone string, id types.ID) (*VPCR
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11425,7 +10606,6 @@ func (o *VPCRouterOp) Update(ctx context.Context, zone string, id types.ID, para
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -11435,9 +10615,6 @@ func (o *VPCRouterOp) Update(ctx context.Context, zone string, id types.ID, para
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -11445,11 +10622,9 @@ func (o *VPCRouterOp) Update(ctx context.Context, zone string, id types.ID, para
 		param = &VPCRouterUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *VPCRouterUpdateRequest `mapconv:"Appliance,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -11483,7 +10658,6 @@ func (o *VPCRouterOp) Delete(ctx context.Context, zone string, id types.ID) erro
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11506,7 +10680,6 @@ func (o *VPCRouterOp) Config(ctx context.Context, zone string, id types.ID) erro
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11529,7 +10702,6 @@ func (o *VPCRouterOp) Boot(ctx context.Context, zone string, id types.ID) error 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11552,7 +10724,6 @@ func (o *VPCRouterOp) Shutdown(ctx context.Context, zone string, id types.ID, sh
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
-		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -11562,9 +10733,6 @@ func (o *VPCRouterOp) Shutdown(ctx context.Context, zone string, id types.ID, sh
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -11572,11 +10740,9 @@ func (o *VPCRouterOp) Shutdown(ctx context.Context, zone string, id types.ID, sh
 		shutdownOption = &ShutdownOption{}
 	}
 	args := &struct {
-		Argzone           string
 		Argid             types.ID
 		ArgshutdownOption *ShutdownOption `mapconv:",squash"`
 	}{
-		Argzone:           zone,
 		Argid:             id,
 		ArgshutdownOption: shutdownOption,
 	}
@@ -11601,7 +10767,6 @@ func (o *VPCRouterOp) Reset(ctx context.Context, zone string, id types.ID) error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11624,7 +10789,6 @@ func (o *VPCRouterOp) ConnectToSwitch(ctx context.Context, zone string, id types
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"nicIndex":   nicIndex,
 		"switchID":   switchID,
@@ -11649,7 +10813,6 @@ func (o *VPCRouterOp) DisconnectFromSwitch(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"nicIndex":   nicIndex,
 	})
@@ -11673,7 +10836,6 @@ func (o *VPCRouterOp) MonitorInterface(ctx context.Context, zone string, id type
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
 		"id":         id,
 		"index":      index,
 		"condition":  condition,
@@ -11684,9 +10846,6 @@ func (o *VPCRouterOp) MonitorInterface(ctx context.Context, zone string, id type
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -11697,12 +10856,10 @@ func (o *VPCRouterOp) MonitorInterface(ctx context.Context, zone string, id type
 		condition = &MonitorCondition{}
 	}
 	args := &struct {
-		Argzone      string
 		Argid        types.ID
 		Argindex     int
 		Argcondition *MonitorCondition `mapconv:",squash"`
 	}{
-		Argzone:      zone,
 		Argid:        id,
 		Argindex:     index,
 		Argcondition: condition,
@@ -11751,12 +10908,12 @@ func NewWebAccelOp(caller APICaller) WebAccelAPI {
 }
 
 // List is API call
-func (o *WebAccelOp) List(ctx context.Context, zone string) (*WebAccelListResult, error) {
+func (o *WebAccelOp) List(ctx context.Context) (*WebAccelListResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/site", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 	})
 	if err != nil {
 		return nil, err
@@ -11782,12 +10939,12 @@ func (o *WebAccelOp) List(ctx context.Context, zone string) (*WebAccelListResult
 }
 
 // Read is API call
-func (o *WebAccelOp) Read(ctx context.Context, zone string, id types.ID) (*WebAccel, error) {
+func (o *WebAccelOp) Read(ctx context.Context, id types.ID) (*WebAccel, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/site/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11814,12 +10971,12 @@ func (o *WebAccelOp) Read(ctx context.Context, zone string, id types.ID) (*WebAc
 }
 
 // ReadCertificate is API call
-func (o *WebAccelOp) ReadCertificate(ctx context.Context, zone string, id types.ID) (*WebAccelCerts, error) {
+func (o *WebAccelOp) ReadCertificate(ctx context.Context, id types.ID) (*WebAccelCerts, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/site/{{.id}}/certificate", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {
@@ -11846,12 +11003,12 @@ func (o *WebAccelOp) ReadCertificate(ctx context.Context, zone string, id types.
 }
 
 // UpdateCertificate is API call
-func (o *WebAccelOp) UpdateCertificate(ctx context.Context, zone string, id types.ID, param *WebAccelCertUpdateRequest) (*WebAccelCerts, error) {
+func (o *WebAccelOp) UpdateCertificate(ctx context.Context, id types.ID, param *WebAccelCertUpdateRequest) (*WebAccelCerts, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/site/{{.id}}/certificate", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 		"param":      param,
 	})
@@ -11861,9 +11018,6 @@ func (o *WebAccelOp) UpdateCertificate(ctx context.Context, zone string, id type
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
 	}
@@ -11871,11 +11025,9 @@ func (o *WebAccelOp) UpdateCertificate(ctx context.Context, zone string, id type
 		param = &WebAccelCertUpdateRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argid    types.ID
 		Argparam *WebAccelCertUpdateRequest `mapconv:"Certificate,recursive"`
 	}{
-		Argzone:  zone,
 		Argid:    id,
 		Argparam: param,
 	}
@@ -11904,12 +11056,12 @@ func (o *WebAccelOp) UpdateCertificate(ctx context.Context, zone string, id type
 }
 
 // DeleteAllCache is API call
-func (o *WebAccelOp) DeleteAllCache(ctx context.Context, zone string, param *WebAccelDeleteAllCacheRequest) error {
+func (o *WebAccelOp) DeleteAllCache(ctx context.Context, param *WebAccelDeleteAllCacheRequest) error {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/deleteallcache", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -11918,17 +11070,12 @@ func (o *WebAccelOp) DeleteAllCache(ctx context.Context, zone string, param *Web
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &WebAccelDeleteAllCacheRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *WebAccelDeleteAllCacheRequest `mapconv:"Site,recursive"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -11947,12 +11094,12 @@ func (o *WebAccelOp) DeleteAllCache(ctx context.Context, zone string, param *Web
 }
 
 // DeleteCache is API call
-func (o *WebAccelOp) DeleteCache(ctx context.Context, zone string, param *WebAccelDeleteCacheRequest) ([]*WebAccelDeleteCacheResult, error) {
+func (o *WebAccelOp) DeleteCache(ctx context.Context, param *WebAccelDeleteCacheRequest) ([]*WebAccelDeleteCacheResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/deletecache", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"param":      param,
 	})
 	if err != nil {
@@ -11961,17 +11108,12 @@ func (o *WebAccelOp) DeleteCache(ctx context.Context, zone string, param *WebAcc
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if param == nil {
 		param = &WebAccelDeleteCacheRequest{}
 	}
 	args := &struct {
-		Argzone  string
 		Argparam *WebAccelDeleteCacheRequest `mapconv:",squash"`
 	}{
-		Argzone:  zone,
 		Argparam: param,
 	}
 
@@ -12018,12 +11160,12 @@ func NewZoneOp(caller APICaller) ZoneAPI {
 }
 
 // Find is API call
-func (o *ZoneOp) Find(ctx context.Context, zone string, conditions *FindCondition) (*ZoneFindResult, error) {
+func (o *ZoneOp) Find(ctx context.Context, conditions *FindCondition) (*ZoneFindResult, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -12032,17 +11174,12 @@ func (o *ZoneOp) Find(ctx context.Context, zone string, conditions *FindConditio
 
 	var body interface{}
 
-	if zone == "" {
-		zone = ""
-	}
 	if conditions == nil {
 		conditions = &FindCondition{}
 	}
 	args := &struct {
-		Argzone       string
 		Argconditions *FindCondition `mapconv:",squash"`
 	}{
-		Argzone:       zone,
 		Argconditions: conditions,
 	}
 
@@ -12070,12 +11207,12 @@ func (o *ZoneOp) Find(ctx context.Context, zone string, conditions *FindConditio
 }
 
 // Read is API call
-func (o *ZoneOp) Read(ctx context.Context, zone string, id types.ID) (*Zone, error) {
+func (o *ZoneOp) Read(ctx context.Context, id types.ID) (*Zone, error) {
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
-		"zone":       zone,
+		"zone":       APIDefaultZone,
 		"id":         id,
 	})
 	if err != nil {

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -358,6 +358,7 @@ func (o *ArchiveOp) Find(ctx context.Context, zone string, conditions *FindCondi
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -404,6 +405,7 @@ func (o *ArchiveOp) Create(ctx context.Context, zone string, param *ArchiveCreat
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -450,6 +452,7 @@ func (o *ArchiveOp) CreateBlank(ctx context.Context, zone string, param *Archive
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -496,6 +499,7 @@ func (o *ArchiveOp) Read(ctx context.Context, zone string, id types.ID) (*Archiv
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -527,6 +531,7 @@ func (o *ArchiveOp) Update(ctx context.Context, zone string, id types.ID, param 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -579,6 +584,7 @@ func (o *ArchiveOp) Delete(ctx context.Context, zone string, id types.ID) error 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -601,6 +607,7 @@ func (o *ArchiveOp) OpenFTP(ctx context.Context, zone string, id types.ID, openO
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"openOption": openOption,
 	})
@@ -653,6 +660,7 @@ func (o *ArchiveOp) CloseFTP(ctx context.Context, zone string, id types.ID) erro
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -744,6 +752,7 @@ func (o *AutoBackupOp) Find(ctx context.Context, zone string, conditions *FindCo
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -790,6 +799,7 @@ func (o *AutoBackupOp) Create(ctx context.Context, zone string, param *AutoBacku
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -836,6 +846,7 @@ func (o *AutoBackupOp) Read(ctx context.Context, zone string, id types.ID) (*Aut
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -867,6 +878,7 @@ func (o *AutoBackupOp) Update(ctx context.Context, zone string, id types.ID, par
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -919,6 +931,7 @@ func (o *AutoBackupOp) Delete(ctx context.Context, zone string, id types.ID) err
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1176,6 +1189,7 @@ func (o *BridgeOp) Find(ctx context.Context, zone string, conditions *FindCondit
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -1222,6 +1236,7 @@ func (o *BridgeOp) Create(ctx context.Context, zone string, param *BridgeCreateR
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -1268,6 +1283,7 @@ func (o *BridgeOp) Read(ctx context.Context, zone string, id types.ID) (*Bridge,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1299,6 +1315,7 @@ func (o *BridgeOp) Update(ctx context.Context, zone string, id types.ID, param *
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -1351,6 +1368,7 @@ func (o *BridgeOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1392,6 +1410,7 @@ func (o *CDROMOp) Find(ctx context.Context, zone string, conditions *FindConditi
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -1438,6 +1457,7 @@ func (o *CDROMOp) Create(ctx context.Context, zone string, param *CDROMCreateReq
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -1484,6 +1504,7 @@ func (o *CDROMOp) Read(ctx context.Context, zone string, id types.ID) (*CDROM, e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1515,6 +1536,7 @@ func (o *CDROMOp) Update(ctx context.Context, zone string, id types.ID, param *C
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -1567,6 +1589,7 @@ func (o *CDROMOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1589,6 +1612,7 @@ func (o *CDROMOp) OpenFTP(ctx context.Context, zone string, id types.ID, openOpt
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"openOption": openOption,
 	})
@@ -1641,6 +1665,7 @@ func (o *CDROMOp) CloseFTP(ctx context.Context, zone string, id types.ID) error 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1733,6 +1758,7 @@ func (o *DatabaseOp) Find(ctx context.Context, zone string, conditions *FindCond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -1779,6 +1805,7 @@ func (o *DatabaseOp) Create(ctx context.Context, zone string, param *DatabaseCre
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -1825,6 +1852,7 @@ func (o *DatabaseOp) Read(ctx context.Context, zone string, id types.ID) (*Datab
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1856,6 +1884,7 @@ func (o *DatabaseOp) Update(ctx context.Context, zone string, id types.ID, param
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -1908,6 +1937,7 @@ func (o *DatabaseOp) Delete(ctx context.Context, zone string, id types.ID) error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1930,6 +1960,7 @@ func (o *DatabaseOp) Config(ctx context.Context, zone string, id types.ID) error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1952,6 +1983,7 @@ func (o *DatabaseOp) Boot(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -1974,6 +2006,7 @@ func (o *DatabaseOp) Shutdown(ctx context.Context, zone string, id types.ID, shu
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
+		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -2017,6 +2050,7 @@ func (o *DatabaseOp) Reset(ctx context.Context, zone string, id types.ID) error 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2039,6 +2073,7 @@ func (o *DatabaseOp) MonitorCPU(ctx context.Context, zone string, id types.ID, c
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -2091,6 +2126,7 @@ func (o *DatabaseOp) MonitorDisk(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -2143,6 +2179,7 @@ func (o *DatabaseOp) MonitorInterface(ctx context.Context, zone string, id types
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -2195,6 +2232,7 @@ func (o *DatabaseOp) MonitorDatabase(ctx context.Context, zone string, id types.
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -2247,6 +2285,7 @@ func (o *DatabaseOp) Status(ctx context.Context, zone string, id types.ID) (*Dat
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2297,6 +2336,7 @@ func (o *DiskOp) Find(ctx context.Context, zone string, conditions *FindConditio
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -2343,6 +2383,7 @@ func (o *DiskOp) Create(ctx context.Context, zone string, param *DiskCreateReque
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -2389,6 +2430,7 @@ func (o *DiskOp) CreateDistantly(ctx context.Context, zone string, createParam *
 		"rootURL":     SakuraCloudAPIRoot,
 		"pathSuffix":  o.PathSuffix,
 		"pathName":    o.PathName,
+		"zone":        zone,
 		"createParam": createParam,
 		"distantFrom": distantFrom,
 	})
@@ -2441,6 +2483,7 @@ func (o *DiskOp) Config(ctx context.Context, zone string, id types.ID, edit *Dis
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"edit":       edit,
 	})
@@ -2484,6 +2527,7 @@ func (o *DiskOp) CreateWithConfig(ctx context.Context, zone string, createParam 
 		"rootURL":         SakuraCloudAPIRoot,
 		"pathSuffix":      o.PathSuffix,
 		"pathName":        o.PathName,
+		"zone":            zone,
 		"createParam":     createParam,
 		"editParam":       editParam,
 		"bootAtAvailable": bootAtAvailable,
@@ -2542,6 +2586,7 @@ func (o *DiskOp) CreateWithConfigDistantly(ctx context.Context, zone string, cre
 		"rootURL":         SakuraCloudAPIRoot,
 		"pathSuffix":      o.PathSuffix,
 		"pathName":        o.PathName,
+		"zone":            zone,
 		"createParam":     createParam,
 		"editParam":       editParam,
 		"bootAtAvailable": bootAtAvailable,
@@ -2606,6 +2651,7 @@ func (o *DiskOp) ToBlank(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2628,6 +2674,7 @@ func (o *DiskOp) ResizePartition(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2650,6 +2697,7 @@ func (o *DiskOp) ConnectToServer(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"serverID":   serverID,
 	})
@@ -2673,6 +2721,7 @@ func (o *DiskOp) DisconnectFromServer(ctx context.Context, zone string, id types
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2695,6 +2744,7 @@ func (o *DiskOp) InstallDistantFrom(ctx context.Context, zone string, id types.I
 		"rootURL":      SakuraCloudAPIRoot,
 		"pathSuffix":   o.PathSuffix,
 		"pathName":     o.PathName,
+		"zone":         zone,
 		"id":           id,
 		"installParam": installParam,
 		"distantFrom":  distantFrom,
@@ -2753,6 +2803,7 @@ func (o *DiskOp) Install(ctx context.Context, zone string, id types.ID, installP
 		"rootURL":      SakuraCloudAPIRoot,
 		"pathSuffix":   o.PathSuffix,
 		"pathName":     o.PathName,
+		"zone":         zone,
 		"id":           id,
 		"installParam": installParam,
 	})
@@ -2805,6 +2856,7 @@ func (o *DiskOp) Read(ctx context.Context, zone string, id types.ID) (*Disk, err
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2836,6 +2888,7 @@ func (o *DiskOp) Update(ctx context.Context, zone string, id types.ID, param *Di
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -2888,6 +2941,7 @@ func (o *DiskOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -2910,6 +2964,7 @@ func (o *DiskOp) Monitor(ctx context.Context, zone string, id types.ID, conditio
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -2981,6 +3036,7 @@ func (o *DiskPlanOp) Find(ctx context.Context, zone string, conditions *FindCond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -3027,6 +3083,7 @@ func (o *DiskPlanOp) Read(ctx context.Context, zone string, id types.ID) (*DiskP
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3740,6 +3797,7 @@ func (o *InterfaceOp) Find(ctx context.Context, zone string, conditions *FindCon
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -3786,6 +3844,7 @@ func (o *InterfaceOp) Create(ctx context.Context, zone string, param *InterfaceC
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -3832,6 +3891,7 @@ func (o *InterfaceOp) Read(ctx context.Context, zone string, id types.ID) (*Inte
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3863,6 +3923,7 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -3915,6 +3976,7 @@ func (o *InterfaceOp) Delete(ctx context.Context, zone string, id types.ID) erro
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -3937,6 +3999,7 @@ func (o *InterfaceOp) Monitor(ctx context.Context, zone string, id types.ID, con
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -3989,6 +4052,7 @@ func (o *InterfaceOp) ConnectToSharedSegment(ctx context.Context, zone string, i
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4011,6 +4075,7 @@ func (o *InterfaceOp) ConnectToSwitch(ctx context.Context, zone string, id types
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"switchID":   switchID,
 	})
@@ -4034,6 +4099,7 @@ func (o *InterfaceOp) DisconnectFromSwitch(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4056,6 +4122,7 @@ func (o *InterfaceOp) ConnectToPacketFilter(ctx context.Context, zone string, id
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
+		"zone":           zone,
 		"id":             id,
 		"packetFilterID": packetFilterID,
 	})
@@ -4079,6 +4146,7 @@ func (o *InterfaceOp) DisconnectFromPacketFilter(ctx context.Context, zone strin
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4120,6 +4188,7 @@ func (o *InternetOp) Find(ctx context.Context, zone string, conditions *FindCond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -4166,6 +4235,7 @@ func (o *InternetOp) Create(ctx context.Context, zone string, param *InternetCre
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -4212,6 +4282,7 @@ func (o *InternetOp) Read(ctx context.Context, zone string, id types.ID) (*Inter
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4243,6 +4314,7 @@ func (o *InternetOp) Update(ctx context.Context, zone string, id types.ID, param
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -4295,6 +4367,7 @@ func (o *InternetOp) Delete(ctx context.Context, zone string, id types.ID) error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4317,6 +4390,7 @@ func (o *InternetOp) UpdateBandWidth(ctx context.Context, zone string, id types.
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -4369,6 +4443,7 @@ func (o *InternetOp) AddSubnet(ctx context.Context, zone string, id types.ID, pa
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -4421,6 +4496,7 @@ func (o *InternetOp) UpdateSubnet(ctx context.Context, zone string, id types.ID,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"subnetID":   subnetID,
 		"param":      param,
@@ -4479,6 +4555,7 @@ func (o *InternetOp) DeleteSubnet(ctx context.Context, zone string, id types.ID,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"subnetID":   subnetID,
 	})
@@ -4502,6 +4579,7 @@ func (o *InternetOp) Monitor(ctx context.Context, zone string, id types.ID, cond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -4554,6 +4632,7 @@ func (o *InternetOp) EnableIPv6(ctx context.Context, zone string, id types.ID) (
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4585,6 +4664,7 @@ func (o *InternetOp) DisableIPv6(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"ipv6netID":  ipv6netID,
 	})
@@ -4627,6 +4707,7 @@ func (o *InternetPlanOp) Find(ctx context.Context, zone string, conditions *Find
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -4673,6 +4754,7 @@ func (o *InternetPlanOp) Read(ctx context.Context, zone string, id types.ID) (*I
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4723,6 +4805,7 @@ func (o *IPAddressOp) List(ctx context.Context, zone string) (*IPAddressListResu
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 	})
 	if err != nil {
 		return nil, err
@@ -4753,6 +4836,7 @@ func (o *IPAddressOp) Read(ctx context.Context, zone string, ipAddress string) (
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"ipAddress":  ipAddress,
 	})
 	if err != nil {
@@ -4784,6 +4868,7 @@ func (o *IPAddressOp) UpdateHostName(ctx context.Context, zone string, ipAddress
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"ipAddress":  ipAddress,
 		"hostName":   hostName,
 	})
@@ -4855,6 +4940,7 @@ func (o *IPv6NetOp) List(ctx context.Context, zone string) (*IPv6NetListResult, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 	})
 	if err != nil {
 		return nil, err
@@ -4885,6 +4971,7 @@ func (o *IPv6NetOp) Read(ctx context.Context, zone string, id types.ID) (*IPv6Ne
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -4935,6 +5022,7 @@ func (o *IPv6AddrOp) Find(ctx context.Context, zone string, conditions *FindCond
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -4981,6 +5069,7 @@ func (o *IPv6AddrOp) Create(ctx context.Context, zone string, param *IPv6AddrCre
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -5027,6 +5116,7 @@ func (o *IPv6AddrOp) Read(ctx context.Context, zone string, ipv6addr string) (*I
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         ipv6addr,
 	})
 	if err != nil {
@@ -5058,6 +5148,7 @@ func (o *IPv6AddrOp) Update(ctx context.Context, zone string, ipv6addr string, p
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         ipv6addr,
 		"param":      param,
 	})
@@ -5110,6 +5201,7 @@ func (o *IPv6AddrOp) Delete(ctx context.Context, zone string, ipv6addr string) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         ipv6addr,
 	})
 	if err != nil {
@@ -5470,6 +5562,7 @@ func (o *LoadBalancerOp) Find(ctx context.Context, zone string, conditions *Find
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -5516,6 +5609,7 @@ func (o *LoadBalancerOp) Create(ctx context.Context, zone string, param *LoadBal
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -5562,6 +5656,7 @@ func (o *LoadBalancerOp) Read(ctx context.Context, zone string, id types.ID) (*L
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5593,6 +5688,7 @@ func (o *LoadBalancerOp) Update(ctx context.Context, zone string, id types.ID, p
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -5645,6 +5741,7 @@ func (o *LoadBalancerOp) Delete(ctx context.Context, zone string, id types.ID) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5667,6 +5764,7 @@ func (o *LoadBalancerOp) Config(ctx context.Context, zone string, id types.ID) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5689,6 +5787,7 @@ func (o *LoadBalancerOp) Boot(ctx context.Context, zone string, id types.ID) err
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5711,6 +5810,7 @@ func (o *LoadBalancerOp) Shutdown(ctx context.Context, zone string, id types.ID,
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
+		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -5754,6 +5854,7 @@ func (o *LoadBalancerOp) Reset(ctx context.Context, zone string, id types.ID) er
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5776,6 +5877,7 @@ func (o *LoadBalancerOp) MonitorInterface(ctx context.Context, zone string, id t
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -5828,6 +5930,7 @@ func (o *LoadBalancerOp) Status(ctx context.Context, zone string, id types.ID) (
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -5878,6 +5981,7 @@ func (o *MobileGatewayOp) Find(ctx context.Context, zone string, conditions *Fin
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -5924,6 +6028,7 @@ func (o *MobileGatewayOp) Create(ctx context.Context, zone string, param *Mobile
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -5970,6 +6075,7 @@ func (o *MobileGatewayOp) Read(ctx context.Context, zone string, id types.ID) (*
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6001,6 +6107,7 @@ func (o *MobileGatewayOp) Update(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6053,6 +6160,7 @@ func (o *MobileGatewayOp) Delete(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6075,6 +6183,7 @@ func (o *MobileGatewayOp) Config(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6097,6 +6206,7 @@ func (o *MobileGatewayOp) Boot(ctx context.Context, zone string, id types.ID) er
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6119,6 +6229,7 @@ func (o *MobileGatewayOp) Shutdown(ctx context.Context, zone string, id types.ID
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
+		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -6162,6 +6273,7 @@ func (o *MobileGatewayOp) Reset(ctx context.Context, zone string, id types.ID) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6184,6 +6296,7 @@ func (o *MobileGatewayOp) ConnectToSwitch(ctx context.Context, zone string, id t
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"switchID":   switchID,
 	})
@@ -6207,6 +6320,7 @@ func (o *MobileGatewayOp) DisconnectFromSwitch(ctx context.Context, zone string,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6229,6 +6343,7 @@ func (o *MobileGatewayOp) GetDNS(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6260,6 +6375,7 @@ func (o *MobileGatewayOp) SetDNS(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6303,6 +6419,7 @@ func (o *MobileGatewayOp) GetSIMRoutes(ctx context.Context, zone string, id type
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6334,6 +6451,7 @@ func (o *MobileGatewayOp) SetSIMRoutes(ctx context.Context, zone string, id type
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6377,6 +6495,7 @@ func (o *MobileGatewayOp) ListSIM(ctx context.Context, zone string, id types.ID)
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6408,6 +6527,7 @@ func (o *MobileGatewayOp) AddSIM(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6451,6 +6571,7 @@ func (o *MobileGatewayOp) DeleteSIM(ctx context.Context, zone string, id types.I
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"simID":      simID,
 	})
@@ -6474,6 +6595,7 @@ func (o *MobileGatewayOp) Logs(ctx context.Context, zone string, id types.ID) ([
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6505,6 +6627,7 @@ func (o *MobileGatewayOp) GetTrafficConfig(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6536,6 +6659,7 @@ func (o *MobileGatewayOp) SetTrafficConfig(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6579,6 +6703,7 @@ func (o *MobileGatewayOp) DeleteTrafficConfig(ctx context.Context, zone string, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6601,6 +6726,7 @@ func (o *MobileGatewayOp) TrafficStatus(ctx context.Context, zone string, id typ
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6632,6 +6758,7 @@ func (o *MobileGatewayOp) MonitorInterface(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"index":      index,
 		"condition":  condition,
@@ -6709,6 +6836,7 @@ func (o *NFSOp) Find(ctx context.Context, zone string, conditions *FindCondition
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -6755,6 +6883,7 @@ func (o *NFSOp) Create(ctx context.Context, zone string, param *NFSCreateRequest
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -6801,6 +6930,7 @@ func (o *NFSOp) Read(ctx context.Context, zone string, id types.ID) (*NFS, error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6832,6 +6962,7 @@ func (o *NFSOp) Update(ctx context.Context, zone string, id types.ID, param *NFS
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -6884,6 +7015,7 @@ func (o *NFSOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6906,6 +7038,7 @@ func (o *NFSOp) Boot(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6928,6 +7061,7 @@ func (o *NFSOp) Shutdown(ctx context.Context, zone string, id types.ID, shutdown
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
+		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -6971,6 +7105,7 @@ func (o *NFSOp) Reset(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -6993,6 +7128,7 @@ func (o *NFSOp) MonitorFreeDiskSize(ctx context.Context, zone string, id types.I
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -7045,6 +7181,7 @@ func (o *NFSOp) MonitorInterface(ctx context.Context, zone string, id types.ID, 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -7337,6 +7474,7 @@ func (o *PacketFilterOp) Find(ctx context.Context, zone string, conditions *Find
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -7383,6 +7521,7 @@ func (o *PacketFilterOp) Create(ctx context.Context, zone string, param *PacketF
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -7429,6 +7568,7 @@ func (o *PacketFilterOp) Read(ctx context.Context, zone string, id types.ID) (*P
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7460,6 +7600,7 @@ func (o *PacketFilterOp) Update(ctx context.Context, zone string, id types.ID, p
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -7512,6 +7653,7 @@ func (o *PacketFilterOp) Delete(ctx context.Context, zone string, id types.ID) e
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7553,6 +7695,7 @@ func (o *PrivateHostOp) Find(ctx context.Context, zone string, conditions *FindC
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -7599,6 +7742,7 @@ func (o *PrivateHostOp) Create(ctx context.Context, zone string, param *PrivateH
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -7645,6 +7789,7 @@ func (o *PrivateHostOp) Read(ctx context.Context, zone string, id types.ID) (*Pr
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7676,6 +7821,7 @@ func (o *PrivateHostOp) Update(ctx context.Context, zone string, id types.ID, pa
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -7728,6 +7874,7 @@ func (o *PrivateHostOp) Delete(ctx context.Context, zone string, id types.ID) er
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -7769,6 +7916,7 @@ func (o *PrivateHostPlanOp) Find(ctx context.Context, zone string, conditions *F
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -7815,6 +7963,7 @@ func (o *PrivateHostPlanOp) Read(ctx context.Context, zone string, id types.ID) 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8400,6 +8549,7 @@ func (o *ServerOp) Find(ctx context.Context, zone string, conditions *FindCondit
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -8446,6 +8596,7 @@ func (o *ServerOp) Create(ctx context.Context, zone string, param *ServerCreateR
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -8492,6 +8643,7 @@ func (o *ServerOp) Read(ctx context.Context, zone string, id types.ID) (*Server,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8523,6 +8675,7 @@ func (o *ServerOp) Update(ctx context.Context, zone string, id types.ID, param *
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -8575,6 +8728,7 @@ func (o *ServerOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8597,6 +8751,7 @@ func (o *ServerOp) ChangePlan(ctx context.Context, zone string, id types.ID, pla
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"plan":       plan,
 	})
@@ -8649,6 +8804,7 @@ func (o *ServerOp) InsertCDROM(ctx context.Context, zone string, id types.ID, in
 		"rootURL":     SakuraCloudAPIRoot,
 		"pathSuffix":  o.PathSuffix,
 		"pathName":    o.PathName,
+		"zone":        zone,
 		"id":          id,
 		"insertParam": insertParam,
 	})
@@ -8692,6 +8848,7 @@ func (o *ServerOp) EjectCDROM(ctx context.Context, zone string, id types.ID, ins
 		"rootURL":     SakuraCloudAPIRoot,
 		"pathSuffix":  o.PathSuffix,
 		"pathName":    o.PathName,
+		"zone":        zone,
 		"id":          id,
 		"insertParam": insertParam,
 	})
@@ -8735,6 +8892,7 @@ func (o *ServerOp) Boot(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8757,6 +8915,7 @@ func (o *ServerOp) Shutdown(ctx context.Context, zone string, id types.ID, shutd
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
+		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -8800,6 +8959,7 @@ func (o *ServerOp) Reset(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8822,6 +8982,7 @@ func (o *ServerOp) Monitor(ctx context.Context, zone string, id types.ID, condit
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"condition":  condition,
 	})
@@ -8893,6 +9054,7 @@ func (o *ServerPlanOp) Find(ctx context.Context, zone string, conditions *FindCo
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -8939,6 +9101,7 @@ func (o *ServerPlanOp) Read(ctx context.Context, zone string, id types.ID) (*Ser
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -8989,6 +9152,7 @@ func (o *ServiceClassOp) Find(ctx context.Context, zone string, conditions *Find
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -10222,6 +10386,7 @@ func (o *SwitchOp) Find(ctx context.Context, zone string, conditions *FindCondit
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -10268,6 +10433,7 @@ func (o *SwitchOp) Create(ctx context.Context, zone string, param *SwitchCreateR
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -10314,6 +10480,7 @@ func (o *SwitchOp) Read(ctx context.Context, zone string, id types.ID) (*Switch,
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10345,6 +10512,7 @@ func (o *SwitchOp) Update(ctx context.Context, zone string, id types.ID, param *
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -10397,6 +10565,7 @@ func (o *SwitchOp) Delete(ctx context.Context, zone string, id types.ID) error {
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10419,6 +10588,7 @@ func (o *SwitchOp) ConnectToBridge(ctx context.Context, zone string, id types.ID
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"bridgeID":   bridgeID,
 	})
@@ -10442,6 +10612,7 @@ func (o *SwitchOp) DisconnectFromBridge(ctx context.Context, zone string, id typ
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10483,6 +10654,7 @@ func (o *VPCRouterOp) Find(ctx context.Context, zone string, conditions *FindCon
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"conditions": conditions,
 	})
 	if err != nil {
@@ -10529,6 +10701,7 @@ func (o *VPCRouterOp) Create(ctx context.Context, zone string, param *VPCRouterC
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"param":      param,
 	})
 	if err != nil {
@@ -10575,6 +10748,7 @@ func (o *VPCRouterOp) Read(ctx context.Context, zone string, id types.ID) (*VPCR
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10606,6 +10780,7 @@ func (o *VPCRouterOp) Update(ctx context.Context, zone string, id types.ID, para
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"param":      param,
 	})
@@ -10658,6 +10833,7 @@ func (o *VPCRouterOp) Delete(ctx context.Context, zone string, id types.ID) erro
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10680,6 +10856,7 @@ func (o *VPCRouterOp) Config(ctx context.Context, zone string, id types.ID) erro
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10702,6 +10879,7 @@ func (o *VPCRouterOp) Boot(ctx context.Context, zone string, id types.ID) error 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10724,6 +10902,7 @@ func (o *VPCRouterOp) Shutdown(ctx context.Context, zone string, id types.ID, sh
 		"rootURL":        SakuraCloudAPIRoot,
 		"pathSuffix":     o.PathSuffix,
 		"pathName":       o.PathName,
+		"zone":           zone,
 		"id":             id,
 		"shutdownOption": shutdownOption,
 	})
@@ -10767,6 +10946,7 @@ func (o *VPCRouterOp) Reset(ctx context.Context, zone string, id types.ID) error
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 	})
 	if err != nil {
@@ -10789,6 +10969,7 @@ func (o *VPCRouterOp) ConnectToSwitch(ctx context.Context, zone string, id types
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"nicIndex":   nicIndex,
 		"switchID":   switchID,
@@ -10813,6 +10994,7 @@ func (o *VPCRouterOp) DisconnectFromSwitch(ctx context.Context, zone string, id 
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"nicIndex":   nicIndex,
 	})
@@ -10836,6 +11018,7 @@ func (o *VPCRouterOp) MonitorInterface(ctx context.Context, zone string, id type
 		"rootURL":    SakuraCloudAPIRoot,
 		"pathSuffix": o.PathSuffix,
 		"pathName":   o.PathName,
+		"zone":       zone,
 		"id":         id,
 		"index":      index,
 		"condition":  condition,

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -30,7 +30,7 @@ type ArchiveAPI interface {
 
 // AuthStatusAPI is interface for operate AuthStatus resource
 type AuthStatusAPI interface {
-	Read(ctx context.Context, zone string) (*AuthStatus, error)
+	Read(ctx context.Context) (*AuthStatus, error)
 }
 
 /*************************************************
@@ -52,12 +52,12 @@ type AutoBackupAPI interface {
 
 // BillAPI is interface for operate Bill resource
 type BillAPI interface {
-	ByContract(ctx context.Context, zone string, accountID types.ID) (*BillByContractResult, error)
-	ByContractYear(ctx context.Context, zone string, accountID types.ID, year int) (*BillByContractYearResult, error)
-	ByContractYearMonth(ctx context.Context, zone string, accountID types.ID, year int, month int) (*BillByContractYearMonthResult, error)
-	Read(ctx context.Context, zone string, id types.ID) (*BillReadResult, error)
-	Details(ctx context.Context, zone string, MemberCode string, id types.ID) (*BillDetailsResult, error)
-	DetailsCSV(ctx context.Context, zone string, MemberCode string, id types.ID) (*BillDetailCSV, error)
+	ByContract(ctx context.Context, accountID types.ID) (*BillByContractResult, error)
+	ByContractYear(ctx context.Context, accountID types.ID, year int) (*BillByContractYearResult, error)
+	ByContractYearMonth(ctx context.Context, accountID types.ID, year int, month int) (*BillByContractYearMonthResult, error)
+	Read(ctx context.Context, id types.ID) (*BillReadResult, error)
+	Details(ctx context.Context, MemberCode string, id types.ID) (*BillDetailsResult, error)
+	DetailsCSV(ctx context.Context, MemberCode string, id types.ID) (*BillDetailCSV, error)
 }
 
 /*************************************************
@@ -94,7 +94,7 @@ type CDROMAPI interface {
 
 // CouponAPI is interface for operate Coupon resource
 type CouponAPI interface {
-	Find(ctx context.Context, zone string, accountID types.ID) (*CouponFindResult, error)
+	Find(ctx context.Context, accountID types.ID) (*CouponFindResult, error)
 }
 
 /*************************************************
@@ -159,11 +159,11 @@ type DiskPlanAPI interface {
 
 // DNSAPI is interface for operate DNS resource
 type DNSAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*DNSFindResult, error)
-	Create(ctx context.Context, zone string, param *DNSCreateRequest) (*DNS, error)
-	Read(ctx context.Context, zone string, id types.ID) (*DNS, error)
-	Update(ctx context.Context, zone string, id types.ID, param *DNSUpdateRequest) (*DNS, error)
-	Delete(ctx context.Context, zone string, id types.ID) error
+	Find(ctx context.Context, conditions *FindCondition) (*DNSFindResult, error)
+	Create(ctx context.Context, param *DNSCreateRequest) (*DNS, error)
+	Read(ctx context.Context, id types.ID) (*DNS, error)
+	Update(ctx context.Context, id types.ID, param *DNSUpdateRequest) (*DNS, error)
+	Delete(ctx context.Context, id types.ID) error
 }
 
 /*************************************************
@@ -172,11 +172,11 @@ type DNSAPI interface {
 
 // GSLBAPI is interface for operate GSLB resource
 type GSLBAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*GSLBFindResult, error)
-	Create(ctx context.Context, zone string, param *GSLBCreateRequest) (*GSLB, error)
-	Read(ctx context.Context, zone string, id types.ID) (*GSLB, error)
-	Update(ctx context.Context, zone string, id types.ID, param *GSLBUpdateRequest) (*GSLB, error)
-	Delete(ctx context.Context, zone string, id types.ID) error
+	Find(ctx context.Context, conditions *FindCondition) (*GSLBFindResult, error)
+	Create(ctx context.Context, param *GSLBCreateRequest) (*GSLB, error)
+	Read(ctx context.Context, id types.ID) (*GSLB, error)
+	Update(ctx context.Context, id types.ID, param *GSLBUpdateRequest) (*GSLB, error)
+	Delete(ctx context.Context, id types.ID) error
 }
 
 /*************************************************
@@ -185,11 +185,11 @@ type GSLBAPI interface {
 
 // IconAPI is interface for operate Icon resource
 type IconAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*IconFindResult, error)
-	Create(ctx context.Context, zone string, param *IconCreateRequest) (*Icon, error)
-	Read(ctx context.Context, zone string, id types.ID) (*Icon, error)
-	Update(ctx context.Context, zone string, id types.ID, param *IconUpdateRequest) (*Icon, error)
-	Delete(ctx context.Context, zone string, id types.ID) error
+	Find(ctx context.Context, conditions *FindCondition) (*IconFindResult, error)
+	Create(ctx context.Context, param *IconCreateRequest) (*Icon, error)
+	Read(ctx context.Context, id types.ID) (*Icon, error)
+	Update(ctx context.Context, id types.ID, param *IconUpdateRequest) (*Icon, error)
+	Delete(ctx context.Context, id types.ID) error
 }
 
 /*************************************************
@@ -281,11 +281,11 @@ type IPv6AddrAPI interface {
 
 // LicenseAPI is interface for operate License resource
 type LicenseAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*LicenseFindResult, error)
-	Create(ctx context.Context, zone string, param *LicenseCreateRequest) (*License, error)
-	Read(ctx context.Context, zone string, id types.ID) (*License, error)
-	Update(ctx context.Context, zone string, id types.ID, param *LicenseUpdateRequest) (*License, error)
-	Delete(ctx context.Context, zone string, id types.ID) error
+	Find(ctx context.Context, conditions *FindCondition) (*LicenseFindResult, error)
+	Create(ctx context.Context, param *LicenseCreateRequest) (*License, error)
+	Read(ctx context.Context, id types.ID) (*License, error)
+	Update(ctx context.Context, id types.ID, param *LicenseUpdateRequest) (*License, error)
+	Delete(ctx context.Context, id types.ID) error
 }
 
 /*************************************************
@@ -294,8 +294,8 @@ type LicenseAPI interface {
 
 // LicenseInfoAPI is interface for operate LicenseInfo resource
 type LicenseInfoAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*LicenseInfoFindResult, error)
-	Read(ctx context.Context, zone string, id types.ID) (*LicenseInfo, error)
+	Find(ctx context.Context, conditions *FindCondition) (*LicenseInfoFindResult, error)
+	Read(ctx context.Context, id types.ID) (*LicenseInfo, error)
 }
 
 /*************************************************
@@ -373,11 +373,11 @@ type NFSAPI interface {
 
 // NoteAPI is interface for operate Note resource
 type NoteAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*NoteFindResult, error)
-	Create(ctx context.Context, zone string, param *NoteCreateRequest) (*Note, error)
-	Read(ctx context.Context, zone string, id types.ID) (*Note, error)
-	Update(ctx context.Context, zone string, id types.ID, param *NoteUpdateRequest) (*Note, error)
-	Delete(ctx context.Context, zone string, id types.ID) error
+	Find(ctx context.Context, conditions *FindCondition) (*NoteFindResult, error)
+	Create(ctx context.Context, param *NoteCreateRequest) (*Note, error)
+	Read(ctx context.Context, id types.ID) (*Note, error)
+	Update(ctx context.Context, id types.ID, param *NoteUpdateRequest) (*Note, error)
+	Delete(ctx context.Context, id types.ID) error
 }
 
 /*************************************************
@@ -422,17 +422,17 @@ type PrivateHostPlanAPI interface {
 
 // ProxyLBAPI is interface for operate ProxyLB resource
 type ProxyLBAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*ProxyLBFindResult, error)
-	Create(ctx context.Context, zone string, param *ProxyLBCreateRequest) (*ProxyLB, error)
-	Read(ctx context.Context, zone string, id types.ID) (*ProxyLB, error)
-	Update(ctx context.Context, zone string, id types.ID, param *ProxyLBUpdateRequest) (*ProxyLB, error)
-	Delete(ctx context.Context, zone string, id types.ID) error
-	ChangePlan(ctx context.Context, zone string, id types.ID, param *ProxyLBChangePlanRequest) (*ProxyLB, error)
-	GetCertificates(ctx context.Context, zone string, id types.ID) (*ProxyLBCertificates, error)
-	SetCertificates(ctx context.Context, zone string, id types.ID, param *ProxyLBSetCertificatesRequest) (*ProxyLBCertificates, error)
-	DeleteCertificates(ctx context.Context, zone string, id types.ID) error
-	RenewLetsEncryptCert(ctx context.Context, zone string, id types.ID) error
-	HealthStatus(ctx context.Context, zone string, id types.ID) (*ProxyLBHealth, error)
+	Find(ctx context.Context, conditions *FindCondition) (*ProxyLBFindResult, error)
+	Create(ctx context.Context, param *ProxyLBCreateRequest) (*ProxyLB, error)
+	Read(ctx context.Context, id types.ID) (*ProxyLB, error)
+	Update(ctx context.Context, id types.ID, param *ProxyLBUpdateRequest) (*ProxyLB, error)
+	Delete(ctx context.Context, id types.ID) error
+	ChangePlan(ctx context.Context, id types.ID, param *ProxyLBChangePlanRequest) (*ProxyLB, error)
+	GetCertificates(ctx context.Context, id types.ID) (*ProxyLBCertificates, error)
+	SetCertificates(ctx context.Context, id types.ID, param *ProxyLBSetCertificatesRequest) (*ProxyLBCertificates, error)
+	DeleteCertificates(ctx context.Context, id types.ID) error
+	RenewLetsEncryptCert(ctx context.Context, id types.ID) error
+	HealthStatus(ctx context.Context, id types.ID) (*ProxyLBHealth, error)
 }
 
 /*************************************************
@@ -441,8 +441,8 @@ type ProxyLBAPI interface {
 
 // RegionAPI is interface for operate Region resource
 type RegionAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*RegionFindResult, error)
-	Read(ctx context.Context, zone string, id types.ID) (*Region, error)
+	Find(ctx context.Context, conditions *FindCondition) (*RegionFindResult, error)
+	Read(ctx context.Context, id types.ID) (*Region, error)
 }
 
 /*************************************************
@@ -490,22 +490,22 @@ type ServiceClassAPI interface {
 
 // SIMAPI is interface for operate SIM resource
 type SIMAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*SIMFindResult, error)
-	Create(ctx context.Context, zone string, param *SIMCreateRequest) (*SIM, error)
-	Read(ctx context.Context, zone string, id types.ID) (*SIM, error)
-	Update(ctx context.Context, zone string, id types.ID, param *SIMUpdateRequest) (*SIM, error)
-	Delete(ctx context.Context, zone string, id types.ID) error
-	Activate(ctx context.Context, zone string, id types.ID) error
-	Deactivate(ctx context.Context, zone string, id types.ID) error
-	AssignIP(ctx context.Context, zone string, id types.ID, param *SIMAssignIPRequest) error
-	ClearIP(ctx context.Context, zone string, id types.ID) error
-	IMEILock(ctx context.Context, zone string, id types.ID, param *SIMIMEILockRequest) error
-	IMEIUnlock(ctx context.Context, zone string, id types.ID) error
-	Logs(ctx context.Context, zone string, id types.ID) (*SIMLogsResult, error)
-	GetNetworkOperator(ctx context.Context, zone string, id types.ID) ([]*SIMNetworkOperatorConfig, error)
-	SetNetworkOperator(ctx context.Context, zone string, id types.ID, configs []*SIMNetworkOperatorConfig) error
-	MonitorSIM(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*LinkActivity, error)
-	Status(ctx context.Context, zone string, id types.ID) (*SIMInfo, error)
+	Find(ctx context.Context, conditions *FindCondition) (*SIMFindResult, error)
+	Create(ctx context.Context, param *SIMCreateRequest) (*SIM, error)
+	Read(ctx context.Context, id types.ID) (*SIM, error)
+	Update(ctx context.Context, id types.ID, param *SIMUpdateRequest) (*SIM, error)
+	Delete(ctx context.Context, id types.ID) error
+	Activate(ctx context.Context, id types.ID) error
+	Deactivate(ctx context.Context, id types.ID) error
+	AssignIP(ctx context.Context, id types.ID, param *SIMAssignIPRequest) error
+	ClearIP(ctx context.Context, id types.ID) error
+	IMEILock(ctx context.Context, id types.ID, param *SIMIMEILockRequest) error
+	IMEIUnlock(ctx context.Context, id types.ID) error
+	Logs(ctx context.Context, id types.ID) (*SIMLogsResult, error)
+	GetNetworkOperator(ctx context.Context, id types.ID) ([]*SIMNetworkOperatorConfig, error)
+	SetNetworkOperator(ctx context.Context, id types.ID, configs []*SIMNetworkOperatorConfig) error
+	MonitorSIM(ctx context.Context, id types.ID, condition *MonitorCondition) (*LinkActivity, error)
+	Status(ctx context.Context, id types.ID) (*SIMInfo, error)
 }
 
 /*************************************************
@@ -514,13 +514,13 @@ type SIMAPI interface {
 
 // SimpleMonitorAPI is interface for operate SimpleMonitor resource
 type SimpleMonitorAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*SimpleMonitorFindResult, error)
-	Create(ctx context.Context, zone string, param *SimpleMonitorCreateRequest) (*SimpleMonitor, error)
-	Read(ctx context.Context, zone string, id types.ID) (*SimpleMonitor, error)
-	Update(ctx context.Context, zone string, id types.ID, param *SimpleMonitorUpdateRequest) (*SimpleMonitor, error)
-	Delete(ctx context.Context, zone string, id types.ID) error
-	MonitorResponseTime(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*ResponseTimeSecActivity, error)
-	HealthStatus(ctx context.Context, zone string, id types.ID) (*SimpleMonitorHealthStatus, error)
+	Find(ctx context.Context, conditions *FindCondition) (*SimpleMonitorFindResult, error)
+	Create(ctx context.Context, param *SimpleMonitorCreateRequest) (*SimpleMonitor, error)
+	Read(ctx context.Context, id types.ID) (*SimpleMonitor, error)
+	Update(ctx context.Context, id types.ID, param *SimpleMonitorUpdateRequest) (*SimpleMonitor, error)
+	Delete(ctx context.Context, id types.ID) error
+	MonitorResponseTime(ctx context.Context, id types.ID, condition *MonitorCondition) (*ResponseTimeSecActivity, error)
+	HealthStatus(ctx context.Context, id types.ID) (*SimpleMonitorHealthStatus, error)
 }
 
 /*************************************************
@@ -529,12 +529,12 @@ type SimpleMonitorAPI interface {
 
 // SSHKeyAPI is interface for operate SSHKey resource
 type SSHKeyAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*SSHKeyFindResult, error)
-	Create(ctx context.Context, zone string, param *SSHKeyCreateRequest) (*SSHKey, error)
-	Generate(ctx context.Context, zone string, param *SSHKeyGenerateRequest) (*SSHKeyGenerated, error)
-	Read(ctx context.Context, zone string, id types.ID) (*SSHKey, error)
-	Update(ctx context.Context, zone string, id types.ID, param *SSHKeyUpdateRequest) (*SSHKey, error)
-	Delete(ctx context.Context, zone string, id types.ID) error
+	Find(ctx context.Context, conditions *FindCondition) (*SSHKeyFindResult, error)
+	Create(ctx context.Context, param *SSHKeyCreateRequest) (*SSHKey, error)
+	Generate(ctx context.Context, param *SSHKeyGenerateRequest) (*SSHKeyGenerated, error)
+	Read(ctx context.Context, id types.ID) (*SSHKey, error)
+	Update(ctx context.Context, id types.ID, param *SSHKeyUpdateRequest) (*SSHKey, error)
+	Delete(ctx context.Context, id types.ID) error
 }
 
 /*************************************************
@@ -578,12 +578,12 @@ type VPCRouterAPI interface {
 
 // WebAccelAPI is interface for operate WebAccel resource
 type WebAccelAPI interface {
-	List(ctx context.Context, zone string) (*WebAccelListResult, error)
-	Read(ctx context.Context, zone string, id types.ID) (*WebAccel, error)
-	ReadCertificate(ctx context.Context, zone string, id types.ID) (*WebAccelCerts, error)
-	UpdateCertificate(ctx context.Context, zone string, id types.ID, param *WebAccelCertUpdateRequest) (*WebAccelCerts, error)
-	DeleteAllCache(ctx context.Context, zone string, param *WebAccelDeleteAllCacheRequest) error
-	DeleteCache(ctx context.Context, zone string, param *WebAccelDeleteCacheRequest) ([]*WebAccelDeleteCacheResult, error)
+	List(ctx context.Context) (*WebAccelListResult, error)
+	Read(ctx context.Context, id types.ID) (*WebAccel, error)
+	ReadCertificate(ctx context.Context, id types.ID) (*WebAccelCerts, error)
+	UpdateCertificate(ctx context.Context, id types.ID, param *WebAccelCertUpdateRequest) (*WebAccelCerts, error)
+	DeleteAllCache(ctx context.Context, param *WebAccelDeleteAllCacheRequest) error
+	DeleteCache(ctx context.Context, param *WebAccelDeleteCacheRequest) ([]*WebAccelDeleteCacheResult, error)
 }
 
 /*************************************************
@@ -592,6 +592,6 @@ type WebAccelAPI interface {
 
 // ZoneAPI is interface for operate Zone resource
 type ZoneAPI interface {
-	Find(ctx context.Context, zone string, conditions *FindCondition) (*ZoneFindResult, error)
-	Read(ctx context.Context, zone string, id types.ID) (*Zone, error)
+	Find(ctx context.Context, conditions *FindCondition) (*ZoneFindResult, error)
+	Read(ctx context.Context, id types.ID) (*Zone, error)
 }


### PR DESCRIPTION
グローバルリソースの場合、API引数としてゾーンを受け取らず常に固定値を利用するようにする。

APIのシグニチャは以下のように変更となる。

変更前:
```go
// AuthStatusAPI is interface for operate AuthStatus resource
type AuthStatusAPI interface {
	Read(ctx context.Context, zone string) (*AuthStatus, error)
}
```

変更後:
```go
// AuthStatusAPI is interface for operate AuthStatus resource
type AuthStatusAPI interface {
	Read(ctx context.Context) (*AuthStatus, error)
}
```
