### PR TITLE
帯域幅の算出

### DIFF
--- a/internal/define/models.go
+++ b/internal/define/models.go
@@ -4,6 +4,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/internal/dsl"
 	"github.com/sacloud/libsacloud/v2/internal/dsl/meta"
 	"github.com/sacloud/libsacloud/v2/sacloud/naked"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
 type modelsDef struct{}
@@ -304,6 +305,10 @@ func (m *modelsDef) interfaceModel() *dsl.Model {
 				Tags: &dsl.FieldTags{
 					MapConv: "PacketFilter.RequiredHostVersionn",
 				},
+			},
+			{
+				Name: "UpstreamType",
+				Type: meta.Static(types.EUpstreamNetworkType("")),
 			},
 		},
 	}

--- a/sacloud/customize_model.go
+++ b/sacloud/customize_model.go
@@ -1,0 +1,48 @@
+package sacloud
+
+import "github.com/sacloud/libsacloud/v2/sacloud/types"
+
+// BandWidthAt 指定インデックスのNICの帯域幅を算出
+//
+// 不明な場合は-1を、制限なしの場合は0を、以外の場合はMbps単位で返す
+func (s *Server) BandWidthAt(index int) int {
+	if len(s.Interfaces) <= index {
+		return -1
+	}
+
+	nic := s.Interfaces[index]
+
+	switch nic.UpstreamType {
+	case types.UpstreamNetworkTypes.None:
+		return -1
+	case types.UpstreamNetworkTypes.Shared:
+		return 100
+	case types.UpstreamNetworkTypes.Switch, types.UpstreamNetworkTypes.Router:
+		//
+		// 上流ネットワークがスイッチだった場合の帯域制限
+		// https://manual.sakura.ad.jp/cloud/support/technical/network.html#support-network-03
+		//
+
+		// 専有ホストの場合は制限なし
+		if !s.PrivateHostID.IsEmpty() {
+			return 0
+		}
+
+		// メモリに応じた制限
+		memory := s.GetMemoryGB()
+		switch {
+		case memory < 32:
+			return 1000
+		case 32 <= memory && memory < 128:
+			return 2000
+		case 128 <= memory && memory < 224:
+			return 5000
+		case 224 <= memory:
+			return 10000
+		default:
+			return -1
+		}
+	default:
+		return -1
+	}
+}

--- a/sacloud/customize_model_test.go
+++ b/sacloud/customize_model_test.go
@@ -1,0 +1,147 @@
+package sacloud
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer_BandWidthAt(t *testing.T) {
+	cases := []struct {
+		msg    string
+		in     *Server
+		index  int
+		expect int
+	}{
+		{
+			msg:    "no NICs",
+			in:     &Server{},
+			expect: -1,
+		},
+		{
+			msg: "invalid NIC index",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Unknown,
+					},
+				},
+			},
+			index:  1,
+			expect: -1,
+		},
+		{
+			msg: "unknown upstream type",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Unknown,
+					},
+				},
+			},
+			expect: -1,
+		},
+		{
+			msg: "shared",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Shared,
+					},
+				},
+			},
+			expect: 100,
+		},
+		{
+			msg: "switch with private host",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Switch,
+					},
+				},
+				PrivateHostID: 1,
+			},
+			expect: 0,
+		},
+		{
+			msg: "memory less than 32GB",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Switch,
+					},
+				},
+				MemoryMB: 31 * 1024,
+			},
+			expect: 1000,
+		},
+		{
+			msg: "switch with memory 32GB",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Switch,
+					},
+				},
+				MemoryMB: 32 * 1024,
+			},
+			expect: 2000,
+		},
+		{
+			msg: "memory less than 128GB",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Switch,
+					},
+				},
+				MemoryMB: 127 * 1024,
+			},
+			expect: 2000,
+		},
+		{
+			msg: "switch with memory 128GB",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Switch,
+					},
+				},
+				MemoryMB: 128 * 1024,
+			},
+			expect: 5000,
+		},
+		{
+			msg: "memory less than 224GB",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Switch,
+					},
+				},
+				MemoryMB: 223 * 1024,
+			},
+			expect: 5000,
+		},
+		{
+			msg: "switch with memory 224GB",
+			in: &Server{
+				Interfaces: []*InterfaceView{
+					{
+						UpstreamType: types.UpstreamNetworkTypes.Switch,
+					},
+				},
+				MemoryMB: 224 * 1024,
+			},
+			expect: 10000,
+		},
+	}
+
+	for _, tc := range cases {
+		actual := tc.in.BandWidthAt(tc.index)
+		require.Equal(t, tc.expect, actual, tc.msg)
+	}
+
+}

