### PR TITLE
unit test時のsetupパッケージの待ち時間を短縮

### DIFF
--- a/utils/setup/retryable_setup_test.go
+++ b/utils/setup/retryable_setup_test.go
@@ -50,6 +50,9 @@ func TestRetryableSetup_Setup(t *testing.T) {
 				Read: func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
 					return &dummyIDAccessor{id: 1}, nil
 				},
+				ProvisioningRetryInterval: time.Millisecond,
+				DeleteRetryInterval:       time.Millisecond,
+				PollInterval:              time.Millisecond,
 			}
 			res, err := retryable.Setup(ctx, zone)
 
@@ -67,6 +70,9 @@ func TestRetryableSetup_Setup(t *testing.T) {
 				Read: func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
 					return &dummyIDAccessor{id: 1}, nil
 				},
+				ProvisioningRetryInterval: time.Millisecond,
+				DeleteRetryInterval:       time.Millisecond,
+				PollInterval:              time.Millisecond,
 			}
 			res, err := retryable.Setup(ctx, zone)
 
@@ -75,7 +81,7 @@ func TestRetryableSetup_Setup(t *testing.T) {
 		})
 
 	})
-
+	//
 	t.Run("Retry", func(t *testing.T) {
 
 		t.Run("retry under max count", func(t *testing.T) {

--- a/utils/setup/setup_test.go
+++ b/utils/setup/setup_test.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/accessor"
@@ -56,6 +57,11 @@ func TestRetryableSetup(t *testing.T) {
 					IsWaitForCopy: true,
 					IsWaitForUp:   true,
 					RetryCount:    3,
+				}
+				if !testutil.IsAccTest() {
+					nfsSetup.ProvisioningRetryInterval = time.Millisecond
+					nfsSetup.DeleteRetryInterval = time.Millisecond
+					nfsSetup.PollInterval = time.Millisecond
 				}
 
 				return nfsSetup.Setup(ctx, testZone)


### PR DESCRIPTION
デフォルト状態だと10秒(5秒待ちが2回)発生するため、unit test時のみ待ち時間を短くする。