### PR TITLE
API/ProxyLB: MonitorConnection

### DIFF
--- a/internal/define/conditions.go
+++ b/internal/define/conditions.go
@@ -15,6 +15,7 @@ var monitorParameter = &dsl.Model{
 			Tags: &dsl.FieldTags{
 				JSON: ",omitempty",
 			},
+			DefaultValue: `time.Now().Truncate(time.Second).Add(-time.Hour)`,
 		},
 		{
 			Name: "End",
@@ -22,6 +23,7 @@ var monitorParameter = &dsl.Model{
 			Tags: &dsl.FieldTags{
 				JSON: ",omitempty",
 			},
+			DefaultValue: `time.Now().Truncate(time.Second)`,
 		},
 	},
 }

--- a/internal/define/proxylb.go
+++ b/internal/define/proxylb.go
@@ -131,6 +131,10 @@ var proxyLBAPI = &dsl.Resource{
 
 		// Health
 		ops.HealthStatus(proxyLBAPIName, meta.Static(naked.ProxyLBHealth{}), proxyLBHealth),
+
+		// Monitor
+		ops.MonitorChild(proxyLBAPIName, "Connection", "activity/proxylb",
+			monitorParameter, monitors.connectionModel()),
 	},
 }
 

--- a/internal/tools/gen-api-models/main.go
+++ b/internal/tools/gen-api-models/main.go
@@ -84,9 +84,15 @@ func (o *{{ $struct }}) {{ .Name }}({{ range .Arguments }}{{ .ArgName }} {{ .Typ
 // Get{{$name}} returns value of {{$name}} 
 func (o *{{ $struct }}) Get{{$name}}() {{$typeName}} {
 	{{ if .DefaultValue -}}
+	{{ if eq .Type.GoType "time.Time" -}}
+	if o.{{$name}}.IsZero() {
+		return {{.DefaultValue}}
+	}
+	{{ else -}}
 	if o.{{$name}} == {{.Type.ZeroInitializeSourceCode}}{
 		return {{.DefaultValue}}
 	}
+	{{ end -}}
 	{{ end -}}
 	return o.{{$name}}
 }

--- a/sacloud/fake/ops_proxy_lb.go
+++ b/sacloud/fake/ops_proxy_lb.go
@@ -188,3 +188,28 @@ func (o *ProxyLBOp) HealthStatus(ctx context.Context, id types.ID) (*sacloud.Pro
 
 	return s.getByID(ResourceProxyLB+"Status", sacloud.APIDefaultZone, id).(*sacloud.ProxyLBHealth), nil
 }
+
+// MonitorConnection is fake implementation
+func (o *ProxyLBOp) MonitorConnection(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.ConnectionActivity, error) {
+	_, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().Truncate(time.Second)
+	m := now.Minute() % 5
+	if m != 0 {
+		now.Add(time.Duration(m) * time.Minute)
+	}
+
+	res := &sacloud.ConnectionActivity{}
+	for i := 0; i < 5; i++ {
+		res.Values = append(res.Values, &sacloud.MonitorConnectionValue{
+			Time:              now.Add(time.Duration(i*-5) * time.Minute),
+			ConnectionsPerSec: float64(random(1000)),
+			ActiveConnections: float64(random(1000)),
+		})
+	}
+
+	return res, nil
+}

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -3102,6 +3102,12 @@ type ProxyLBHealthStatusStubResult struct {
 	Err           error
 }
 
+// ProxyLBMonitorConnectionStubResult is expected values of the MonitorConnection operation
+type ProxyLBMonitorConnectionStubResult struct {
+	ConnectionActivity *sacloud.ConnectionActivity
+	Err                error
+}
+
 // ProxyLBStub is for trace ProxyLBOp operations
 type ProxyLBStub struct {
 	FindStubResult                 *ProxyLBFindStubResult
@@ -3115,6 +3121,7 @@ type ProxyLBStub struct {
 	DeleteCertificatesStubResult   *ProxyLBDeleteCertificatesStubResult
 	RenewLetsEncryptCertStubResult *ProxyLBRenewLetsEncryptCertStubResult
 	HealthStatusStubResult         *ProxyLBHealthStatusStubResult
+	MonitorConnectionStubResult    *ProxyLBMonitorConnectionStubResult
 }
 
 // NewProxyLBStub creates new ProxyLBStub instance
@@ -3208,6 +3215,14 @@ func (s *ProxyLBStub) HealthStatus(ctx context.Context, id types.ID) (*sacloud.P
 		log.Fatal("ProxyLBStub.HealthStatusStubResult is not set")
 	}
 	return s.HealthStatusStubResult.ProxyLBHealth, s.HealthStatusStubResult.Err
+}
+
+// MonitorConnection is API call with trace log
+func (s *ProxyLBStub) MonitorConnection(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.ConnectionActivity, error) {
+	if s.MonitorConnectionStubResult == nil {
+		log.Fatal("ProxyLBStub.MonitorConnectionStubResult is not set")
+	}
+	return s.MonitorConnectionStubResult.ConnectionActivity, s.MonitorConnectionStubResult.Err
 }
 
 /*************************************************

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -6858,6 +6858,39 @@ func (t *ProxyLBTracer) HealthStatus(ctx context.Context, id types.ID) (*sacloud
 	return resultProxyLBHealth, err
 }
 
+// MonitorConnection is API call with trace log
+func (t *ProxyLBTracer) MonitorConnection(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.ConnectionActivity, error) {
+	log.Println("[TRACE] ProxyLBAPI.MonitorConnection start")
+	targetArguments := struct {
+		Argid        types.ID                  `json:"id"`
+		Argcondition *sacloud.MonitorCondition `json:"condition"`
+	}{
+		Argid:        id,
+		Argcondition: condition,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ProxyLBAPI.MonitorConnection end")
+	}()
+
+	resultConnectionActivity, err := t.Internal.MonitorConnection(ctx, id, condition)
+	targetResults := struct {
+		ConnectionActivity *sacloud.ConnectionActivity
+		Error              error
+	}{
+		ConnectionActivity: resultConnectionActivity,
+		Error:              err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultConnectionActivity, err
+}
+
 /*************************************************
 * RegionTracer
 *************************************************/

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -7197,6 +7197,43 @@ func (o *ProxyLBOp) HealthStatus(ctx context.Context, id types.ID) (*ProxyLBHeal
 	return results.ProxyLBHealth, nil
 }
 
+// MonitorConnection is API call
+func (o *ProxyLBOp) MonitorConnection(ctx context.Context, id types.ID, condition *MonitorCondition) (*ConnectionActivity, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/activity/proxylb/monitor", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"condition":  condition,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// build request body
+	var body interface{}
+	v, err := o.transformMonitorConnectionArgs(id, condition)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformMonitorConnectionResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.ConnectionActivity, nil
+}
+
 /*************************************************
 * RegionOp
 *************************************************/

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -4237,6 +4237,49 @@ func (o *ProxyLBOp) transformHealthStatusResults(data []byte) (*proxyLBHealthSta
 	return results, nil
 }
 
+func (o *ProxyLBOp) transformMonitorConnectionArgs(id types.ID, condition *MonitorCondition) (*proxyLBMonitorConnectionRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if condition == nil {
+		condition = &MonitorCondition{}
+	}
+	var arg1 interface{} = condition
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &proxyLBMonitorConnectionRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ProxyLBOp) transformMonitorConnectionResults(data []byte) (*proxyLBMonitorConnectionResult, error) {
+	nakedResponse := &proxyLBMonitorConnectionResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &proxyLBMonitorConnectionResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *RegionOp) transformFindArgs(conditions *FindCondition) (*regionFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -430,6 +430,7 @@ type ProxyLBAPI interface {
 	DeleteCertificates(ctx context.Context, id types.ID) error
 	RenewLetsEncryptCert(ctx context.Context, id types.ID) error
 	HealthStatus(ctx context.Context, id types.ID) (*ProxyLBHealth, error)
+	MonitorConnection(ctx context.Context, id types.ID, condition *MonitorCondition) (*ConnectionActivity, error)
 }
 
 /*************************************************

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -1730,6 +1730,20 @@ type proxyLBHealthStatusResponseEnvelope struct {
 	ProxyLB *naked.ProxyLBHealth `json:",omitempty"`
 }
 
+// proxyLBMonitorConnectionRequestEnvelope is envelop of API request
+type proxyLBMonitorConnectionRequestEnvelope struct {
+	Start time.Time `json:",omitempty"`
+	End   time.Time `json:",omitempty"`
+}
+
+// proxyLBMonitorConnectionResponseEnvelope is envelop of API response
+type proxyLBMonitorConnectionResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Data *naked.MonitorValues `json:",omitempty"`
+}
+
 // regionFindRequestEnvelope is envelop of API request
 type regionFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -4813,6 +4813,9 @@ func (o *MonitorCondition) setDefaults() interface{} {
 
 // GetStart returns value of Start
 func (o *MonitorCondition) GetStart() time.Time {
+	if o.Start.IsZero() {
+		return time.Now().Truncate(time.Second).Add(-time.Hour)
+	}
 	return o.Start
 }
 
@@ -4823,6 +4826,9 @@ func (o *MonitorCondition) SetStart(v time.Time) {
 
 // GetEnd returns value of End
 func (o *MonitorCondition) GetEnd() time.Time {
+	if o.End.IsZero() {
+		return time.Now().Truncate(time.Second)
+	}
 	return o.End
 }
 
@@ -16349,6 +16355,98 @@ func (o *ProxyLBHealth) GetServers() []*LoadBalancerServerStatus {
 // SetServers sets value to Servers
 func (o *ProxyLBHealth) SetServers(v []*LoadBalancerServerStatus) {
 	o.Servers = v
+}
+
+/*************************************************
+* ConnectionActivity
+*************************************************/
+
+// ConnectionActivity represents API parameter/response structure
+type ConnectionActivity struct {
+	Values []*MonitorConnectionValue `mapconv:"[]Connection"`
+}
+
+// Validate validates by field tags
+func (o *ConnectionActivity) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ConnectionActivity) setDefaults() interface{} {
+	return &struct {
+		Values []*MonitorConnectionValue `mapconv:"[]Connection"`
+	}{
+		Values: o.GetValues(),
+	}
+}
+
+// GetValues returns value of Values
+func (o *ConnectionActivity) GetValues() []*MonitorConnectionValue {
+	return o.Values
+}
+
+// SetValues sets value to Values
+func (o *ConnectionActivity) SetValues(v []*MonitorConnectionValue) {
+	o.Values = v
+}
+
+/*************************************************
+* MonitorConnectionValue
+*************************************************/
+
+// MonitorConnectionValue represents API parameter/response structure
+type MonitorConnectionValue struct {
+	Time              time.Time `json:",omitempty" mapconv:",omitempty"`
+	ActiveConnections float64   `json:",omitempty" mapconv:",omitempty"`
+	ConnectionsPerSec float64   `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *MonitorConnectionValue) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *MonitorConnectionValue) setDefaults() interface{} {
+	return &struct {
+		Time              time.Time `json:",omitempty" mapconv:",omitempty"`
+		ActiveConnections float64   `json:",omitempty" mapconv:",omitempty"`
+		ConnectionsPerSec float64   `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Time:              o.GetTime(),
+		ActiveConnections: o.GetActiveConnections(),
+		ConnectionsPerSec: o.GetConnectionsPerSec(),
+	}
+}
+
+// GetTime returns value of Time
+func (o *MonitorConnectionValue) GetTime() time.Time {
+	return o.Time
+}
+
+// SetTime sets value to Time
+func (o *MonitorConnectionValue) SetTime(v time.Time) {
+	o.Time = v
+}
+
+// GetActiveConnections returns value of ActiveConnections
+func (o *MonitorConnectionValue) GetActiveConnections() float64 {
+	return o.ActiveConnections
+}
+
+// SetActiveConnections sets value to ActiveConnections
+func (o *MonitorConnectionValue) SetActiveConnections(v float64) {
+	o.ActiveConnections = v
+}
+
+// GetConnectionsPerSec returns value of ConnectionsPerSec
+func (o *MonitorConnectionValue) GetConnectionsPerSec() float64 {
+	return o.ConnectionsPerSec
+}
+
+// SetConnectionsPerSec sets value to ConnectionsPerSec
+func (o *MonitorConnectionValue) SetConnectionsPerSec(v float64) {
+	o.ConnectionsPerSec = v
 }
 
 /*************************************************

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -1001,6 +1001,13 @@ type proxyLBHealthStatusResult struct {
 	ProxyLBHealth *ProxyLBHealth `json:",omitempty" mapconv:"ProxyLB,omitempty,recursive"`
 }
 
+// proxyLBMonitorConnectionResult represents the Result of API
+type proxyLBMonitorConnectionResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	ConnectionActivity *ConnectionActivity `json:",omitempty" mapconv:"Data,omitempty,recursive"`
+}
+
 // RegionFindResult represents the Result of API
 type RegionFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources


### PR DESCRIPTION
- エンハンスドロードバランサでのアクティビティモニタAPI
- アクティビティモニタAPIへのパラメータにデフォルト値を設定
  - 開始: 現在時刻を秒で切り捨て-1時間
  - 終了: 現在時刻の秒で切り捨て