--- a/sacloud/naked/interface_test.go
+++ b/sacloud/naked/interface_test.go
@@ -1,0 +1,42 @@
+package naked
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInterface_UnmarshalJSON(t *testing.T) {
+
+	cases := []struct {
+		in  string
+		out types.EUpstreamNetworkType
+	}{
+		{
+			in:  `{}`,
+			out: types.UpstreamNetworkTypes.None,
+		},
+		{
+			in:  `{"Switch":{}}`,
+			out: types.UpstreamNetworkTypes.Switch,
+		},
+		{
+			in:  `{"Switch":{"Scope":"shared","Subnet":{}}}`,
+			out: types.UpstreamNetworkTypes.Shared,
+		},
+		{
+			in:  `{"Switch":{"Scope":"user","Subnet":{}}}`,
+			out: types.UpstreamNetworkTypes.Router,
+		},
+	}
+
+	for _, tc := range cases {
+		var iface Interface
+		err := json.Unmarshal([]byte(tc.in), &iface)
+		require.NoError(t, err)
+		require.Equal(t, tc.out.String(), iface.UpstreamType.String())
+	}
+
+}

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -3982,6 +3982,7 @@ type InterfaceView struct {
 	PacketFilterID                  string             `mapconv:"PacketFilter.ID"`
 	PacketFilterName                string             `mapconv:"PacketFilter.Name"`
 	PacketFilterRequiredHostVersion types.StringNumber `mapconv:"PacketFilter.RequiredHostVersionn"`
+	UpstreamType                    types.EUpstreamNetworkType
 }
 
 // Validate validates by field tags
@@ -4009,6 +4010,7 @@ func (o *InterfaceView) setDefaults() interface{} {
 		PacketFilterID                  string             `mapconv:"PacketFilter.ID"`
 		PacketFilterName                string             `mapconv:"PacketFilter.Name"`
 		PacketFilterRequiredHostVersion types.StringNumber `mapconv:"PacketFilter.RequiredHostVersionn"`
+		UpstreamType                    types.EUpstreamNetworkType
 	}{
 		ID:                              o.ID,
 		MACAddress:                      o.MACAddress,
@@ -4027,6 +4029,7 @@ func (o *InterfaceView) setDefaults() interface{} {
 		PacketFilterID:                  o.PacketFilterID,
 		PacketFilterName:                o.PacketFilterName,
 		PacketFilterRequiredHostVersion: o.PacketFilterRequiredHostVersion,
+		UpstreamType:                    o.UpstreamType,
 	}
 }
 
