### PR TITLE
API/VPCRouter: Status

### DIFF
--- a/internal/define/vpc_router.go
+++ b/internal/define/vpc_router.go
@@ -68,6 +68,28 @@ var vpcRouterAPI = &dsl.Resource{
 		// monitor
 		ops.MonitorChildBy(vpcRouterAPIName, "Interface", "interface",
 			monitorParameter, monitors.interfaceModel()),
+
+		// status
+		{
+			ResourceName: vpcRouterAPIName,
+			Name:         "Status",
+			Arguments: dsl.Arguments{
+				dsl.ArgumentID,
+			},
+			PathFormat: dsl.IDAndSuffixPathFormat("status"),
+			Method:     http.MethodGet,
+			ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
+				Type: meta.Static(naked.VPCRouterStatus{}),
+				Name: "Router",
+			}),
+			Results: dsl.Results{
+				{
+					SourceField: "Router",
+					DestField:   vpcRouterStatusView.Name,
+					Model:       vpcRouterStatusView,
+				},
+			},
+		},
 	},
 }
 
@@ -172,6 +194,75 @@ var (
 				Type: models.vpcRouterSetting(),
 				Tags: &dsl.FieldTags{
 					MapConv: ",omitempty,recursive",
+				},
+			},
+		},
+	}
+
+	vpcRouterStatusView = &dsl.Model{
+		Name:      "VPCRouterStatus",
+		NakedType: meta.Static(naked.VPCRouterStatus{}),
+		Fields: []*dsl.FieldDesc{
+			fields.Def("FirewallReceiveLogs", meta.TypeStringSlice),
+			fields.Def("FirewallSendLogs", meta.TypeStringSlice),
+			fields.Def("VPNLogs", meta.TypeStringSlice),
+			fields.Def("SessionCount", meta.TypeInt),
+			{
+				Name: "DHCPServerLeases",
+				Type: &dsl.Model{
+					Name:    "VPCRouterDHCPServerLease",
+					IsArray: true,
+					Fields: []*dsl.FieldDesc{
+						fields.Def("IPAddress", meta.TypeString),
+						fields.Def("MACAddress", meta.TypeString),
+					},
+				},
+				Tags: &dsl.FieldTags{
+					MapConv: "[]DHCPServerLeases,recursive",
+				},
+			},
+			{
+				Name: "L2TPIPsecServerSessions",
+				Type: &dsl.Model{
+					Name:    "VPCRouterL2TPIPsecServerSession",
+					IsArray: true,
+					Fields: []*dsl.FieldDesc{
+						fields.Def("User", meta.TypeString),
+						fields.Def("IPAddress", meta.TypeString),
+						fields.Def("TimeSec", meta.TypeInt),
+					},
+				},
+				Tags: &dsl.FieldTags{
+					MapConv: "[]L2TPIPsecServerSessions,recursive",
+				},
+			},
+			{
+				Name: "PPTPServerSessions",
+				Type: &dsl.Model{
+					Name:    "VPCRouterPPTPServerSession",
+					IsArray: true,
+					Fields: []*dsl.FieldDesc{
+						fields.Def("User", meta.TypeString),
+						fields.Def("IPAddress", meta.TypeString),
+						fields.Def("TimeSec", meta.TypeInt),
+					},
+				},
+				Tags: &dsl.FieldTags{
+					MapConv: "[]PPTPServerSessions,recursive",
+				},
+			},
+			{
+				Name: "SiteToSiteIPsecVPNPeers",
+				Type: &dsl.Model{
+					Name:    "VPCRouterSiteToSiteIPsecVPNPeer",
+					IsArray: true,
+					Fields: []*dsl.FieldDesc{
+						fields.Def("Status", meta.TypeString),
+						fields.Def("Peer", meta.TypeString),
+					},
+				},
+				Tags: &dsl.FieldTags{
+					MapConv: "[]SiteToSiteIPsecVPNPeers,recursive",
 				},
 			},
 		},

--- a/sacloud/fake/ops_vpc_router.go
+++ b/sacloud/fake/ops_vpc_router.go
@@ -272,3 +272,13 @@ func (o *VPCRouterOp) MonitorInterface(ctx context.Context, zone string, id type
 
 	return res, nil
 }
+
+// Status is fake implementation
+func (o *VPCRouterOp) Status(ctx context.Context, zone string, id types.ID) (*sacloud.VPCRouterStatus, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sacloud.VPCRouterStatus{}, nil
+}

--- a/sacloud/naked/vpc_router.go
+++ b/sacloud/naked/vpc_router.go
@@ -344,3 +344,29 @@ type VPCRouterStaticRouteConfig struct {
 	Prefix  string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	NextHop string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 }
+
+// VPCRouterStatus ステータス
+type VPCRouterStatus struct {
+	FirewallReceiveLogs []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	FirewallSendLogs    []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	VPNLogs             []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	SessionCount        int      `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	DHCPServerLeases    []struct {
+		IPAddress  string
+		MACAddress string
+	} `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	L2TPIPsecServerSessions []struct {
+		User      string
+		IPAddress string
+		TimeSec   int
+	} `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	PPTPServerSessions []struct {
+		User      string
+		IPAddress string
+		TimeSec   int
+	} `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	SiteToSiteIPsecVPNPeers []struct {
+		Status string
+		Peer   string
+	} `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+}

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -4217,6 +4217,12 @@ type VPCRouterMonitorInterfaceStubResult struct {
 	Err               error
 }
 
+// VPCRouterStatusStubResult is expected values of the Status operation
+type VPCRouterStatusStubResult struct {
+	VPCRouterStatus *sacloud.VPCRouterStatus
+	Err             error
+}
+
 // VPCRouterStub is for trace VPCRouterOp operations
 type VPCRouterStub struct {
 	FindStubResult                 *VPCRouterFindStubResult
@@ -4231,6 +4237,7 @@ type VPCRouterStub struct {
 	ConnectToSwitchStubResult      *VPCRouterConnectToSwitchStubResult
 	DisconnectFromSwitchStubResult *VPCRouterDisconnectFromSwitchStubResult
 	MonitorInterfaceStubResult     *VPCRouterMonitorInterfaceStubResult
+	StatusStubResult               *VPCRouterStatusStubResult
 }
 
 // NewVPCRouterStub creates new VPCRouterStub instance
@@ -4332,6 +4339,14 @@ func (s *VPCRouterStub) MonitorInterface(ctx context.Context, zone string, id ty
 		log.Fatal("VPCRouterStub.MonitorInterfaceStubResult is not set")
 	}
 	return s.MonitorInterfaceStubResult.InterfaceActivity, s.MonitorInterfaceStubResult.Err
+}
+
+// Status is API call with trace log
+func (s *VPCRouterStub) Status(ctx context.Context, zone string, id types.ID) (*sacloud.VPCRouterStatus, error) {
+	if s.StatusStubResult == nil {
+		log.Fatal("VPCRouterStub.StatusStubResult is not set")
+	}
+	return s.StatusStubResult.VPCRouterStatus, s.StatusStubResult.Err
 }
 
 /*************************************************

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -9211,6 +9211,39 @@ func (t *VPCRouterTracer) MonitorInterface(ctx context.Context, zone string, id 
 	return resultInterfaceActivity, err
 }
 
+// Status is API call with trace log
+func (t *VPCRouterTracer) Status(ctx context.Context, zone string, id types.ID) (*sacloud.VPCRouterStatus, error) {
+	log.Println("[TRACE] VPCRouterAPI.Status start")
+	targetArguments := struct {
+		Argzone string
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] VPCRouterAPI.Status end")
+	}()
+
+	resultVPCRouterStatus, err := t.Internal.Status(ctx, zone, id)
+	targetResults := struct {
+		VPCRouterStatus *sacloud.VPCRouterStatus
+		Error           error
+	}{
+		VPCRouterStatus: resultVPCRouterStatus,
+		Error:           err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultVPCRouterStatus, err
+}
+
 /*************************************************
 * WebAccelTracer
 *************************************************/

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -9634,6 +9634,37 @@ func (o *VPCRouterOp) MonitorInterface(ctx context.Context, zone string, id type
 	return results.InterfaceActivity, nil
 }
 
+// Status is API call
+func (o *VPCRouterOp) Status(ctx context.Context, zone string, id types.ID) (*VPCRouterStatus, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/status", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformStatusResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.VPCRouterStatus, nil
+}
+
 /*************************************************
 * WebAccelOp
 *************************************************/

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -5745,6 +5745,19 @@ func (o *VPCRouterOp) transformMonitorInterfaceResults(data []byte) (*vPCRouterM
 	return results, nil
 }
 
+func (o *VPCRouterOp) transformStatusResults(data []byte) (*vPCRouterStatusResult, error) {
+	nakedResponse := &vPCRouterStatusResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &vPCRouterStatusResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *WebAccelOp) transformListResults(data []byte) (*WebAccelListResult, error) {
 	nakedResponse := &webAccelListResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -571,6 +571,7 @@ type VPCRouterAPI interface {
 	ConnectToSwitch(ctx context.Context, zone string, id types.ID, nicIndex int, switchID types.ID) error
 	DisconnectFromSwitch(ctx context.Context, zone string, id types.ID, nicIndex int) error
 	MonitorInterface(ctx context.Context, zone string, id types.ID, index int, condition *MonitorCondition) (*InterfaceActivity, error)
+	Status(ctx context.Context, zone string, id types.ID) (*VPCRouterStatus, error)
 }
 
 /*************************************************

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -2307,6 +2307,14 @@ type vPCRouterMonitorInterfaceResponseEnvelope struct {
 	Data *naked.MonitorValues `json:",omitempty"`
 }
 
+// vPCRouterStatusResponseEnvelope is envelop of API response
+type vPCRouterStatusResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Router *naked.VPCRouterStatus `json:",omitempty"`
+}
+
 // webAccelListResponseEnvelope is envelop of API response
 type webAccelListResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -22984,6 +22984,340 @@ func (o *VPCRouterUpdateRequest) SetSettings(v *VPCRouterSetting) {
 }
 
 /*************************************************
+* VPCRouterStatus
+*************************************************/
+
+// VPCRouterStatus represents API parameter/response structure
+type VPCRouterStatus struct {
+	FirewallReceiveLogs     []string
+	FirewallSendLogs        []string
+	VPNLogs                 []string
+	SessionCount            int
+	DHCPServerLeases        []*VPCRouterDHCPServerLease        `mapconv:"[]DHCPServerLeases,recursive"`
+	L2TPIPsecServerSessions []*VPCRouterL2TPIPsecServerSession `mapconv:"[]L2TPIPsecServerSessions,recursive"`
+	PPTPServerSessions      []*VPCRouterPPTPServerSession      `mapconv:"[]PPTPServerSessions,recursive"`
+	SiteToSiteIPsecVPNPeers []*VPCRouterSiteToSiteIPsecVPNPeer `mapconv:"[]SiteToSiteIPsecVPNPeers,recursive"`
+}
+
+// Validate validates by field tags
+func (o *VPCRouterStatus) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *VPCRouterStatus) setDefaults() interface{} {
+	return &struct {
+		FirewallReceiveLogs     []string
+		FirewallSendLogs        []string
+		VPNLogs                 []string
+		SessionCount            int
+		DHCPServerLeases        []*VPCRouterDHCPServerLease        `mapconv:"[]DHCPServerLeases,recursive"`
+		L2TPIPsecServerSessions []*VPCRouterL2TPIPsecServerSession `mapconv:"[]L2TPIPsecServerSessions,recursive"`
+		PPTPServerSessions      []*VPCRouterPPTPServerSession      `mapconv:"[]PPTPServerSessions,recursive"`
+		SiteToSiteIPsecVPNPeers []*VPCRouterSiteToSiteIPsecVPNPeer `mapconv:"[]SiteToSiteIPsecVPNPeers,recursive"`
+	}{
+		FirewallReceiveLogs:     o.GetFirewallReceiveLogs(),
+		FirewallSendLogs:        o.GetFirewallSendLogs(),
+		VPNLogs:                 o.GetVPNLogs(),
+		SessionCount:            o.GetSessionCount(),
+		DHCPServerLeases:        o.GetDHCPServerLeases(),
+		L2TPIPsecServerSessions: o.GetL2TPIPsecServerSessions(),
+		PPTPServerSessions:      o.GetPPTPServerSessions(),
+		SiteToSiteIPsecVPNPeers: o.GetSiteToSiteIPsecVPNPeers(),
+	}
+}
+
+// GetFirewallReceiveLogs returns value of FirewallReceiveLogs
+func (o *VPCRouterStatus) GetFirewallReceiveLogs() []string {
+	return o.FirewallReceiveLogs
+}
+
+// SetFirewallReceiveLogs sets value to FirewallReceiveLogs
+func (o *VPCRouterStatus) SetFirewallReceiveLogs(v []string) {
+	o.FirewallReceiveLogs = v
+}
+
+// GetFirewallSendLogs returns value of FirewallSendLogs
+func (o *VPCRouterStatus) GetFirewallSendLogs() []string {
+	return o.FirewallSendLogs
+}
+
+// SetFirewallSendLogs sets value to FirewallSendLogs
+func (o *VPCRouterStatus) SetFirewallSendLogs(v []string) {
+	o.FirewallSendLogs = v
+}
+
+// GetVPNLogs returns value of VPNLogs
+func (o *VPCRouterStatus) GetVPNLogs() []string {
+	return o.VPNLogs
+}
+
+// SetVPNLogs sets value to VPNLogs
+func (o *VPCRouterStatus) SetVPNLogs(v []string) {
+	o.VPNLogs = v
+}
+
+// GetSessionCount returns value of SessionCount
+func (o *VPCRouterStatus) GetSessionCount() int {
+	return o.SessionCount
+}
+
+// SetSessionCount sets value to SessionCount
+func (o *VPCRouterStatus) SetSessionCount(v int) {
+	o.SessionCount = v
+}
+
+// GetDHCPServerLeases returns value of DHCPServerLeases
+func (o *VPCRouterStatus) GetDHCPServerLeases() []*VPCRouterDHCPServerLease {
+	return o.DHCPServerLeases
+}
+
+// SetDHCPServerLeases sets value to DHCPServerLeases
+func (o *VPCRouterStatus) SetDHCPServerLeases(v []*VPCRouterDHCPServerLease) {
+	o.DHCPServerLeases = v
+}
+
+// GetL2TPIPsecServerSessions returns value of L2TPIPsecServerSessions
+func (o *VPCRouterStatus) GetL2TPIPsecServerSessions() []*VPCRouterL2TPIPsecServerSession {
+	return o.L2TPIPsecServerSessions
+}
+
+// SetL2TPIPsecServerSessions sets value to L2TPIPsecServerSessions
+func (o *VPCRouterStatus) SetL2TPIPsecServerSessions(v []*VPCRouterL2TPIPsecServerSession) {
+	o.L2TPIPsecServerSessions = v
+}
+
+// GetPPTPServerSessions returns value of PPTPServerSessions
+func (o *VPCRouterStatus) GetPPTPServerSessions() []*VPCRouterPPTPServerSession {
+	return o.PPTPServerSessions
+}
+
+// SetPPTPServerSessions sets value to PPTPServerSessions
+func (o *VPCRouterStatus) SetPPTPServerSessions(v []*VPCRouterPPTPServerSession) {
+	o.PPTPServerSessions = v
+}
+
+// GetSiteToSiteIPsecVPNPeers returns value of SiteToSiteIPsecVPNPeers
+func (o *VPCRouterStatus) GetSiteToSiteIPsecVPNPeers() []*VPCRouterSiteToSiteIPsecVPNPeer {
+	return o.SiteToSiteIPsecVPNPeers
+}
+
+// SetSiteToSiteIPsecVPNPeers sets value to SiteToSiteIPsecVPNPeers
+func (o *VPCRouterStatus) SetSiteToSiteIPsecVPNPeers(v []*VPCRouterSiteToSiteIPsecVPNPeer) {
+	o.SiteToSiteIPsecVPNPeers = v
+}
+
+/*************************************************
+* VPCRouterDHCPServerLease
+*************************************************/
+
+// VPCRouterDHCPServerLease represents API parameter/response structure
+type VPCRouterDHCPServerLease struct {
+	IPAddress  string
+	MACAddress string
+}
+
+// Validate validates by field tags
+func (o *VPCRouterDHCPServerLease) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *VPCRouterDHCPServerLease) setDefaults() interface{} {
+	return &struct {
+		IPAddress  string
+		MACAddress string
+	}{
+		IPAddress:  o.GetIPAddress(),
+		MACAddress: o.GetMACAddress(),
+	}
+}
+
+// GetIPAddress returns value of IPAddress
+func (o *VPCRouterDHCPServerLease) GetIPAddress() string {
+	return o.IPAddress
+}
+
+// SetIPAddress sets value to IPAddress
+func (o *VPCRouterDHCPServerLease) SetIPAddress(v string) {
+	o.IPAddress = v
+}
+
+// GetMACAddress returns value of MACAddress
+func (o *VPCRouterDHCPServerLease) GetMACAddress() string {
+	return o.MACAddress
+}
+
+// SetMACAddress sets value to MACAddress
+func (o *VPCRouterDHCPServerLease) SetMACAddress(v string) {
+	o.MACAddress = v
+}
+
+/*************************************************
+* VPCRouterL2TPIPsecServerSession
+*************************************************/
+
+// VPCRouterL2TPIPsecServerSession represents API parameter/response structure
+type VPCRouterL2TPIPsecServerSession struct {
+	User      string
+	IPAddress string
+	TimeSec   int
+}
+
+// Validate validates by field tags
+func (o *VPCRouterL2TPIPsecServerSession) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *VPCRouterL2TPIPsecServerSession) setDefaults() interface{} {
+	return &struct {
+		User      string
+		IPAddress string
+		TimeSec   int
+	}{
+		User:      o.GetUser(),
+		IPAddress: o.GetIPAddress(),
+		TimeSec:   o.GetTimeSec(),
+	}
+}
+
+// GetUser returns value of User
+func (o *VPCRouterL2TPIPsecServerSession) GetUser() string {
+	return o.User
+}
+
+// SetUser sets value to User
+func (o *VPCRouterL2TPIPsecServerSession) SetUser(v string) {
+	o.User = v
+}
+
+// GetIPAddress returns value of IPAddress
+func (o *VPCRouterL2TPIPsecServerSession) GetIPAddress() string {
+	return o.IPAddress
+}
+
+// SetIPAddress sets value to IPAddress
+func (o *VPCRouterL2TPIPsecServerSession) SetIPAddress(v string) {
+	o.IPAddress = v
+}
+
+// GetTimeSec returns value of TimeSec
+func (o *VPCRouterL2TPIPsecServerSession) GetTimeSec() int {
+	return o.TimeSec
+}
+
+// SetTimeSec sets value to TimeSec
+func (o *VPCRouterL2TPIPsecServerSession) SetTimeSec(v int) {
+	o.TimeSec = v
+}
+
+/*************************************************
+* VPCRouterPPTPServerSession
+*************************************************/
+
+// VPCRouterPPTPServerSession represents API parameter/response structure
+type VPCRouterPPTPServerSession struct {
+	User      string
+	IPAddress string
+	TimeSec   int
+}
+
+// Validate validates by field tags
+func (o *VPCRouterPPTPServerSession) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *VPCRouterPPTPServerSession) setDefaults() interface{} {
+	return &struct {
+		User      string
+		IPAddress string
+		TimeSec   int
+	}{
+		User:      o.GetUser(),
+		IPAddress: o.GetIPAddress(),
+		TimeSec:   o.GetTimeSec(),
+	}
+}
+
+// GetUser returns value of User
+func (o *VPCRouterPPTPServerSession) GetUser() string {
+	return o.User
+}
+
+// SetUser sets value to User
+func (o *VPCRouterPPTPServerSession) SetUser(v string) {
+	o.User = v
+}
+
+// GetIPAddress returns value of IPAddress
+func (o *VPCRouterPPTPServerSession) GetIPAddress() string {
+	return o.IPAddress
+}
+
+// SetIPAddress sets value to IPAddress
+func (o *VPCRouterPPTPServerSession) SetIPAddress(v string) {
+	o.IPAddress = v
+}
+
+// GetTimeSec returns value of TimeSec
+func (o *VPCRouterPPTPServerSession) GetTimeSec() int {
+	return o.TimeSec
+}
+
+// SetTimeSec sets value to TimeSec
+func (o *VPCRouterPPTPServerSession) SetTimeSec(v int) {
+	o.TimeSec = v
+}
+
+/*************************************************
+* VPCRouterSiteToSiteIPsecVPNPeer
+*************************************************/
+
+// VPCRouterSiteToSiteIPsecVPNPeer represents API parameter/response structure
+type VPCRouterSiteToSiteIPsecVPNPeer struct {
+	Status string
+	Peer   string
+}
+
+// Validate validates by field tags
+func (o *VPCRouterSiteToSiteIPsecVPNPeer) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *VPCRouterSiteToSiteIPsecVPNPeer) setDefaults() interface{} {
+	return &struct {
+		Status string
+		Peer   string
+	}{
+		Status: o.GetStatus(),
+		Peer:   o.GetPeer(),
+	}
+}
+
+// GetStatus returns value of Status
+func (o *VPCRouterSiteToSiteIPsecVPNPeer) GetStatus() string {
+	return o.Status
+}
+
+// SetStatus sets value to Status
+func (o *VPCRouterSiteToSiteIPsecVPNPeer) SetStatus(v string) {
+	o.Status = v
+}
+
+// GetPeer returns value of Peer
+func (o *VPCRouterSiteToSiteIPsecVPNPeer) GetPeer() string {
+	return o.Peer
+}
+
+// SetPeer sets value to Peer
+func (o *VPCRouterSiteToSiteIPsecVPNPeer) SetPeer(v string) {
+	o.Peer = v
+}
+
+/*************************************************
 * WebAccel
 *************************************************/
 

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -1308,6 +1308,13 @@ type vPCRouterMonitorInterfaceResult struct {
 	InterfaceActivity *InterfaceActivity `json:",omitempty" mapconv:"Data,omitempty,recursive"`
 }
 
+// vPCRouterStatusResult represents the Result of API
+type vPCRouterStatusResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	VPCRouterStatus *VPCRouterStatus `json:",omitempty" mapconv:"Router,omitempty,recursive"`
+}
+
 // WebAccelListResult represents the Result of API
 type WebAccelListResult struct {
 	Total int `json:",omitempty"` // Total count of target resources


### PR DESCRIPTION
VPCルータに`Status` APIを追加。

Note: VPCルータのステータスとしてはサイト間VPNのステータスを取得する`GET /appliance/:id/vpcrouter/sitetosite/connectiondetails`もあるが、こちらは利用頻度が低いため当面サポートしない。