### PR TITLE
プランIDなどの定数定義の追加

### DIFF
--- a/sacloud/fake/functions.go
+++ b/sacloud/fake/functions.go
@@ -128,9 +128,9 @@ func fillDiskPlan(target interface{}) {
 	if v, ok := target.(accessor.DiskPlan); ok {
 		id := v.GetDiskPlanID()
 		switch id {
-		case types.ID(2):
+		case types.DiskPlans.HDD:
 			v.SetDiskPlanName("標準プラン")
-		case types.ID(4):
+		case types.DiskPlans.SSD:
 			v.SetDiskPlanName("SSDプラン")
 		}
 		v.SetDiskPlanStorageClass("iscsi9999")

--- a/sacloud/fake/initial_values.go
+++ b/sacloud/fake/initial_values.go
@@ -32,14 +32,9 @@ var authStatus = &sacloud.AuthStatus{
 	Permission:         types.Permissions.Create,
 }
 
-var zones = []string{"tk1a", "is1a", "is1b", "tk1v"}
+var zones = types.ZoneNames
 
-var zoneIDs = map[string]types.ID{
-	"tk1a": types.ID(21001),
-	"is1a": types.ID(31001),
-	"is1b": types.ID(31002),
-	"tk1v": types.ID(29001),
-}
+var zoneIDs = types.ZoneIDs
 
 var sharedSegmentSwitch = &sacloud.Switch{
 	ID:             pool.generateID(),
@@ -77,7 +72,7 @@ func initArchives() {
 			Scope:                types.Scopes.Shared,
 			Availability:         types.Availabilities.Available,
 			SizeMB:               20480,
-			DiskPlanID:           types.ID(2),
+			DiskPlanID:           types.DiskPlans.HDD,
 			DiskPlanName:         "標準プラン",
 			DiskPlanStorageClass: "iscsi9999",
 		},
@@ -89,7 +84,7 @@ func initArchives() {
 			Scope:                types.Scopes.Shared,
 			Availability:         types.Availabilities.Available,
 			SizeMB:               20480,
-			DiskPlanID:           types.ID(2),
+			DiskPlanID:           types.DiskPlans.HDD,
 			DiskPlanName:         "標準プラン",
 			DiskPlanStorageClass: "iscsi9999",
 		},
@@ -302,7 +297,7 @@ func initServerPlan() {
 }
 
 func initInternetPlan() {
-	bandWidthList := []int{100, 250500, 1000, 1500, 2000, 2500, 3000, 5000}
+	bandWidthList := []int{100, 250, 500, 1000, 1500, 2000, 2500, 3000, 5000}
 
 	var plans []*sacloud.InternetPlan
 

--- a/sacloud/fake/ops_archive.go
+++ b/sacloud/fake/ops_archive.go
@@ -50,7 +50,7 @@ func (o *ArchiveOp) Create(ctx context.Context, zone string, param *sacloud.Arch
 
 	result.DisplayOrder = int64(random(100))
 	result.Availability = types.Availabilities.Migrating
-	result.DiskPlanID = types.ID(2)
+	result.DiskPlanID = types.DiskPlans.HDD
 	result.DiskPlanName = "標準プラン"
 	result.DiskPlanStorageClass = "iscsi9999"
 

--- a/sacloud/test/archive_op_test.go
+++ b/sacloud/test/archive_op_test.go
@@ -107,7 +107,7 @@ var (
 		Description: createArchiveParam.Description,
 		Tags:        createArchiveParam.Tags,
 		Scope:       types.Scopes.User,
-		DiskPlanID:  types.ID(2),
+		DiskPlanID:  types.DiskPlans.HDD,
 	}
 	updateArchiveParam = &sacloud.ArchiveUpdateRequest{
 		Name:        "libsacloud-archive-upd",
@@ -120,7 +120,7 @@ var (
 		Description: updateArchiveParam.Description,
 		Tags:        updateArchiveParam.Tags,
 		Scope:       types.Scopes.User,
-		DiskPlanID:  types.ID(2),
+		DiskPlanID:  types.DiskPlans.HDD,
 		IconID:      updateArchiveParam.IconID,
 	}
 	updateArchiveToMinParam = &sacloud.ArchiveUpdateRequest{
@@ -131,7 +131,7 @@ var (
 		Name:        updateArchiveToMinParam.Name,
 		Description: updateArchiveToMinParam.Description,
 		Scope:       types.Scopes.User,
-		DiskPlanID:  types.ID(2),
+		DiskPlanID:  types.DiskPlans.HDD,
 	}
 )
 

--- a/sacloud/test/auto_backup_op_test.go
+++ b/sacloud/test/auto_backup_op_test.go
@@ -19,7 +19,7 @@ func TestAutoBackupOpCRUD(t *testing.T) {
 			disk, err := diskOp.Create(ctx, testZone, &sacloud.DiskCreateRequest{
 				Name:       "libsacloud-disk-with-autobackup",
 				SizeMB:     20 * 1024,
-				DiskPlanID: types.ID(4), //SSD
+				DiskPlanID: types.DiskPlans.SSD,
 			}, nil)
 			if !assert.NoError(t, err) {
 				return err

--- a/sacloud/test/database_op_test.go
+++ b/sacloud/test/database_op_test.go
@@ -87,7 +87,7 @@ var (
 	}
 
 	createDatabaseParam = &sacloud.DatabaseCreateRequest{
-		PlanID:         types.ID(10),
+		PlanID:         types.DatabasePlans.DB10GB,
 		IPAddresses:    []string{"192.168.0.11"},
 		NetworkMaskLen: 24,
 		DefaultRoute:   "192.168.0.1",

--- a/sacloud/test/disk_op_test.go
+++ b/sacloud/test/disk_op_test.go
@@ -76,7 +76,7 @@ var (
 	}
 
 	createDiskParam = &sacloud.DiskCreateRequest{
-		DiskPlanID:  types.ID(4), //SSD
+		DiskPlanID:  types.DiskPlans.SSD,
 		Connection:  types.DiskConnections.VirtIO,
 		Name:        "libsacloud-disk",
 		Description: "desc",
@@ -168,7 +168,7 @@ func TestDiskOp_Config(t *testing.T) {
 				client := sacloud.NewDiskOp(singletonAPICaller())
 				disk, err := client.Create(ctx, testZone, &sacloud.DiskCreateRequest{
 					Name:            "libsacloud-disk-edit",
-					DiskPlanID:      types.ID(4),
+					DiskPlanID:      types.DiskPlans.SSD,
 					SizeMB:          20 * 1024,
 					SourceArchiveID: archiveID,
 				}, nil)

--- a/sacloud/test/load_balancer_op_test.go
+++ b/sacloud/test/load_balancer_op_test.go
@@ -90,7 +90,7 @@ var (
 	}
 
 	createLoadBalancerParam = &sacloud.LoadBalancerCreateRequest{
-		PlanID:         types.ID(2),
+		PlanID:         types.LoadBalancerPlans.Premium,
 		VRID:           100,
 		IPAddresses:    []string{"192.168.0.11", "192.168.0.12"},
 		NetworkMaskLen: 24,

--- a/sacloud/test/nfs_op_test.go
+++ b/sacloud/test/nfs_op_test.go
@@ -81,7 +81,7 @@ var (
 		"ModifiedAt",
 	}
 	createNFSParam = &sacloud.NFSCreateRequest{
-		PlanID:         types.ID(1001012001),
+		PlanID:         types.ID(1001012001), // TODO プラン検索をutilsに実装後に修正
 		IPAddresses:    []string{"192.168.0.11"},
 		NetworkMaskLen: 24,
 		DefaultRoute:   "192.168.0.1",

--- a/sacloud/test/vpc_router_op_test.go
+++ b/sacloud/test/vpc_router_op_test.go
@@ -68,7 +68,7 @@ var (
 	}
 
 	createVPCRouterParam = &sacloud.VPCRouterCreateRequest{
-		PlanID: types.ID(1), // standard  TODO プランIDをどこかで定義する
+		PlanID: types.VPCRouterPlans.Standard,
 		Switch: &sacloud.ApplianceConnectedSwitch{
 			Scope: types.Scopes.Shared,
 		},
@@ -392,7 +392,7 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 
 var (
 	withRouterCreateVPCRouterParam = &sacloud.VPCRouterCreateRequest{
-		PlanID:      types.ID(1), // standard  TODO プランIDをどこかで定義する
+		PlanID:      types.VPCRouterPlans.Standard,
 		Name:        "libsacloud-vpc-router",
 		Description: "desc",
 		Tags:        []string{"tag1", "tag2"},

--- a/sacloud/types/database_plan.go
+++ b/sacloud/types/database_plan.go
@@ -1,0 +1,29 @@
+package types
+
+// DatabasePlans データベースプラン
+var DatabasePlans = struct {
+	// DB10GB 10GB
+	DB10GB ID
+	// DB30GB 30GB
+	DB30GB ID
+	// DB90GB 90GB
+	DB90GB ID
+	// DB240GB 240GB
+	DB240GB ID
+	// DB500GB 500GB
+	DB500GB ID
+	// DB1TB 1TB
+	DB1TB ID
+}{
+	DB10GB:  ID(10),
+	DB30GB:  ID(30),
+	DB90GB:  ID(90),
+	DB240GB: ID(240),
+	DB500GB: ID(500),
+	DB1TB:   ID(1000),
+}
+
+// SlaveDatabasePlanID マスター側のプランIDからスレーブのプランIDを算出
+func SlaveDatabasePlanID(masterPlanID ID) ID {
+	return ID(int64(masterPlanID) + 1)
+}

--- a/sacloud/types/disk_plan.go
+++ b/sacloud/types/disk_plan.go
@@ -1,0 +1,12 @@
+package types
+
+// DiskPlans ディスクプランID 利用可能なサイズはDiskPlanAPIで取得すること
+var DiskPlans = struct {
+	// SSD ssdプラン
+	SSD ID
+	// HDD hddプラン
+	HDD ID
+}{
+	SSD: ID(4),
+	HDD: ID(2),
+}

--- a/sacloud/types/load_balancer_plan.go
+++ b/sacloud/types/load_balancer_plan.go
@@ -1,0 +1,12 @@
+package types
+
+// LoadBalancerPlans ロードバランサーのプラン
+var LoadBalancerPlans = struct {
+	// Standard スタンダード
+	Standard ID
+	// Premium プレミアム
+	Premium ID
+}{
+	Standard: ID(1),
+	Premium:  ID(2),
+}

--- a/sacloud/types/nfs_plan.go
+++ b/sacloud/types/nfs_plan.go
@@ -1,0 +1,15 @@
+package types
+
+// NFSPlans NFSプラン
+//
+// Note: NFS作成時のPlanIDはこの値+サイズでNFSプランを検索、そのIDを指定すること
+// NFSプランの検索はutils/nfsのfunc FindPlan(plan types.ID, size int64)を利用する
+var NFSPlans = struct {
+	// HDD hddプラン
+	HDD ID
+	// SSD ssdプラン
+	SSD ID
+}{
+	HDD: ID(1),
+	SSD: ID(2),
+}

--- a/sacloud/types/vpc_router_plan.go
+++ b/sacloud/types/vpc_router_plan.go
@@ -1,0 +1,15 @@
+package types
+
+// VPCRouterPlans VPCルータのプラン
+var VPCRouterPlans = struct {
+	// Standard スタンダードプラン シングル構成/最大スループット 80Mbps/一部機能は利用不可
+	Standard ID
+	// Premium プレミアムプラン 冗長構成/最大スループット400Mbps
+	Premium ID
+	// HighSpec ハイスペックプラン 冗長構成/最大スループット1,200Mbps
+	HighSpec ID
+}{
+	Standard: ID(1),
+	Premium:  ID(2),
+	HighSpec: ID(3),
+}

--- a/sacloud/types/zone.go
+++ b/sacloud/types/zone.go
@@ -1,0 +1,23 @@
+package types
+
+const (
+	// ZoneTk1aID 東京第1ゾーン
+	ZoneTk1aID = ID(21001)
+	// ZoneIs1aID 石狩第1ゾーン
+	ZoneIs1aID = ID(31001)
+	// ZoneIs1bID 石狩第1ゾーン
+	ZoneIs1bID = ID(31002)
+	// ZoneTk1vID サンドボックスゾーン
+	ZoneTk1vID = ID(29001)
+)
+
+// ZoneNames 利用できるゾーンの一覧
+var ZoneNames = []string{"tk1a", "is1a", "is1b", "tk1v"}
+
+// ZoneIDs ゾーンIDと名称のマップ
+var ZoneIDs = map[string]ID{
+	"tk1a": ZoneTk1aID,
+	"is1a": ZoneIs1aID,
+	"is1b": ZoneIs1bID,
+	"tk1v": ZoneTk1vID,
+}


### PR DESCRIPTION
プランIDなど向けの定数を`sacloud/types`配下に定義する。