### PR TITLE
sacloud/testutil: SingletonAPICaller()で*sacloud.Clientを返却

### DIFF
--- a/sacloud/testutil/util.go
+++ b/sacloud/testutil/util.go
@@ -29,14 +29,14 @@ func ResourceName(name string) string {
 }
 
 var testZone string
-var apiCaller sacloud.APICaller
+var apiCaller *sacloud.Client
 var httpTrace bool
 
 var accTestOnce sync.Once
 var accTestMu sync.Mutex
 
 // SingletonAPICaller 環境変数からシングルトンAPICallerを作成する
-func SingletonAPICaller() sacloud.APICaller {
+func SingletonAPICaller() *sacloud.Client {
 
 	accTestMu.Lock()
 	defer accTestMu.Unlock()

--- a/utils/server/builder_test.go
+++ b/utils/server/builder_test.go
@@ -281,9 +281,11 @@ func TestBuilder_Build_BlackBox(t *testing.T) {
 	var testZone = testutil.TestZone()
 
 	testutil.Run(t, &testutil.CRUDTestCase{
-		SetupAPICallerFunc: testutil.SingletonAPICaller,
-		Parallel:           true,
-		IgnoreStartupWait:  true,
+		SetupAPICallerFunc: func() sacloud.APICaller {
+			return testutil.SingletonAPICaller()
+		},
+		Parallel:          true,
+		IgnoreStartupWait: true,
 
 		Setup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
 			switchOp := sacloud.NewSwitchOp(caller)

--- a/utils/setup/setup_test.go
+++ b/utils/setup/setup_test.go
@@ -17,8 +17,10 @@ func TestRetryableSetup(t *testing.T) {
 	testZone := testutil.TestZone()
 
 	testutil.Run(t, &testutil.CRUDTestCase{
-		Parallel:           true,
-		SetupAPICallerFunc: testutil.SingletonAPICaller,
+		Parallel: true,
+		SetupAPICallerFunc: func() sacloud.APICaller {
+			return testutil.SingletonAPICaller()
+		},
 
 		Setup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
 			switchOp := sacloud.NewSwitchOp(caller)


### PR DESCRIPTION
`testutil.SingletonAPICaller()`の戻り値をsacloud.APICallerインターフェースから*sacloud.Clientへと変更する。