### PR TITLE
ディスクの修正可否判定funcの移行

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ VETARGS?=-all
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 export GO111MODULE=on
 
-default: clean gen fmt goimports golint vet test
+default: gen fmt goimports golint vet test
 
 test:
 	TESTACC= go test ./... $(TESTARGS) -v -timeout=120m -parallel=8 ;
@@ -20,7 +20,7 @@ clean:
 	rm -f sacloud/trace/zz_*.go
 
 .PHONY: gen
-gen: clean
+gen:
 	go generate ./...; gofmt -s -l -w $(GOFMT_FILES); goimports -l -w $(GOFMT_FILES)
 
 vet: golint

--- a/utils/archive/functions.go
+++ b/utils/archive/functions.go
@@ -79,7 +79,7 @@ func CanEditDisk(ctx context.Context, zone string, reader *SourceInfoReader, id 
 		}
 	}
 	if disk != nil {
-		// 無限ルール予防
+		// 無限ループ予防
 		if disk.ID == disk.SourceDiskID || disk.ID == disk.SourceArchiveID {
 			return false, errors.New("invalid state: disk has invalid ID or SourceDiskID or SourceArchiveID")
 		}
@@ -100,7 +100,7 @@ func CanEditDisk(ctx context.Context, zone string, reader *SourceInfoReader, id 
 		return false, err
 	}
 
-	// 無限ルール予防
+	// 無限ループ予防
 	if archive.ID == archive.SourceDiskID || archive.ID == archive.SourceArchiveID {
 		return false, errors.New("invalid state: archive has invalid ID or SourceDiskID or SourceArchiveID")
 	}

--- a/utils/archive/functions.go
+++ b/utils/archive/functions.go
@@ -2,10 +2,13 @@ package archive
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
 // Finder アーカイブ検索インターフェース
@@ -29,4 +32,112 @@ func FindByOSType(ctx context.Context, api Finder, zone string, os ostype.Archiv
 		return nil, fmt.Errorf("archive not found with ostype.ArchiveOSType: %v", os)
 	}
 	return searched.Archives[0], nil
+}
+
+// SourceInfoReader アーカイブソースを取得するためのインターフェース
+type SourceInfoReader struct {
+	ArchiveReader SourceArchiveReader
+	DiskReader    SourceDiskReader
+}
+
+// SourceArchiveReader アーカイブ参照インターフェース
+type SourceArchiveReader interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Archive, error)
+}
+
+// SourceDiskReader ディスク参照インターフェース
+type SourceDiskReader interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Disk, error)
+}
+
+var (
+	// allowDiskEditTags ディスクの編集可否判定に用いるタグ
+	allowDiskEditTags = []string{
+		"os-unix",
+		"os-linux",
+	}
+
+	// bundleInfoWindowsHostClass ディスクの編集可否判定に用いる、BundleInfoでのWindows判定文字列
+	bundleInfoWindowsHostClass = "ms_windows"
+)
+
+func isSophosUTM(archive *sacloud.Archive) bool {
+	// SophosUTMであれば編集不可
+	if archive.BundleInfo != nil && strings.Contains(strings.ToLower(archive.BundleInfo.ServiceClass), "sophosutm") {
+		return true
+	}
+	return false
+}
+
+// CanEditDisk ディスクの修正が可能か判定
+func CanEditDisk(ctx context.Context, zone string, reader *SourceInfoReader, id types.ID) (bool, error) {
+
+	disk, err := reader.DiskReader.Read(ctx, zone, id)
+	if err != nil {
+		if !sacloud.IsNotFoundError(err) {
+			return false, err
+		}
+	}
+	if disk != nil {
+		// 無限ルール予防
+		if disk.ID == disk.SourceDiskID || disk.ID == disk.SourceArchiveID {
+			return false, errors.New("invalid state: disk has invalid ID or SourceDiskID or SourceArchiveID")
+		}
+
+		if disk.SourceDiskID.IsEmpty() && disk.SourceArchiveID.IsEmpty() {
+			return false, nil
+		}
+		if !disk.SourceDiskID.IsEmpty() {
+			return CanEditDisk(ctx, zone, reader, disk.SourceDiskID)
+		}
+		if !disk.SourceArchiveID.IsEmpty() {
+			id = disk.SourceArchiveID
+		}
+	}
+
+	archive, err := reader.ArchiveReader.Read(ctx, zone, id)
+	if err != nil {
+		return false, err
+	}
+
+	// 無限ルール予防
+	if archive.ID == archive.SourceDiskID || archive.ID == archive.SourceArchiveID {
+		return false, errors.New("invalid state: archive has invalid ID or SourceDiskID or SourceArchiveID")
+	}
+
+	// BundleInfoがあれば編集不可
+	if archive.BundleInfo != nil && archive.BundleInfo.HostClass == bundleInfoWindowsHostClass {
+		// Windows
+		return false, nil
+	}
+
+	// SophosUTMであれば編集不可
+	if archive.HasTag("pkg-sophosutm") || isSophosUTM(archive) {
+		return false, nil
+	}
+	// OPNsenseであれば編集不可
+	if archive.HasTag("distro-opnsense") {
+		return false, nil
+	}
+	// Netwiser VEであれば編集不可
+	if archive.HasTag("pkg-netwiserve") {
+		return false, nil
+	}
+
+	for _, t := range allowDiskEditTags {
+		if archive.HasTag(t) {
+			// 対応OSインストール済みディスク
+			return true, nil
+		}
+	}
+
+	// ここまできても判定できないならソースに投げる
+	if !archive.SourceDiskID.IsEmpty() && archive.SourceDiskAvailability != types.Availabilities.Discontinued {
+		return CanEditDisk(ctx, zone, reader, archive.SourceDiskID)
+	}
+	if !archive.SourceArchiveID.IsEmpty() && archive.SourceArchiveAvailability != types.Availabilities.Discontinued {
+		return CanEditDisk(ctx, zone, reader, archive.SourceArchiveID)
+	}
+	return false, nil
+
 }

