### PR TITLE
検索フィルタで重複キーを許可

### DIFF
--- a/sacloud/search/example_test.go
+++ b/sacloud/search/example_test.go
@@ -28,7 +28,7 @@ func Example() {
 	// 名称に"Example"を含むサーバを検索
 	condition := &sacloud.FindCondition{
 		Filter: search.Filter{
-			search.Key("Name"): search.PartialMatch("Example"),
+			search.Criterion{Key: search.Key("Name"), Value: search.PartialMatch("Example")},
 		},
 	}
 	searched, err := serverOp.Find(context.Background(), zone, condition)
@@ -44,9 +44,12 @@ func Example() {
 	//   - 作成日時が1週間以上前
 	condition = &sacloud.FindCondition{
 		Filter: search.Filter{
-			search.Key("Name"):                               search.AndEqual("test", "example"),
-			search.Key("Zone.Name"):                          search.OrEqual("is1a", "is1b"),
-			search.KeyWithOp("CreatedAt", search.OpLessThan): time.Now().Add(-7 * 24 * time.Hour),
+			search.Criterion{Key: search.Key("Name"), Value: search.AndEqual("test", "example")},
+			search.Criterion{Key: search.Key("Zone.Name"), Value: search.OrEqual("is1a", "is1b")},
+			search.Criterion{
+				Key:   search.KeyWithOp("CreatedAt", search.OpLessThan),
+				Value: time.Now().Add(-7 * 24 * time.Hour),
+			},
 		},
 	}
 	searched, err = serverOp.Find(context.Background(), zone, condition)

--- a/sacloud/search/filter.go
+++ b/sacloud/search/filter.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -14,13 +15,19 @@ import (
 // このため、libsacloud側では数値型に見える項目でもさくらのクラウド側では文字列となっている場合がある。
 // これらの項目ではOpEqual以外の演算子は利用できない。
 // また、これらの項目でスカラ値を検索条件に与えた場合は部分一致ではなく完全一致となるため注意。
-type Filter map[FilterKey]interface{}
+type Filter Criteria
+
+// Criteria 検索条件
+type Criteria []Criterion
 
 // MarshalJSON 検索系APIコール時のGETパラメータを出力するためのjson.Marshaler実装
 func (f Filter) MarshalJSON() ([]byte, error) {
-	result := make(map[string]interface{})
+	var results []string
 
-	for key, expression := range f {
+	for _, item := range f {
+		key := item.Key
+		expression := item.Value
+
 		if expression == nil {
 			continue
 		}
@@ -35,10 +42,34 @@ func (f Filter) MarshalJSON() ([]byte, error) {
 			exp = convertToValidFilterCondition(exp)
 		}
 
-		result[key.String()] = exp
+		marshaled, err := json.Marshal(map[string]interface{}{key.String(): exp})
+		if err != nil {
+			return nil, err
+		}
+
+		result := strings.Trim(string(marshaled), "{}")
+		results = append(results, result)
 	}
 
-	return json.Marshal(result)
+	return []byte(fmt.Sprintf("{%s}", strings.Join(results, ","))), nil
+}
+
+// Add 項目追加
+func (f *Filter) Add(item Criterion) {
+	*f = append(*f, item)
+}
+
+// AddNew 項目を作成して追加
+func (f *Filter) AddNew(key FilterKey, value interface{}) {
+	f.Add(Criterion{Key: key, Value: value})
+}
+
+// Criterion フィルタの項目
+type Criterion struct {
+	// Key キー
+	Key FilterKey
+	// Value 検索条件値
+	Value interface{}
 }
 
 func convertToValidFilterCondition(v interface{}) string {

--- a/sacloud/search/filter_test.go
+++ b/sacloud/search/filter_test.go
@@ -95,14 +95,27 @@ func TestFilter(t *testing.T) {
 					condition: time.Date(2011, 9, 1, 0, 0, 0, 0, loc),
 				},
 			},
-			expect: `{"CreatedAt\u003c":"2011-09-01T00:00:00+09:00","Name":"test%20example","Zone.Name":["is1a","is1b"]}`,
+			expect: `{"Name":"test%20example","Zone.Name":["is1a","is1b"],"CreatedAt\u003c":"2011-09-01T00:00:00+09:00"}`,
+		},
+		{
+			conditions: []*inputKeyValue{
+				{
+					key:       Key("Tags.Name"),
+					condition: "value1",
+				},
+				{
+					key:       Key("Tags.Name"),
+					condition: "value2",
+				},
+			},
+			expect: `{"Tags.Name":["value1"],"Tags.Name":["value2"]}`,
 		},
 	}
 
 	for _, tc := range cases {
 		filter := Filter{}
 		for _, kv := range tc.conditions {
-			filter[kv.key] = kv.condition
+			filter.AddNew(kv.key, kv.condition)
 		}
 
 		data, err := json.Marshal(filter)

--- a/sacloud/test/disk_op_test.go
+++ b/sacloud/test/disk_op_test.go
@@ -148,11 +148,11 @@ func TestDiskOp_Config(t *testing.T) {
 		Parallel:           true,
 		SetupAPICallerFunc: singletonAPICaller,
 		Setup: func(ctx *CRUDTestContext, caller sacloud.APICaller) error {
-			archiveName := "CentOS"
 			client := sacloud.NewArchiveOp(singletonAPICaller())
 			searched, err := client.Find(ctx, testZone, &sacloud.FindCondition{
 				Filter: search.Filter{
-					search.Key("Name"): search.PartialMatch(archiveName),
+					search.Criterion{Key: search.Key("Tags.Name"), Value: "current-stable"},
+					search.Criterion{Key: search.Key("Tags.Name"), Value: "distro-centos"},
 				},
 			})
 			if !assert.NoError(t, err) {

--- a/sacloud/test/functions.go
+++ b/sacloud/test/functions.go
@@ -13,7 +13,7 @@ func lookupDNSByName(caller sacloud.APICaller, zoneName string) (*sacloud.DNS, e
 	searched, err := dnsOp.Find(context.Background(), &sacloud.FindCondition{
 		Count: 1,
 		Filter: search.Filter{
-			search.Key("Name"): zoneName,
+			search.Criterion{Key: search.Key("Name"), Value: zoneName},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
以下のようなパターンでのフィルタ指定を許可する。

```
{
    "Tags.Name":["value1"],
    "Tags.Name":["value2"]
}
```