### PR TITLE
Revert "検索フィルタで重複キーを許可"

### DIFF
--- a/sacloud/search/example_test.go
+++ b/sacloud/search/example_test.go
@@ -28,7 +28,7 @@ func Example() {
 	// 名称に"Example"を含むサーバを検索
 	condition := &sacloud.FindCondition{
 		Filter: search.Filter{
-			search.Criterion{Key: search.Key("Name"), Value: search.PartialMatch("Example")},
+			search.Key("Name"): search.PartialMatch("Example"),
 		},
 	}
 	searched, err := serverOp.Find(context.Background(), zone, condition)
@@ -44,12 +44,9 @@ func Example() {
 	//   - 作成日時が1週間以上前
 	condition = &sacloud.FindCondition{
 		Filter: search.Filter{
-			search.Criterion{Key: search.Key("Name"), Value: search.AndEqual("test", "example")},
-			search.Criterion{Key: search.Key("Zone.Name"), Value: search.OrEqual("is1a", "is1b")},
-			search.Criterion{
-				Key:   search.KeyWithOp("CreatedAt", search.OpLessThan),
-				Value: time.Now().Add(-7 * 24 * time.Hour),
-			},
+			search.Key("Name"):                               search.AndEqual("test", "example"),
+			search.Key("Zone.Name"):                          search.OrEqual("is1a", "is1b"),
+			search.KeyWithOp("CreatedAt", search.OpLessThan): time.Now().Add(-7 * 24 * time.Hour),
 		},
 	}
 	searched, err = serverOp.Find(context.Background(), zone, condition)

--- a/sacloud/search/filter_test.go
+++ b/sacloud/search/filter_test.go
@@ -95,27 +95,14 @@ func TestFilter(t *testing.T) {
 					condition: time.Date(2011, 9, 1, 0, 0, 0, 0, loc),
 				},
 			},
-			expect: `{"Name":"test%20example","Zone.Name":["is1a","is1b"],"CreatedAt\u003c":"2011-09-01T00:00:00+09:00"}`,
-		},
-		{
-			conditions: []*inputKeyValue{
-				{
-					key:       Key("Tags.Name"),
-					condition: "value1",
-				},
-				{
-					key:       Key("Tags.Name"),
-					condition: "value2",
-				},
-			},
-			expect: `{"Tags.Name":["value1"],"Tags.Name":["value2"]}`,
+			expect: `{"CreatedAt\u003c":"2011-09-01T00:00:00+09:00","Name":"test%20example","Zone.Name":["is1a","is1b"]}`,
 		},
 	}
 
 	for _, tc := range cases {
 		filter := Filter{}
 		for _, kv := range tc.conditions {
-			filter.AddNew(kv.key, kv.condition)
+			filter[kv.key] = kv.condition
 		}
 
 		data, err := json.Marshal(filter)

--- a/sacloud/test/disk_op_test.go
+++ b/sacloud/test/disk_op_test.go
@@ -148,11 +148,11 @@ func TestDiskOp_Config(t *testing.T) {
 		Parallel:           true,
 		SetupAPICallerFunc: singletonAPICaller,
 		Setup: func(ctx *CRUDTestContext, caller sacloud.APICaller) error {
+			archiveName := "CentOS"
 			client := sacloud.NewArchiveOp(singletonAPICaller())
 			searched, err := client.Find(ctx, testZone, &sacloud.FindCondition{
 				Filter: search.Filter{
-					search.Criterion{Key: search.Key("Tags.Name"), Value: "current-stable"},
-					search.Criterion{Key: search.Key("Tags.Name"), Value: "distro-centos"},
+					search.Key("Name"): search.PartialMatch(archiveName),
 				},
 			})
 			if !assert.NoError(t, err) {

--- a/sacloud/test/functions.go
+++ b/sacloud/test/functions.go
@@ -13,7 +13,7 @@ func lookupDNSByName(caller sacloud.APICaller, zoneName string) (*sacloud.DNS, e
 	searched, err := dnsOp.Find(context.Background(), &sacloud.FindCondition{
 		Count: 1,
 		Filter: search.Filter{
-			search.Criterion{Key: search.Key("Name"), Value: zoneName},
+			search.Key("Name"): zoneName,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Reverts sacloud/libsacloud#273

APIの挙動を勘違いしていたためRevertする。
実際には以下のようなパターンで検索フィルタを指定していた。

```
{
  "Tags.Name":[
    ["current-stable","distro-centos"]
  ]
}
```