@@ -4218,6 +4221,16 @@ func (o *InterfaceView) GetPacketFilterRequiredHostVersion() types.StringNumber 
 // SetPacketFilterRequiredHostVersion sets value to PacketFilterRequiredHostVersion
 func (o *InterfaceView) SetPacketFilterRequiredHostVersion(v types.StringNumber) {
 	o.PacketFilterRequiredHostVersion = v
+}
+
+// GetUpstreamType returns value of UpstreamType
+func (o *InterfaceView) GetUpstreamType() types.EUpstreamNetworkType {
+	return o.UpstreamType
+}
+
+// SetUpstreamType sets value to UpstreamType
+func (o *InterfaceView) SetUpstreamType(v types.EUpstreamNetworkType) {
+	o.UpstreamType = v
 }
 
 /*************************************************
@@ -11573,7 +11586,8 @@ type MobileGatewayInterface struct {
 	PacketFilterID                  string             `mapconv:"PacketFilter.ID"`
 	PacketFilterName                string             `mapconv:"PacketFilter.Name"`
 	PacketFilterRequiredHostVersion types.StringNumber `mapconv:"PacketFilter.RequiredHostVersionn"`
-	Index                           int                `mapconv:",omitempty"`
+	UpstreamType                    types.EUpstreamNetworkType
+	Index                           int `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -11601,7 +11615,8 @@ func (o *MobileGatewayInterface) setDefaults() interface{} {
 		PacketFilterID                  string             `mapconv:"PacketFilter.ID"`
 		PacketFilterName                string             `mapconv:"PacketFilter.Name"`
 		PacketFilterRequiredHostVersion types.StringNumber `mapconv:"PacketFilter.RequiredHostVersionn"`
-		Index                           int                `mapconv:",omitempty"`
+		UpstreamType                    types.EUpstreamNetworkType
+		Index                           int `mapconv:",omitempty"`
 	}{
 		ID:                              o.ID,
 		MACAddress:                      o.MACAddress,
@@ -11620,6 +11635,7 @@ func (o *MobileGatewayInterface) setDefaults() interface{} {
 		PacketFilterID:                  o.PacketFilterID,
 		PacketFilterName:                o.PacketFilterName,
 		PacketFilterRequiredHostVersion: o.PacketFilterRequiredHostVersion,
+		UpstreamType:                    o.UpstreamType,
 		Index:                           o.Index,
 	}
 }
@@ -11812,6 +11828,16 @@ func (o *MobileGatewayInterface) GetPacketFilterRequiredHostVersion() types.Stri
 // SetPacketFilterRequiredHostVersion sets value to PacketFilterRequiredHostVersion
 func (o *MobileGatewayInterface) SetPacketFilterRequiredHostVersion(v types.StringNumber) {
 	o.PacketFilterRequiredHostVersion = v
+}
+
+// GetUpstreamType returns value of UpstreamType
+func (o *MobileGatewayInterface) GetUpstreamType() types.EUpstreamNetworkType {
+	return o.UpstreamType
+}
+
+// SetUpstreamType sets value to UpstreamType
+func (o *MobileGatewayInterface) SetUpstreamType(v types.EUpstreamNetworkType) {
+	o.UpstreamType = v
 }
 
 // GetIndex returns value of Index
@@ -22242,7 +22268,8 @@ type VPCRouterInterface struct {
 	PacketFilterID                  string             `mapconv:"PacketFilter.ID"`
 	PacketFilterName                string             `mapconv:"PacketFilter.Name"`
 	PacketFilterRequiredHostVersion types.StringNumber `mapconv:"PacketFilter.RequiredHostVersionn"`
-	Index                           int                `mapconv:",omitempty"`
+	UpstreamType                    types.EUpstreamNetworkType
+	Index                           int `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -22270,7 +22297,8 @@ func (o *VPCRouterInterface) setDefaults() interface{} {
 		PacketFilterID                  string             `mapconv:"PacketFilter.ID"`
 		PacketFilterName                string             `mapconv:"PacketFilter.Name"`
 		PacketFilterRequiredHostVersion types.StringNumber `mapconv:"PacketFilter.RequiredHostVersionn"`
-		Index                           int                `mapconv:",omitempty"`
+		UpstreamType                    types.EUpstreamNetworkType
+		Index                           int `mapconv:",omitempty"`
 	}{
 		ID:                              o.ID,
 		MACAddress:                      o.MACAddress,
@@ -22289,6 +22317,7 @@ func (o *VPCRouterInterface) setDefaults() interface{} {
 		PacketFilterID:                  o.PacketFilterID,
 		PacketFilterName:                o.PacketFilterName,
 		PacketFilterRequiredHostVersion: o.PacketFilterRequiredHostVersion,
+		UpstreamType:                    o.UpstreamType,
 		Index:                           o.Index,
 	}
 }
@@ -22481,6 +22510,16 @@ func (o *VPCRouterInterface) GetPacketFilterRequiredHostVersion() types.StringNu
 // SetPacketFilterRequiredHostVersion sets value to PacketFilterRequiredHostVersion
 func (o *VPCRouterInterface) SetPacketFilterRequiredHostVersion(v types.StringNumber) {
 	o.PacketFilterRequiredHostVersion = v
+}
+
+// GetUpstreamType returns value of UpstreamType
+func (o *VPCRouterInterface) GetUpstreamType() types.EUpstreamNetworkType {
+	return o.UpstreamType
+}
+
+// SetUpstreamType sets value to UpstreamType
+func (o *VPCRouterInterface) SetUpstreamType(v types.EUpstreamNetworkType) {
+	o.UpstreamType = v
 }
 
 // GetIndex returns value of Index


### PR DESCRIPTION
(fix #292)

サーバの接続ネットワークやスペックなどからNICごとの帯域幅を算出する。

Note: 当初は`sacloud/accessor`を用いてDSLでfuncの定義を行いたかったが、 #293 により断念。
現状この処理は他のモデルで利用することがないため、コード生成されるsacloudパッケージ配下のモデルに対し手動でfuncを定義している。今後類似のfuncが必要になった際に #293 の対応を含めて実装方法を再検討する。