--- a/utils/archive/functions_test.go
+++ b/utils/archive/functions_test.go
@@ -3,11 +3,13 @@ package archive
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -100,4 +102,227 @@ func TestAccFindByOSType(t *testing.T) {
 			t.Logf("zone: %s ostype[%s] => {ID: %d, Name: %s}", zone, os, archive.ID, archive.Name)
 		}
 	}
+}
+
+type dummyArchiveReader struct {
+	archives []*sacloud.Archive
+	err      error
+}
+
+func (r *dummyArchiveReader) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Archive, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	for _, a := range r.archives {
+		if a.ID == id {
+			return a, nil
+		}
+	}
+	return nil, sacloud.NewAPIError(http.MethodGet, nil, "", http.StatusNotFound, nil)
+}
+
+type dummyDiskReader struct {
+	disks []*sacloud.Disk
+	err   error
+}
+
+func (r *dummyDiskReader) Read(ctx context.Context, zone string, id types.ID) (*sacloud.Disk, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	for _, d := range r.disks {
+		if d.ID == id {
+			return d, nil
+		}
+	}
+	return nil, sacloud.NewAPIError(http.MethodGet, nil, "", http.StatusNotFound, nil)
+}
+
+func TestCanEditDisk(t *testing.T) {
+
+	cases := []struct {
+		msg            string
+		id             types.ID
+		readers        *SourceInfoReader
+		expectedResult bool
+		expectedErr    error
+	}{
+		{
+			msg: "disk reader returns unexpected error",
+			id:  1,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{},
+				DiskReader: &dummyDiskReader{
+					err: errors.New("dummy"),
+				},
+			},
+			expectedErr: errors.New("dummy"),
+		},
+		{
+			msg: "from empty disk",
+			id:  2,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{},
+				DiskReader: &dummyDiskReader{
+					disks: []*sacloud.Disk{
+						{ID: 2},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			msg: "disk copied from disk",
+			id:  2,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{
+					archives: []*sacloud.Archive{
+						{
+							ID:   1,
+							Tags: types.Tags{"os-linux"},
+						},
+					},
+				},
+				DiskReader: &dummyDiskReader{
+					disks: []*sacloud.Disk{
+						{ID: 2, SourceDiskID: 3},
+						{ID: 3, SourceArchiveID: 1},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			msg: "archive reader returns error",
+			id:  1,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{
+					err: errors.New("dummy"),
+				},
+				DiskReader: &dummyDiskReader{},
+			},
+			expectedErr: errors.New("dummy"),
+		},
+		{
+			msg: "archive with bundle info",
+			id:  1,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{
+					archives: []*sacloud.Archive{
+						{
+							ID: 1,
+							BundleInfo: &sacloud.BundleInfo{
+								HostClass: bundleInfoWindowsHostClass,
+							},
+							Tags: types.Tags{"os-linux"},
+						},
+					},
+				},
+				DiskReader: &dummyDiskReader{},
+			},
+			expectedResult: false,
+		},
+		{
+			msg: "sophos UTM: service class",
+			id:  1,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{
+					archives: []*sacloud.Archive{
+						{
+							ID: 1,
+							BundleInfo: &sacloud.BundleInfo{
+								ServiceClass: "hoge/dummy/sophosutm",
+							},
+							Tags: types.Tags{"os-linux"},
+						},
+					},
+				},
+				DiskReader: &dummyDiskReader{},
+			},
+			expectedResult: false,
+		},
+		{
+			msg: "sophos UTM: tag",
+			id:  1,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{
+					archives: []*sacloud.Archive{
+						{
+							ID:   1,
+							Tags: types.Tags{"pkg-sophosutm"},
+						},
+					},
+				},
+				DiskReader: &dummyDiskReader{},
+			},
+			expectedResult: false,
+		},
+		{
+			msg: "OPNsense",
+			id:  1,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{
+					archives: []*sacloud.Archive{
+						{
+							ID:   1,
+							Tags: types.Tags{"distro-opnsense"},
+						},
+					},
+				},
+				DiskReader: &dummyDiskReader{},
+			},
+			expectedResult: false,
+		},
+		{
+			msg: "Netwiser VE",
+			id:  1,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{
+					archives: []*sacloud.Archive{
+						{
+							ID:   1,
+							Tags: types.Tags{"distro-netwiserve"},
+						},
+					},
+				},
+				DiskReader: &dummyDiskReader{},
+			},
+			expectedResult: false,
+		},
+		{
+			msg: "Nested",
+			id:  4,
+			readers: &SourceInfoReader{
+				ArchiveReader: &dummyArchiveReader{
+					archives: []*sacloud.Archive{
+						{
+							ID:   1,
+							Tags: types.Tags{"os-unix"},
+						},
+						{ID: 2, SourceDiskID: 5},
+						{ID: 3, SourceArchiveID: 1},
+					},
+				},
+				DiskReader: &dummyDiskReader{
+					disks: []*sacloud.Disk{
+						{ID: 4, SourceArchiveID: 2},
+						{ID: 5, SourceDiskID: 6},
+						{ID: 6, SourceArchiveID: 3},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range cases {
+		res, err := CanEditDisk(context.Background(), "tk1v", tc.readers, tc.id)
+		if tc.expectedErr != nil {
+			require.Equal(t, tc.expectedErr, err, tc.msg)
+		} else {
+			require.NoError(t, err, tc.msg)
+		}
+		require.Equal(t, tc.expectedResult, res, tc.msg)
+	}
+
 }


### PR DESCRIPTION
v1からfunc `CanEditDisk`を移行する。

- これまでは起点がアーカイブ/ディスクかでfuncを分けていたが統一する
- ArchiveOpではなく`util/archive`配下に置く