### PR TITLE
utils/nfs: GetPlanInfo

### DIFF
--- a/utils/nfs/find_plan.go
+++ b/utils/nfs/find_plan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/search"
@@ -17,7 +18,7 @@ type NoteFinder interface {
 }
 
 type nfsPlansEnvelope struct {
-	Plans nfsPlans `json:"plans"`
+	Plans *nfsPlans `json:"plans"`
 }
 
 type nfsPlans struct {
@@ -25,7 +26,7 @@ type nfsPlans struct {
 	SSD []nfsPlanValue
 }
 
-func (p nfsPlans) findPlanID(diskPlanID types.ID, size types.ENFSSize) types.ID {
+func (p *nfsPlans) findPlanID(diskPlanID types.ID, size types.ENFSSize) types.ID {
 	var plans []nfsPlanValue
 	switch diskPlanID {
 	case types.NFSPlans.HDD:
@@ -45,6 +46,28 @@ func (p nfsPlans) findPlanID(diskPlanID types.ID, size types.ENFSSize) types.ID 
 	return types.ID(0)
 }
 
+func (p *nfsPlans) findByPlanID(planID types.ID) *PlanInfo {
+	for _, p := range p.HDD {
+		if p.PlanID == planID {
+			return &PlanInfo{
+				NFSPlanID:  planID,
+				DiskPlanID: types.NFSPlans.HDD,
+				Size:       types.ENFSSize(p.Size),
+			}
+		}
+	}
+	for _, p := range p.SSD {
+		if p.PlanID == planID {
+			return &PlanInfo{
+				NFSPlanID:  planID,
+				DiskPlanID: types.NFSPlans.SSD,
+				Size:       types.ENFSSize(p.Size),
+			}
+		}
+	}
+	return nil
+}
+
 type nfsPlanValue struct {
 	Size         int                 `json:"size"`
 	Availability types.EAvailability `json:"availability"`
@@ -53,7 +76,14 @@ type nfsPlanValue struct {
 
 // FindNFSPlanID ディスクプランとサイズからNFSのプランIDを取得
 func FindNFSPlanID(ctx context.Context, finder NoteFinder, diskPlanID types.ID, size types.ENFSSize) (types.ID, error) {
+	plans, err := findNFSPlans(ctx, finder)
+	if err != nil {
+		return types.ID(0), err
+	}
+	return plans.findPlanID(diskPlanID, size), nil
+}
 
+func findNFSPlans(ctx context.Context, finder NoteFinder) (*nfsPlans, error) {
 	// find note
 	searched, err := finder.Find(ctx, &sacloud.FindCondition{
 		Filter: search.Filter{
@@ -62,18 +92,37 @@ func FindNFSPlanID(ctx context.Context, finder NoteFinder, diskPlanID types.ID, 
 		},
 	})
 	if err != nil {
-		return types.ID(0), err
+		return nil, err
 	}
 	if searched.Count == 0 || len(searched.Notes) == 0 {
-		return types.ID(0), errors.New("note[sys-nfs] not found")
+		return nil, errors.New("note[sys-nfs] not found")
 	}
 	note := searched.Notes[0]
 
 	// parse note's content
 	var pe nfsPlansEnvelope
 	if err := json.Unmarshal([]byte(note.Content), &pe); err != nil {
-		return types.ID(0), err
+		return nil, err
 	}
+	return pe.Plans, nil
+}
 
-	return pe.Plans.findPlanID(diskPlanID, size), nil
+// PlanInfo NFSプランIDに対応するプラン情報
+type PlanInfo struct {
+	NFSPlanID  types.ID
+	Size       types.ENFSSize
+	DiskPlanID types.ID
+}
+
+// GetPlanInfo NFSプランIDから対応するプラン情報を取得
+func GetPlanInfo(ctx context.Context, finder NoteFinder, nfsPlanID types.ID) (*PlanInfo, error) {
+	plans, err := findNFSPlans(ctx, finder)
+	if err != nil {
+		return nil, err
+	}
+	info := plans.findByPlanID(nfsPlanID)
+	if info == nil {
+		return nil, fmt.Errorf("nfs plan [id:%d] not found", nfsPlanID)
+	}
+	return info, nil
 }


### PR DESCRIPTION
NFSアプライアンスはプランIDのみ保持しており、ディスクプラン(HDD/SSD)やサイズを得たい場合はプランIDから検索する必要がある。

NFSのプラン検索は`utils/nfs`パッケージに実装済みであるが、ディスクプランID+サイズからの検索のみでプランIDからの検索は未実装であったためこのPRにて実装する。