### PR TITLE
Patch APIs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-playground/universal-translator v0.16.0 // indirect
 	github.com/hashicorp/go-multierror v1.0.1-0.20190722213833-bdca7bb83f60
 	github.com/huandu/xstrings v1.2.0
+	github.com/imdario/mergo v0.3.8-0.20190722133502-4c317f2286be
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pmezard/go-difflib v1.0.0 // indirect
@@ -20,4 +21,5 @@ require (
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/validator.v9 v9.29.0
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/hashicorp/go-multierror v1.0.1-0.20190722213833-bdca7bb83f60 h1:5Ng5F
 github.com/hashicorp/go-multierror v1.0.1-0.20190722213833-bdca7bb83f60/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
+github.com/imdario/mergo v0.3.8-0.20190722133502-4c317f2286be h1:uxQqQL55ZKzcFHz9ioOEn+1Vd4TVChSe634X1fiMu0U=
+github.com/imdario/mergo v0.3.8-0.20190722133502-4c317f2286be/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/leodido/go-urn v1.1.0 h1:Sm1gr51B1kKyfD2BlRcLSiEkffoG96g6TPv6eRoEiB8=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
@@ -36,7 +38,11 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/go-playground/assert.v1 v1.2.1 h1:xoYuJVE7KT85PYWrN730RguIQO0ePzVRfFMXadIrXTM=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v9 v9.29.0 h1:5ofssLNYgAA/inWn6rTZ4juWpRJUwEnXc1LG2IeXwgQ=
 gopkg.in/go-playground/validator.v9 v9.29.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/define/archive.go
+++ b/internal/define/archive.go
@@ -73,6 +73,9 @@ var archiveAPI = &dsl.Resource{
 		// update
 		ops.Update(archiveAPIName, archiveNakedType, archiveUpdateParam, archiveView),
 
+		// patch
+		ops.Patch(archiveAPIName, archiveNakedType, patchModel(archiveUpdateParam), archiveView),
+
 		// delete
 		ops.Delete(archiveAPIName),
 

--- a/internal/define/auto_backup.go
+++ b/internal/define/auto_backup.go
@@ -30,6 +30,9 @@ var autoBackupAPI = &dsl.Resource{
 		// update
 		ops.UpdateCommonServiceItem(autoBackupAPIName, autoBackupNakedType, autoBackupUpdateParam, autoBackupView),
 
+		// patch
+		ops.PatchCommonServiceItem(autoBackupAPIName, autoBackupNakedType, patchModel(autoBackupUpdateParam), autoBackupView),
+
 		// delete
 		ops.Delete(autoBackupAPIName),
 	},

--- a/internal/define/bridge.go
+++ b/internal/define/bridge.go
@@ -30,6 +30,9 @@ var bridgeAPI = &dsl.Resource{
 		// update
 		ops.Update(bridgeAPIName, bridgeNakedType, bridgeUpdateParam, bridgeView),
 
+		// patch
+		ops.Patch(bridgeAPIName, bridgeNakedType, patchModel(bridgeUpdateParam), bridgeView),
+
 		// delete
 		ops.Delete(bridgeAPIName),
 	},

--- a/internal/define/cdrom.go
+++ b/internal/define/cdrom.go
@@ -68,6 +68,9 @@ var cdromAPI = &dsl.Resource{
 		// update
 		ops.Update(cdromAPIName, cdromNakedType, cdromUpdateParam, cdromView),
 
+		// patch
+		ops.Patch(cdromAPIName, cdromNakedType, patchModel(cdromUpdateParam), cdromView),
+
 		// delete
 		ops.Delete(cdromAPIName),
 

--- a/internal/define/database.go
+++ b/internal/define/database.go
@@ -32,6 +32,9 @@ var databaseAPI = &dsl.Resource{
 		// update
 		ops.UpdateAppliance(databaseAPIName, databaseNakedType, databaseUpdateParam, databaseView),
 
+		// patch
+		ops.PatchAppliance(databaseAPIName, databaseNakedType, patchModel(databaseUpdateParam), databaseView),
+
 		// delete
 		ops.Delete(databaseAPIName),
 

--- a/internal/define/disk.go
+++ b/internal/define/disk.go
@@ -205,6 +205,9 @@ var diskAPI = &dsl.Resource{
 		// update
 		ops.Update(diskAPIName, diskNakedType, diskUpdateParam, diskModel),
 
+		// patch
+		ops.Patch(diskAPIName, diskNakedType, patchModel(diskUpdateParam), diskModel),
+
 		// delete
 		ops.Delete(diskAPIName),
 

--- a/internal/define/dns.go
+++ b/internal/define/dns.go
@@ -31,6 +31,9 @@ var dnsAPI = &dsl.Resource{
 		// update
 		ops.UpdateCommonServiceItem(dnsAPIName, dnsNakedType, dnsUpdateParam, dnsView),
 
+		// patch
+		ops.PatchCommonServiceItem(dnsAPIName, dnsNakedType, patchModel(dnsUpdateParam), dnsView),
+
 		// delete
 		ops.Delete(dnsAPIName),
 	},

--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -1333,6 +1333,7 @@ func (f *fieldsDef) SettingsHash() *dsl.FieldDesc {
 			MapConv: ",omitempty",
 			JSON:    ",omitempty",
 		},
+		IgnorePatch: true,
 	}
 }
 

--- a/internal/define/gslb.go
+++ b/internal/define/gslb.go
@@ -31,6 +31,9 @@ var gslbAPI = &dsl.Resource{
 		// update
 		ops.UpdateCommonServiceItem(gslbAPIName, gslbNakedType, gslbUpdateParam, gslbView),
 
+		// patch
+		ops.PatchCommonServiceItem(gslbAPIName, gslbNakedType, patchModel(gslbUpdateParam), gslbView),
+
 		// delete
 		ops.Delete(gslbAPIName),
 	},

--- a/internal/define/icon.go
+++ b/internal/define/icon.go
@@ -34,6 +34,9 @@ var iconAPI = &dsl.Resource{
 		// update
 		ops.Update(iconAPIName, iconNakedType, iconUpdateParam, iconView),
 
+		// patch
+		ops.Patch(iconAPIName, iconNakedType, patchModel(iconUpdateParam), iconView),
+
 		// delete
 		ops.Delete(iconAPIName),
 	},

--- a/internal/define/interface.go
+++ b/internal/define/interface.go
@@ -32,6 +32,9 @@ var interfaceAPI = &dsl.Resource{
 		// update
 		ops.Update(interfaceAPIName, interfaceNakedType, interfaceUpdateParam, interfaceView),
 
+		// patch
+		ops.Patch(interfaceAPIName, interfaceNakedType, patchModel(interfaceUpdateParam), interfaceView),
+
 		// delete
 		ops.Delete(interfaceAPIName),
 

--- a/internal/define/internet.go
+++ b/internal/define/internet.go
@@ -33,6 +33,9 @@ var internetAPI = &dsl.Resource{
 		// update
 		ops.Update(internetAPIName, internetNakedType, internetUpdateParam, internetView),
 
+		// patch
+		ops.Patch(internetAPIName, internetNakedType, patchModel(internetUpdateParam), internetView),
+
 		// delete
 		ops.Delete(internetAPIName),
 

--- a/internal/define/license.go
+++ b/internal/define/license.go
@@ -31,6 +31,9 @@ var licenseAPI = &dsl.Resource{
 		// update
 		ops.Update(licenseAPIName, licenseNakedType, licenseUpdateParam, licenseView),
 
+		// patch
+		ops.Patch(licenseAPIName, licenseNakedType, patchModel(licenseUpdateParam), licenseView),
+
 		// delete
 		ops.Delete(licenseAPIName),
 	},

--- a/internal/define/load_balancer.go
+++ b/internal/define/load_balancer.go
@@ -30,6 +30,9 @@ var loadBalancerAPI = &dsl.Resource{
 		// update
 		ops.UpdateAppliance(loadBalancerAPIName, loadBalancerNakedType, loadBalancerUpdateParam, loadBalancerView),
 
+		// patch
+		ops.PatchAppliance(loadBalancerAPIName, loadBalancerNakedType, patchModel(loadBalancerUpdateParam), loadBalancerView),
+
 		// delete
 		ops.Delete(loadBalancerAPIName),
 

--- a/internal/define/mobile_gateway.go
+++ b/internal/define/mobile_gateway.go
@@ -32,6 +32,9 @@ var mobileGatewayAPI = &dsl.Resource{
 		// update
 		ops.UpdateAppliance(mobileGatewayAPIName, mobileGatewayNakedType, mobileGatewayUpdateParam, mobileGatewayView),
 
+		// patch
+		ops.PatchAppliance(mobileGatewayAPIName, mobileGatewayNakedType, patchModel(mobileGatewayUpdateParam), mobileGatewayView),
+
 		// delete
 		ops.Delete(mobileGatewayAPIName),
 

--- a/internal/define/nfs.go
+++ b/internal/define/nfs.go
@@ -30,6 +30,9 @@ var nfsAPI = &dsl.Resource{
 		// update
 		ops.UpdateAppliance(nfsAPIName, nfsNakedType, nfsUpdateParam, nfsView),
 
+		// patch
+		ops.PatchAppliance(nfsAPIName, nfsNakedType, patchModel(nfsUpdateParam), nfsView),
+
 		// delete
 		ops.Delete(nfsAPIName),
 

--- a/internal/define/note.go
+++ b/internal/define/note.go
@@ -31,6 +31,9 @@ var noteAPI = &dsl.Resource{
 		// update
 		ops.Update(noteAPIName, noteNakedType, noteUpdateParam, noteView),
 
+		// patch
+		ops.Patch(noteAPIName, noteNakedType, patchModel(noteUpdateParam), noteView),
+
 		// delete
 		ops.Delete(noteAPIName),
 	},

--- a/internal/define/ops/operations.go
+++ b/internal/define/ops/operations.go
@@ -215,6 +215,28 @@ func UpdateCommonServiceItem(resourceName string, nakedType meta.Type, updatePar
 	return update(resourceName, nakedType, updateParam, result, "CommonServiceItem")
 }
 
+func patch(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model, payloadName string) *dsl.Operation {
+	op := update(resourceName, nakedType, updateParam, result, payloadName)
+	op.Name = "Patch"
+	op.IsPatch = true
+	return op
+}
+
+// Patch Patch操作を定義
+func Patch(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model) *dsl.Operation {
+	return patch(resourceName, nakedType, updateParam, result, "")
+}
+
+// PatchAppliance Patch操作を定義
+func PatchAppliance(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model) *dsl.Operation {
+	return patch(resourceName, nakedType, updateParam, result, "Appliance")
+}
+
+// PatchCommonServiceItem Patch操作を定義
+func PatchCommonServiceItem(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model) *dsl.Operation {
+	return patch(resourceName, nakedType, updateParam, result, "CommonServiceItem")
+}
+
 // Delete Delete操作を定義
 func Delete(resourceName string) *dsl.Operation {
 	return &dsl.Operation{

--- a/internal/define/packet_filter.go
+++ b/internal/define/packet_filter.go
@@ -30,6 +30,9 @@ var packetFilterAPI = &dsl.Resource{
 		// update
 		ops.Update(packetFilterAPIName, packetFilterNakedType, packetFilterUpdateParam, packetFilterView),
 
+		// update
+		ops.Patch(packetFilterAPIName, packetFilterNakedType, patchModel(packetFilterUpdateParam), packetFilterView),
+
 		// delete
 		ops.Delete(packetFilterAPIName),
 	},

--- a/internal/define/patch.go
+++ b/internal/define/patch.go
@@ -1,0 +1,32 @@
+package define
+
+import (
+	"strings"
+
+	"github.com/sacloud/libsacloud/v2/internal/dsl"
+	"github.com/sacloud/libsacloud/v2/internal/dsl/meta"
+)
+
+func patchModel(updateModel *dsl.Model) *dsl.Model {
+	pm := &dsl.Model{
+		Name:        strings.Replace(updateModel.Name, "Update", "Patch", -1),
+		ConstFields: updateModel.ConstFields,
+		Methods:     updateModel.Methods,
+		NakedType:   updateModel.NakedType,
+		IsArray:     updateModel.IsArray,
+	}
+
+	var fields []*dsl.FieldDesc
+	for _, f := range updateModel.Fields {
+
+		fields = append(fields, f)
+		if f.IsNeedPatchEmpty() {
+			fields = append(fields, &dsl.FieldDesc{
+				Name: "PatchEmptyTo" + f.Name,
+				Type: meta.TypeFlag,
+			})
+		}
+	}
+	pm.Fields = fields
+	return pm
+}

--- a/internal/define/private_host.go
+++ b/internal/define/private_host.go
@@ -30,6 +30,9 @@ var privateHostAPI = &dsl.Resource{
 		// update
 		ops.Update(privateHostAPIName, privateHostNakedType, privateHostUpdateParam, privateHostView),
 
+		// patch
+		ops.Patch(privateHostAPIName, privateHostNakedType, patchModel(privateHostUpdateParam), privateHostView),
+
 		// delete
 		ops.Delete(privateHostAPIName),
 	},

--- a/internal/define/proxylb.go
+++ b/internal/define/proxylb.go
@@ -33,6 +33,9 @@ var proxyLBAPI = &dsl.Resource{
 		// update
 		ops.UpdateCommonServiceItem(proxyLBAPIName, proxyLBNakedType, proxyLBUpdateParam, proxyLBView),
 
+		// patch
+		ops.PatchCommonServiceItem(proxyLBAPIName, proxyLBNakedType, patchModel(proxyLBUpdateParam), proxyLBView),
+
 		// delete
 		ops.Delete(proxyLBAPIName),
 

--- a/internal/define/server.go
+++ b/internal/define/server.go
@@ -33,6 +33,9 @@ var serverAPI = &dsl.Resource{
 		// update
 		ops.Update(serverAPIName, serverNakedType, serverUpdateParam, serverView),
 
+		// patch
+		ops.Patch(serverAPIName, serverNakedType, patchModel(serverUpdateParam), serverView),
+
 		// delete
 		ops.Delete(serverAPIName),
 

--- a/internal/define/sim.go
+++ b/internal/define/sim.go
@@ -33,6 +33,9 @@ var simAPI = &dsl.Resource{
 		// update
 		ops.UpdateCommonServiceItem(simAPIName, simNakedType, simUpdateParam, simView),
 
+		// patch
+		ops.PatchCommonServiceItem(simAPIName, simNakedType, patchModel(simUpdateParam), simView),
+
 		// delete
 		ops.Delete(simAPIName),
 

--- a/internal/define/simple_monitor.go
+++ b/internal/define/simple_monitor.go
@@ -32,6 +32,9 @@ var simpleMonitorAPI = &dsl.Resource{
 		// update
 		ops.UpdateCommonServiceItem(simpleMonitorAPIName, simpleMonitorNakedType, simpleMonitorUpdateParam, simpleMonitorView),
 
+		// patch
+		ops.PatchCommonServiceItem(simpleMonitorAPIName, simpleMonitorNakedType, patchModel(simpleMonitorUpdateParam), simpleMonitorView),
+
 		// delete
 		ops.Delete(simpleMonitorAPIName),
 

--- a/internal/define/ssh_key.go
+++ b/internal/define/ssh_key.go
@@ -60,6 +60,9 @@ var sshKeyAPI = &dsl.Resource{
 		// update
 		ops.Update(sshKeyAPIName, sshKeyNakedType, sshKeyUpdateParam, sshKeyView),
 
+		// patch
+		ops.Patch(sshKeyAPIName, sshKeyNakedType, patchModel(sshKeyUpdateParam), sshKeyView),
+
 		// delete
 		ops.Delete(sshKeyAPIName),
 	},

--- a/internal/define/switch.go
+++ b/internal/define/switch.go
@@ -32,6 +32,9 @@ var switchAPI = &dsl.Resource{
 		// update
 		ops.Update(switchAPIName, switchNakedType, switchUpdateParam, switchView),
 
+		// patch
+		ops.Patch(switchAPIName, switchNakedType, patchModel(switchUpdateParam), switchView),
+
 		// delete
 		ops.Delete(switchAPIName),
 

--- a/internal/define/vpc_router.go
+++ b/internal/define/vpc_router.go
@@ -32,6 +32,9 @@ var vpcRouterAPI = &dsl.Resource{
 		// update
 		ops.UpdateAppliance(vpcRouterAPIName, vpcRouterNakedType, vpcRouterUpdateParam, vpcRouterView),
 
+		// patch
+		ops.PatchAppliance(vpcRouterAPIName, vpcRouterNakedType, patchModel(vpcRouterUpdateParam), vpcRouterView),
+
 		// delete
 		ops.Delete(vpcRouterAPIName),
 

--- a/internal/dsl/field_desc.go
+++ b/internal/dsl/field_desc.go
@@ -15,6 +15,7 @@ type FieldDesc struct {
 	Description  string // TODO 現在は未使用
 	Methods      []*MethodDesc
 	DefaultValue string // デフォルト値、コード生成時にソースコードに直接転記される
+	IgnorePatch  bool   // trueの場合patch時の値のクリアを行えないようにする
 }
 
 // HasTag タグの定義がなされているか
@@ -33,6 +34,24 @@ func (f *FieldDesc) TagString() string {
 		return ""
 	}
 	return f.Tags.String()
+}
+
+// IsPatchEmptyParam クリアパラメータか判定
+func (f *FieldDesc) IsPatchEmptyParam() bool {
+	return strings.HasPrefix(f.Name, "PatchEmptyTo")
+}
+
+// IsRequired 必須項目であるかを判定
+func (f *FieldDesc) IsRequired() bool {
+	if f.Tags == nil {
+		return false
+	}
+	return strings.Contains(f.Tags.Validate, "required")
+}
+
+// IsNeedPatchEmpty Patch時の値のクリアが必要な項目かを判定
+func (f *FieldDesc) IsNeedPatchEmpty() bool {
+	return !f.IsPatchEmptyParam() && !f.IsRequired() && !f.IgnorePatch
 }
 
 // FieldTags フィールドに付与するタグ

--- a/internal/tools/gen-api-op/main.go
+++ b/internal/tools/gen-api-op/main.go
@@ -89,6 +89,29 @@ func (o *{{ $typeName }}Op) {{ .MethodName }}(ctx context.Context{{if not $resou
 		return {{ $returnErrStatement }}
 	}
 
+	{{if .IsPatch -}}
+	original, err := o.Read(ctx{{if not $resource.IsGlobal}}, zone{{ end }}, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	{{ range .PatchArgumentModel.Fields -}}
+	{{ if .IsNeedPatchEmpty}}if param.PatchEmptyTo{{.Name}} {
+		param.{{.Name}} = {{.Type.ZeroValueSourceCode}}	
+	}
+	{{ end }}{{ end -}}
+	{{ end -}}
+
 	// build request body
 	var body interface{}
 {{ if .HasRequestEnvelope -}}

--- a/sacloud/fake/ops_bridge.go
+++ b/sacloud/fake/ops_bridge.go
@@ -2,7 +2,9 @@ package fake
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -52,7 +54,34 @@ func (o *BridgeOp) Update(ctx context.Context, zone string, id types.ID, param *
 		return nil, err
 	}
 	copySameNameField(param, value)
+	putBridge(zone, value)
 
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *BridgeOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.BridgePatchRequest) (*sacloud.Bridge, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+
+	putBridge(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_cdrom.go
+++ b/sacloud/fake/ops_cdrom.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -60,6 +61,41 @@ func (o *CDROMOp) Update(ctx context.Context, zone string, id types.ID, param *s
 	}
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putCDROM(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *CDROMOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.CDROMPatchRequest) (*sacloud.CDROM, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+
+	putCDROM(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_database.go
+++ b/sacloud/fake/ops_database.go
@@ -2,8 +2,10 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -63,6 +65,49 @@ func (o *DatabaseOp) Update(ctx context.Context, zone string, id types.ID, param
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
 
+	putDatabase(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *DatabaseOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.DatabasePatchRequest) (*sacloud.Database, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToCommonSetting {
+		value.CommonSetting = nil
+	}
+	if param.PatchEmptyToBackupSetting {
+		value.BackupSetting = nil
+	}
+	if param.PatchEmptyToReplicationSetting {
+		value.ReplicationSetting = nil
+	}
+
+	putDatabase(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_disk.go
+++ b/sacloud/fake/ops_disk.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -231,6 +232,44 @@ func (o *DiskOp) Update(ctx context.Context, zone string, id types.ID, param *sa
 	}
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putDisk(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *DiskOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.DiskPatchRequest) (*sacloud.Disk, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToConnection {
+		value.Connection = types.EDiskConnection("")
+	}
+
+	putDisk(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_dns.go
+++ b/sacloud/fake/ops_dns.go
@@ -2,7 +2,9 @@ package fake
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -58,6 +60,43 @@ func (o *DNSOp) Update(ctx context.Context, id types.ID, param *sacloud.DNSUpdat
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
 
+	putDNS(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *DNSOp) Patch(ctx context.Context, id types.ID, param *sacloud.DNSPatchRequest) (*sacloud.DNS, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToRecords {
+		value.Records = nil
+	}
+
+	putDNS(sacloud.APIDefaultZone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_gslb.go
+++ b/sacloud/fake/ops_gslb.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -61,6 +62,56 @@ func (o *GSLBOp) Update(ctx context.Context, id types.ID, param *sacloud.GSLBUpd
 	}
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putGSLB(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *GSLBOp) Patch(ctx context.Context, id types.ID, param *sacloud.GSLBPatchRequest) (*sacloud.GSLB, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToHealthCheck {
+		value.HealthCheck = nil
+	}
+	if param.PatchEmptyToDelayLoop {
+		value.DelayLoop = 0
+	}
+	if param.PatchEmptyToWeighted {
+		value.Weighted = types.StringFlag(false)
+	}
+	if param.PatchEmptyToSorryServer {
+		value.SorryServer = ""
+	}
+	if param.PatchEmptyToDestinationServers {
+		value.DestinationServers = nil
+	}
+
+	putGSLB(sacloud.APIDefaultZone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_icon.go
+++ b/sacloud/fake/ops_icon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -58,6 +59,33 @@ func (o *IconOp) Update(ctx context.Context, id types.ID, param *sacloud.IconUpd
 	}
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putIcon(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *IconOp) Patch(ctx context.Context, id types.ID, param *sacloud.IconPatchRequest) (*sacloud.Icon, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	putIcon(sacloud.APIDefaultZone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_interface.go
+++ b/sacloud/fake/ops_interface.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -59,6 +60,34 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putInterface(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *InterfaceOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.InterfacePatchRequest) (*sacloud.Interface, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToUserIPAddress {
+		param.UserIPAddress = ""
+	}
+	putInterface(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_internet.go
+++ b/sacloud/fake/ops_internet.go
@@ -2,9 +2,11 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -101,6 +103,40 @@ func (o *InternetOp) Update(ctx context.Context, zone string, id types.ID, param
 	}
 	copySameNameField(param, value)
 
+	putInternet(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *InternetOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.InternetPatchRequest) (*sacloud.Internet, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+
+	putInternet(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_license.go
+++ b/sacloud/fake/ops_license.go
@@ -2,7 +2,9 @@ package fake
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -53,6 +55,31 @@ func (o *LicenseOp) Update(ctx context.Context, id types.ID, param *sacloud.Lice
 	}
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putLicense(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *LicenseOp) Patch(ctx context.Context, id types.ID, param *sacloud.LicensePatchRequest) (*sacloud.License, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	putLicense(sacloud.APIDefaultZone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_load_balancer.go
+++ b/sacloud/fake/ops_load_balancer.go
@@ -2,8 +2,10 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -76,6 +78,42 @@ func (o *LoadBalancerOp) Update(ctx context.Context, zone string, id types.ID, p
 			vip.DelayLoop = 10 // default value
 		}
 	}
+	putLoadBalancer(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *LoadBalancerOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerPatchRequest) (*sacloud.LoadBalancer, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToVirtualIPAddresses {
+		value.VirtualIPAddresses = nil
+	}
+
 	putLoadBalancer(zone, value)
 	return value, nil
 }

--- a/sacloud/fake/ops_mobile_gateway.go
+++ b/sacloud/fake/ops_mobile_gateway.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -61,6 +62,43 @@ func (o *MobileGatewayOp) Update(ctx context.Context, zone string, id types.ID, 
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
 
+	putMobileGateway(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *MobileGatewayOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayPatchRequest) (*sacloud.MobileGateway, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToSettings {
+		value.Settings = nil
+	}
+
+	putMobileGateway(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_nfs.go
+++ b/sacloud/fake/ops_nfs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -65,6 +66,40 @@ func (o *NFSOp) Update(ctx context.Context, zone string, id types.ID, param *sac
 
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putNFS(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *NFSOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.NFSPatchRequest) (*sacloud.NFS, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	putNFS(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_note.go
+++ b/sacloud/fake/ops_note.go
@@ -2,7 +2,9 @@ package fake
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -54,6 +56,44 @@ func (o *NoteOp) Update(ctx context.Context, id types.ID, param *sacloud.NoteUpd
 
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putNote(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// Patch is API call
+func (o *NoteOp) Patch(ctx context.Context, id types.ID, param *sacloud.NotePatchRequest) (*sacloud.Note, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToClass {
+		value.Class = ""
+	}
+	if param.PatchEmptyToContent {
+		value.Content = ""
+	}
+
+	putNote(sacloud.APIDefaultZone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_packet_filter.go
+++ b/sacloud/fake/ops_packet_filter.go
@@ -2,7 +2,9 @@ package fake
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -54,6 +56,37 @@ func (o *PacketFilterOp) Update(ctx context.Context, zone string, id types.ID, p
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
 
+	putPacketFilter(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *PacketFilterOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.PacketFilterPatchRequest) (*sacloud.PacketFilter, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToExpression {
+		value.Expression = nil
+	}
+
+	putPacketFilter(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_private_host.go
+++ b/sacloud/fake/ops_private_host.go
@@ -2,7 +2,9 @@ package fake
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -65,6 +67,40 @@ func (o *PrivateHostOp) Update(ctx context.Context, zone string, id types.ID, pa
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
 
+	putPrivateHost(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *PrivateHostOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.PrivateHostPatchRequest) (*sacloud.PrivateHost, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+
+	putPrivateHost(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_proxy_lb.go
+++ b/sacloud/fake/ops_proxy_lb.go
@@ -2,9 +2,11 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -86,6 +88,71 @@ func (o *ProxyLBOp) Update(ctx context.Context, id types.ID, param *sacloud.Prox
 	if value.SorryServer == nil {
 		value.SorryServer = &sacloud.ProxyLBSorryServer{}
 	}
+	putProxyLB(sacloud.APIDefaultZone, value)
+
+	status := ds().Get(ResourceProxyLB+"Status", sacloud.APIDefaultZone, id).(*sacloud.ProxyLBHealth)
+	status.Servers = []*sacloud.LoadBalancerServerStatus{}
+	for _, server := range param.Servers {
+		status.Servers = append(status.Servers, &sacloud.LoadBalancerServerStatus{
+			ActiveConn: 10,
+			Status:     types.ServerInstanceStatuses.Up,
+			IPAddress:  server.IPAddress,
+			Port:       types.StringNumber(server.Port),
+			CPS:        10,
+		})
+	}
+	ds().Put(ResourceProxyLB+"Status", sacloud.APIDefaultZone, id, status)
+
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *ProxyLBOp) Patch(ctx context.Context, id types.ID, param *sacloud.ProxyLBPatchRequest) (*sacloud.ProxyLB, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToHealthCheck {
+		value.HealthCheck = nil
+	}
+	if param.PatchEmptyToSorryServer {
+		value.SorryServer = nil
+	}
+	if param.PatchEmptyToBindPorts {
+		value.BindPorts = nil
+	}
+	if param.PatchEmptyToServers {
+		value.Servers = nil
+	}
+	if param.PatchEmptyToLetsEncrypt {
+		value.LetsEncrypt = nil
+	}
+	if param.PatchEmptyToStickySession {
+		value.StickySession = nil
+	}
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+
 	putProxyLB(sacloud.APIDefaultZone, value)
 
 	status := ds().Get(ResourceProxyLB+"Status", sacloud.APIDefaultZone, id).(*sacloud.ProxyLBHealth)

--- a/sacloud/fake/ops_simple_monitor.go
+++ b/sacloud/fake/ops_simple_monitor.go
@@ -2,8 +2,10 @@ package fake
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -66,7 +68,60 @@ func (o *SimpleMonitorOp) Update(ctx context.Context, id types.ID, param *saclou
 		value.DelayLoop = 60
 	}
 	putSimpleMonitor(sacloud.APIDefaultZone, value)
+	return value, nil
+}
 
+// Patch is fake implementation
+func (o *SimpleMonitorOp) Patch(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorPatchRequest) (*sacloud.SimpleMonitor, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToDelayLoop {
+		value.DelayLoop = 0
+	}
+	if param.PatchEmptyToEnabled {
+		value.Enabled = types.StringFlag(false)
+	}
+	if param.PatchEmptyToHealthCheck {
+		value.HealthCheck = nil
+	}
+	if param.PatchEmptyToNotifyEmailEnabled {
+		value.NotifyEmailEnabled = types.StringFlag(false)
+	}
+	if param.PatchEmptyToNotifyEmailHTML {
+		value.NotifyEmailHTML = types.StringFlag(false)
+	}
+	if param.PatchEmptyToNotifySlackEnabled {
+		value.NotifySlackEnabled = types.StringFlag(false)
+	}
+	if param.PatchEmptyToSlackWebhooksURL {
+		value.SlackWebhooksURL = ""
+	}
+
+	putSimpleMonitor(sacloud.APIDefaultZone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_ssh_key.go
+++ b/sacloud/fake/ops_ssh_key.go
@@ -2,7 +2,9 @@ package fake
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -80,6 +82,35 @@ func (o *SSHKeyOp) Update(ctx context.Context, id types.ID, param *sacloud.SSHKe
 		return nil, err
 	}
 	copySameNameField(param, value)
+
+	putSSHKey(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *SSHKeyOp) Patch(ctx context.Context, id types.ID, param *sacloud.SSHKeyPatchRequest) (*sacloud.SSHKey, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+
+	putSSHKey(sacloud.APIDefaultZone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_switch.go
+++ b/sacloud/fake/ops_switch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -55,6 +56,47 @@ func (o *SwitchOp) Update(ctx context.Context, zone string, id types.ID, param *
 
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putSwitch(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *SwitchOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.SwitchPatchRequest) (*sacloud.Switch, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToNetworkMaskLen {
+		value.NetworkMaskLen = 0
+	}
+	if param.PatchEmptyToDefaultRoute {
+		value.DefaultRoute = ""
+	}
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+
+	putSwitch(zone, value)
 	return value, nil
 }
 

--- a/sacloud/fake/ops_vpc_router.go
+++ b/sacloud/fake/ops_vpc_router.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -102,6 +103,44 @@ func (o *VPCRouterOp) Update(ctx context.Context, zone string, id types.ID, para
 	}
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
+
+	putVPCRouter(zone, value)
+	return value, nil
+}
+
+// Patch is fake implementation
+func (o *VPCRouterOp) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterPatchRequest) (*sacloud.VPCRouter, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, value); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	copySameNameField(param, value)
+
+	if param.PatchEmptyToDescription {
+		value.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		value.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		value.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToSettings {
+		value.Settings = nil
+	}
+
+	putVPCRouter(zone, value)
 	return value, nil
 }
 

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -45,6 +45,12 @@ type ArchiveUpdateStubResult struct {
 	Err     error
 }
 
+// ArchivePatchStubResult is expected values of the Patch operation
+type ArchivePatchStubResult struct {
+	Archive *sacloud.Archive
+	Err     error
+}
+
 // ArchiveDeleteStubResult is expected values of the Delete operation
 type ArchiveDeleteStubResult struct {
 	Err error
@@ -68,6 +74,7 @@ type ArchiveStub struct {
 	CreateBlankStubResult *ArchiveCreateBlankStubResult
 	ReadStubResult        *ArchiveReadStubResult
 	UpdateStubResult      *ArchiveUpdateStubResult
+	PatchStubResult       *ArchivePatchStubResult
 	DeleteStubResult      *ArchiveDeleteStubResult
 	OpenFTPStubResult     *ArchiveOpenFTPStubResult
 	CloseFTPStubResult    *ArchiveCloseFTPStubResult
@@ -116,6 +123,14 @@ func (s *ArchiveStub) Update(ctx context.Context, zone string, id types.ID, para
 		log.Fatal("ArchiveStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.Archive, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *ArchiveStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.ArchivePatchRequest) (*sacloud.Archive, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("ArchiveStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Archive, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -198,6 +213,12 @@ type AutoBackupUpdateStubResult struct {
 	Err        error
 }
 
+// AutoBackupPatchStubResult is expected values of the Patch operation
+type AutoBackupPatchStubResult struct {
+	AutoBackup *sacloud.AutoBackup
+	Err        error
+}
+
 // AutoBackupDeleteStubResult is expected values of the Delete operation
 type AutoBackupDeleteStubResult struct {
 	Err error
@@ -209,6 +230,7 @@ type AutoBackupStub struct {
 	CreateStubResult *AutoBackupCreateStubResult
 	ReadStubResult   *AutoBackupReadStubResult
 	UpdateStubResult *AutoBackupUpdateStubResult
+	PatchStubResult  *AutoBackupPatchStubResult
 	DeleteStubResult *AutoBackupDeleteStubResult
 }
 
@@ -247,6 +269,14 @@ func (s *AutoBackupStub) Update(ctx context.Context, zone string, id types.ID, p
 		log.Fatal("AutoBackupStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.AutoBackup, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *AutoBackupStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.AutoBackupPatchRequest) (*sacloud.AutoBackup, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("AutoBackupStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.AutoBackup, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -388,6 +418,12 @@ type BridgeUpdateStubResult struct {
 	Err    error
 }
 
+// BridgePatchStubResult is expected values of the Patch operation
+type BridgePatchStubResult struct {
+	Bridge *sacloud.Bridge
+	Err    error
+}
+
 // BridgeDeleteStubResult is expected values of the Delete operation
 type BridgeDeleteStubResult struct {
 	Err error
@@ -399,6 +435,7 @@ type BridgeStub struct {
 	CreateStubResult *BridgeCreateStubResult
 	ReadStubResult   *BridgeReadStubResult
 	UpdateStubResult *BridgeUpdateStubResult
+	PatchStubResult  *BridgePatchStubResult
 	DeleteStubResult *BridgeDeleteStubResult
 }
 
@@ -439,6 +476,14 @@ func (s *BridgeStub) Update(ctx context.Context, zone string, id types.ID, param
 	return s.UpdateStubResult.Bridge, s.UpdateStubResult.Err
 }
 
+// Patch is API call with trace log
+func (s *BridgeStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.BridgePatchRequest) (*sacloud.Bridge, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("BridgeStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Bridge, s.PatchStubResult.Err
+}
+
 // Delete is API call with trace log
 func (s *BridgeStub) Delete(ctx context.Context, zone string, id types.ID) error {
 	if s.DeleteStubResult == nil {
@@ -476,6 +521,12 @@ type CDROMUpdateStubResult struct {
 	Err   error
 }
 
+// CDROMPatchStubResult is expected values of the Patch operation
+type CDROMPatchStubResult struct {
+	CDROM *sacloud.CDROM
+	Err   error
+}
+
 // CDROMDeleteStubResult is expected values of the Delete operation
 type CDROMDeleteStubResult struct {
 	Err error
@@ -498,6 +549,7 @@ type CDROMStub struct {
 	CreateStubResult   *CDROMCreateStubResult
 	ReadStubResult     *CDROMReadStubResult
 	UpdateStubResult   *CDROMUpdateStubResult
+	PatchStubResult    *CDROMPatchStubResult
 	DeleteStubResult   *CDROMDeleteStubResult
 	OpenFTPStubResult  *CDROMOpenFTPStubResult
 	CloseFTPStubResult *CDROMCloseFTPStubResult
@@ -538,6 +590,14 @@ func (s *CDROMStub) Update(ctx context.Context, zone string, id types.ID, param 
 		log.Fatal("CDROMStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.CDROM, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *CDROMStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.CDROMPatchRequest) (*sacloud.CDROM, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("CDROMStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.CDROM, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -620,6 +680,12 @@ type DatabaseUpdateStubResult struct {
 	Err      error
 }
 
+// DatabasePatchStubResult is expected values of the Patch operation
+type DatabasePatchStubResult struct {
+	Database *sacloud.Database
+	Err      error
+}
+
 // DatabaseDeleteStubResult is expected values of the Delete operation
 type DatabaseDeleteStubResult struct {
 	Err error
@@ -681,6 +747,7 @@ type DatabaseStub struct {
 	CreateStubResult           *DatabaseCreateStubResult
 	ReadStubResult             *DatabaseReadStubResult
 	UpdateStubResult           *DatabaseUpdateStubResult
+	PatchStubResult            *DatabasePatchStubResult
 	DeleteStubResult           *DatabaseDeleteStubResult
 	ConfigStubResult           *DatabaseConfigStubResult
 	BootStubResult             *DatabaseBootStubResult
@@ -728,6 +795,14 @@ func (s *DatabaseStub) Update(ctx context.Context, zone string, id types.ID, par
 		log.Fatal("DatabaseStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.Database, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *DatabaseStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.DatabasePatchRequest) (*sacloud.Database, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("DatabaseStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Database, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -875,6 +950,12 @@ type DiskUpdateStubResult struct {
 	Err  error
 }
 
+// DiskPatchStubResult is expected values of the Patch operation
+type DiskPatchStubResult struct {
+	Disk *sacloud.Disk
+	Err  error
+}
+
 // DiskDeleteStubResult is expected values of the Delete operation
 type DiskDeleteStubResult struct {
 	Err error
@@ -899,6 +980,7 @@ type DiskStub struct {
 	InstallStubResult              *DiskInstallStubResult
 	ReadStubResult                 *DiskReadStubResult
 	UpdateStubResult               *DiskUpdateStubResult
+	PatchStubResult                *DiskPatchStubResult
 	DeleteStubResult               *DiskDeleteStubResult
 	MonitorStubResult              *DiskMonitorStubResult
 }
@@ -996,6 +1078,14 @@ func (s *DiskStub) Update(ctx context.Context, zone string, id types.ID, param *
 	return s.UpdateStubResult.Disk, s.UpdateStubResult.Err
 }
 
+// Patch is API call with trace log
+func (s *DiskStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.DiskPatchRequest) (*sacloud.Disk, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("DiskStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Disk, s.PatchStubResult.Err
+}
+
 // Delete is API call with trace log
 func (s *DiskStub) Delete(ctx context.Context, zone string, id types.ID) error {
 	if s.DeleteStubResult == nil {
@@ -1083,6 +1173,12 @@ type DNSUpdateStubResult struct {
 	Err error
 }
 
+// DNSPatchStubResult is expected values of the Patch operation
+type DNSPatchStubResult struct {
+	DNS *sacloud.DNS
+	Err error
+}
+
 // DNSDeleteStubResult is expected values of the Delete operation
 type DNSDeleteStubResult struct {
 	Err error
@@ -1094,6 +1190,7 @@ type DNSStub struct {
 	CreateStubResult *DNSCreateStubResult
 	ReadStubResult   *DNSReadStubResult
 	UpdateStubResult *DNSUpdateStubResult
+	PatchStubResult  *DNSPatchStubResult
 	DeleteStubResult *DNSDeleteStubResult
 }
 
@@ -1134,6 +1231,14 @@ func (s *DNSStub) Update(ctx context.Context, id types.ID, param *sacloud.DNSUpd
 	return s.UpdateStubResult.DNS, s.UpdateStubResult.Err
 }
 
+// Patch is API call with trace log
+func (s *DNSStub) Patch(ctx context.Context, id types.ID, param *sacloud.DNSPatchRequest) (*sacloud.DNS, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("DNSStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.DNS, s.PatchStubResult.Err
+}
+
 // Delete is API call with trace log
 func (s *DNSStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
@@ -1170,6 +1275,12 @@ type GSLBUpdateStubResult struct {
 	Err  error
 }
 
+// GSLBPatchStubResult is expected values of the Patch operation
+type GSLBPatchStubResult struct {
+	GSLB *sacloud.GSLB
+	Err  error
+}
+
 // GSLBDeleteStubResult is expected values of the Delete operation
 type GSLBDeleteStubResult struct {
 	Err error
@@ -1181,6 +1292,7 @@ type GSLBStub struct {
 	CreateStubResult *GSLBCreateStubResult
 	ReadStubResult   *GSLBReadStubResult
 	UpdateStubResult *GSLBUpdateStubResult
+	PatchStubResult  *GSLBPatchStubResult
 	DeleteStubResult *GSLBDeleteStubResult
 }
 
@@ -1221,6 +1333,14 @@ func (s *GSLBStub) Update(ctx context.Context, id types.ID, param *sacloud.GSLBU
 	return s.UpdateStubResult.GSLB, s.UpdateStubResult.Err
 }
 
+// Patch is API call with trace log
+func (s *GSLBStub) Patch(ctx context.Context, id types.ID, param *sacloud.GSLBPatchRequest) (*sacloud.GSLB, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("GSLBStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.GSLB, s.PatchStubResult.Err
+}
+
 // Delete is API call with trace log
 func (s *GSLBStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
@@ -1257,6 +1377,12 @@ type IconUpdateStubResult struct {
 	Err  error
 }
 
+// IconPatchStubResult is expected values of the Patch operation
+type IconPatchStubResult struct {
+	Icon *sacloud.Icon
+	Err  error
+}
+
 // IconDeleteStubResult is expected values of the Delete operation
 type IconDeleteStubResult struct {
 	Err error
@@ -1268,6 +1394,7 @@ type IconStub struct {
 	CreateStubResult *IconCreateStubResult
 	ReadStubResult   *IconReadStubResult
 	UpdateStubResult *IconUpdateStubResult
+	PatchStubResult  *IconPatchStubResult
 	DeleteStubResult *IconDeleteStubResult
 }
 
@@ -1308,6 +1435,14 @@ func (s *IconStub) Update(ctx context.Context, id types.ID, param *sacloud.IconU
 	return s.UpdateStubResult.Icon, s.UpdateStubResult.Err
 }
 
+// Patch is API call with trace log
+func (s *IconStub) Patch(ctx context.Context, id types.ID, param *sacloud.IconPatchRequest) (*sacloud.Icon, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("IconStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Icon, s.PatchStubResult.Err
+}
+
 // Delete is API call with trace log
 func (s *IconStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
@@ -1340,6 +1475,12 @@ type InterfaceReadStubResult struct {
 
 // InterfaceUpdateStubResult is expected values of the Update operation
 type InterfaceUpdateStubResult struct {
+	Interface *sacloud.Interface
+	Err       error
+}
+
+// InterfacePatchStubResult is expected values of the Patch operation
+type InterfacePatchStubResult struct {
 	Interface *sacloud.Interface
 	Err       error
 }
@@ -1386,6 +1527,7 @@ type InterfaceStub struct {
 	CreateStubResult                     *InterfaceCreateStubResult
 	ReadStubResult                       *InterfaceReadStubResult
 	UpdateStubResult                     *InterfaceUpdateStubResult
+	PatchStubResult                      *InterfacePatchStubResult
 	DeleteStubResult                     *InterfaceDeleteStubResult
 	MonitorStubResult                    *InterfaceMonitorStubResult
 	ConnectToSharedSegmentStubResult     *InterfaceConnectToSharedSegmentStubResult
@@ -1430,6 +1572,14 @@ func (s *InterfaceStub) Update(ctx context.Context, zone string, id types.ID, pa
 		log.Fatal("InterfaceStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.Interface, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *InterfaceStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.InterfacePatchRequest) (*sacloud.Interface, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("InterfaceStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Interface, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -1516,6 +1666,12 @@ type InternetUpdateStubResult struct {
 	Err      error
 }
 
+// InternetPatchStubResult is expected values of the Patch operation
+type InternetPatchStubResult struct {
+	Internet *sacloud.Internet
+	Err      error
+}
+
 // InternetDeleteStubResult is expected values of the Delete operation
 type InternetDeleteStubResult struct {
 	Err error
@@ -1567,6 +1723,7 @@ type InternetStub struct {
 	CreateStubResult          *InternetCreateStubResult
 	ReadStubResult            *InternetReadStubResult
 	UpdateStubResult          *InternetUpdateStubResult
+	PatchStubResult           *InternetPatchStubResult
 	DeleteStubResult          *InternetDeleteStubResult
 	UpdateBandWidthStubResult *InternetUpdateBandWidthStubResult
 	AddSubnetStubResult       *InternetAddSubnetStubResult
@@ -1612,6 +1769,14 @@ func (s *InternetStub) Update(ctx context.Context, zone string, id types.ID, par
 		log.Fatal("InternetStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.Internet, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *InternetStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.InternetPatchRequest) (*sacloud.Internet, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("InternetStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Internet, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -1937,6 +2102,12 @@ type LicenseUpdateStubResult struct {
 	Err     error
 }
 
+// LicensePatchStubResult is expected values of the Patch operation
+type LicensePatchStubResult struct {
+	License *sacloud.License
+	Err     error
+}
+
 // LicenseDeleteStubResult is expected values of the Delete operation
 type LicenseDeleteStubResult struct {
 	Err error
@@ -1948,6 +2119,7 @@ type LicenseStub struct {
 	CreateStubResult *LicenseCreateStubResult
 	ReadStubResult   *LicenseReadStubResult
 	UpdateStubResult *LicenseUpdateStubResult
+	PatchStubResult  *LicensePatchStubResult
 	DeleteStubResult *LicenseDeleteStubResult
 }
 
@@ -1986,6 +2158,14 @@ func (s *LicenseStub) Update(ctx context.Context, id types.ID, param *sacloud.Li
 		log.Fatal("LicenseStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.License, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *LicenseStub) Patch(ctx context.Context, id types.ID, param *sacloud.LicensePatchRequest) (*sacloud.License, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("LicenseStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.License, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -2067,6 +2247,12 @@ type LoadBalancerUpdateStubResult struct {
 	Err          error
 }
 
+// LoadBalancerPatchStubResult is expected values of the Patch operation
+type LoadBalancerPatchStubResult struct {
+	LoadBalancer *sacloud.LoadBalancer
+	Err          error
+}
+
 // LoadBalancerDeleteStubResult is expected values of the Delete operation
 type LoadBalancerDeleteStubResult struct {
 	Err error
@@ -2110,6 +2296,7 @@ type LoadBalancerStub struct {
 	CreateStubResult           *LoadBalancerCreateStubResult
 	ReadStubResult             *LoadBalancerReadStubResult
 	UpdateStubResult           *LoadBalancerUpdateStubResult
+	PatchStubResult            *LoadBalancerPatchStubResult
 	DeleteStubResult           *LoadBalancerDeleteStubResult
 	ConfigStubResult           *LoadBalancerConfigStubResult
 	BootStubResult             *LoadBalancerBootStubResult
@@ -2154,6 +2341,14 @@ func (s *LoadBalancerStub) Update(ctx context.Context, zone string, id types.ID,
 		log.Fatal("LoadBalancerStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.LoadBalancer, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *LoadBalancerStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerPatchRequest) (*sacloud.LoadBalancer, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("LoadBalancerStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.LoadBalancer, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -2236,6 +2431,12 @@ type MobileGatewayReadStubResult struct {
 
 // MobileGatewayUpdateStubResult is expected values of the Update operation
 type MobileGatewayUpdateStubResult struct {
+	MobileGateway *sacloud.MobileGateway
+	Err           error
+}
+
+// MobileGatewayPatchStubResult is expected values of the Patch operation
+type MobileGatewayPatchStubResult struct {
 	MobileGateway *sacloud.MobileGateway
 	Err           error
 }
@@ -2353,6 +2554,7 @@ type MobileGatewayStub struct {
 	CreateStubResult               *MobileGatewayCreateStubResult
 	ReadStubResult                 *MobileGatewayReadStubResult
 	UpdateStubResult               *MobileGatewayUpdateStubResult
+	PatchStubResult                *MobileGatewayPatchStubResult
 	DeleteStubResult               *MobileGatewayDeleteStubResult
 	ConfigStubResult               *MobileGatewayConfigStubResult
 	BootStubResult                 *MobileGatewayBootStubResult
@@ -2410,6 +2612,14 @@ func (s *MobileGatewayStub) Update(ctx context.Context, zone string, id types.ID
 		log.Fatal("MobileGatewayStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.MobileGateway, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *MobileGatewayStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayPatchRequest) (*sacloud.MobileGateway, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("MobileGatewayStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.MobileGateway, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -2600,6 +2810,12 @@ type NFSUpdateStubResult struct {
 	Err error
 }
 
+// NFSPatchStubResult is expected values of the Patch operation
+type NFSPatchStubResult struct {
+	NFS *sacloud.NFS
+	Err error
+}
+
 // NFSDeleteStubResult is expected values of the Delete operation
 type NFSDeleteStubResult struct {
 	Err error
@@ -2638,6 +2854,7 @@ type NFSStub struct {
 	CreateStubResult              *NFSCreateStubResult
 	ReadStubResult                *NFSReadStubResult
 	UpdateStubResult              *NFSUpdateStubResult
+	PatchStubResult               *NFSPatchStubResult
 	DeleteStubResult              *NFSDeleteStubResult
 	BootStubResult                *NFSBootStubResult
 	ShutdownStubResult            *NFSShutdownStubResult
@@ -2681,6 +2898,14 @@ func (s *NFSStub) Update(ctx context.Context, zone string, id types.ID, param *s
 		log.Fatal("NFSStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.NFS, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *NFSStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.NFSPatchRequest) (*sacloud.NFS, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("NFSStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.NFS, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -2759,6 +2984,12 @@ type NoteUpdateStubResult struct {
 	Err  error
 }
 
+// NotePatchStubResult is expected values of the Patch operation
+type NotePatchStubResult struct {
+	Note *sacloud.Note
+	Err  error
+}
+
 // NoteDeleteStubResult is expected values of the Delete operation
 type NoteDeleteStubResult struct {
 	Err error
@@ -2770,6 +3001,7 @@ type NoteStub struct {
 	CreateStubResult *NoteCreateStubResult
 	ReadStubResult   *NoteReadStubResult
 	UpdateStubResult *NoteUpdateStubResult
+	PatchStubResult  *NotePatchStubResult
 	DeleteStubResult *NoteDeleteStubResult
 }
 
@@ -2810,6 +3042,14 @@ func (s *NoteStub) Update(ctx context.Context, id types.ID, param *sacloud.NoteU
 	return s.UpdateStubResult.Note, s.UpdateStubResult.Err
 }
 
+// Patch is API call with trace log
+func (s *NoteStub) Patch(ctx context.Context, id types.ID, param *sacloud.NotePatchRequest) (*sacloud.Note, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("NoteStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Note, s.PatchStubResult.Err
+}
+
 // Delete is API call with trace log
 func (s *NoteStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
@@ -2846,6 +3086,12 @@ type PacketFilterUpdateStubResult struct {
 	Err          error
 }
 
+// PacketFilterPatchStubResult is expected values of the Patch operation
+type PacketFilterPatchStubResult struct {
+	PacketFilter *sacloud.PacketFilter
+	Err          error
+}
+
 // PacketFilterDeleteStubResult is expected values of the Delete operation
 type PacketFilterDeleteStubResult struct {
 	Err error
@@ -2857,6 +3103,7 @@ type PacketFilterStub struct {
 	CreateStubResult *PacketFilterCreateStubResult
 	ReadStubResult   *PacketFilterReadStubResult
 	UpdateStubResult *PacketFilterUpdateStubResult
+	PatchStubResult  *PacketFilterPatchStubResult
 	DeleteStubResult *PacketFilterDeleteStubResult
 }
 
@@ -2897,6 +3144,14 @@ func (s *PacketFilterStub) Update(ctx context.Context, zone string, id types.ID,
 	return s.UpdateStubResult.PacketFilter, s.UpdateStubResult.Err
 }
 
+// Patch is API call with trace log
+func (s *PacketFilterStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.PacketFilterPatchRequest) (*sacloud.PacketFilter, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("PacketFilterStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.PacketFilter, s.PatchStubResult.Err
+}
+
 // Delete is API call with trace log
 func (s *PacketFilterStub) Delete(ctx context.Context, zone string, id types.ID) error {
 	if s.DeleteStubResult == nil {
@@ -2933,6 +3188,12 @@ type PrivateHostUpdateStubResult struct {
 	Err         error
 }
 
+// PrivateHostPatchStubResult is expected values of the Patch operation
+type PrivateHostPatchStubResult struct {
+	PrivateHost *sacloud.PrivateHost
+	Err         error
+}
+
 // PrivateHostDeleteStubResult is expected values of the Delete operation
 type PrivateHostDeleteStubResult struct {
 	Err error
@@ -2944,6 +3205,7 @@ type PrivateHostStub struct {
 	CreateStubResult *PrivateHostCreateStubResult
 	ReadStubResult   *PrivateHostReadStubResult
 	UpdateStubResult *PrivateHostUpdateStubResult
+	PatchStubResult  *PrivateHostPatchStubResult
 	DeleteStubResult *PrivateHostDeleteStubResult
 }
 
@@ -2982,6 +3244,14 @@ func (s *PrivateHostStub) Update(ctx context.Context, zone string, id types.ID, 
 		log.Fatal("PrivateHostStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.PrivateHost, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *PrivateHostStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.PrivateHostPatchRequest) (*sacloud.PrivateHost, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("PrivateHostStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.PrivateHost, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -3063,6 +3333,12 @@ type ProxyLBUpdateStubResult struct {
 	Err     error
 }
 
+// ProxyLBPatchStubResult is expected values of the Patch operation
+type ProxyLBPatchStubResult struct {
+	ProxyLB *sacloud.ProxyLB
+	Err     error
+}
+
 // ProxyLBDeleteStubResult is expected values of the Delete operation
 type ProxyLBDeleteStubResult struct {
 	Err error
@@ -3114,6 +3390,7 @@ type ProxyLBStub struct {
 	CreateStubResult               *ProxyLBCreateStubResult
 	ReadStubResult                 *ProxyLBReadStubResult
 	UpdateStubResult               *ProxyLBUpdateStubResult
+	PatchStubResult                *ProxyLBPatchStubResult
 	DeleteStubResult               *ProxyLBDeleteStubResult
 	ChangePlanStubResult           *ProxyLBChangePlanStubResult
 	GetCertificatesStubResult      *ProxyLBGetCertificatesStubResult
@@ -3159,6 +3436,14 @@ func (s *ProxyLBStub) Update(ctx context.Context, id types.ID, param *sacloud.Pr
 		log.Fatal("ProxyLBStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.ProxyLB, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *ProxyLBStub) Patch(ctx context.Context, id types.ID, param *sacloud.ProxyLBPatchRequest) (*sacloud.ProxyLB, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("ProxyLBStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.ProxyLB, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -3296,6 +3581,12 @@ type ServerUpdateStubResult struct {
 	Err    error
 }
 
+// ServerPatchStubResult is expected values of the Patch operation
+type ServerPatchStubResult struct {
+	Server *sacloud.Server
+	Err    error
+}
+
 // ServerDeleteStubResult is expected values of the Delete operation
 type ServerDeleteStubResult struct {
 	Err error
@@ -3360,6 +3651,7 @@ type ServerStub struct {
 	CreateStubResult          *ServerCreateStubResult
 	ReadStubResult            *ServerReadStubResult
 	UpdateStubResult          *ServerUpdateStubResult
+	PatchStubResult           *ServerPatchStubResult
 	DeleteStubResult          *ServerDeleteStubResult
 	DeleteWithDisksStubResult *ServerDeleteWithDisksStubResult
 	ChangePlanStubResult      *ServerChangePlanStubResult
@@ -3408,6 +3700,14 @@ func (s *ServerStub) Update(ctx context.Context, zone string, id types.ID, param
 		log.Fatal("ServerStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.Server, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *ServerStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.ServerPatchRequest) (*sacloud.Server, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("ServerStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Server, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -3597,6 +3897,12 @@ type SIMUpdateStubResult struct {
 	Err error
 }
 
+// SIMPatchStubResult is expected values of the Patch operation
+type SIMPatchStubResult struct {
+	SIM *sacloud.SIM
+	Err error
+}
+
 // SIMDeleteStubResult is expected values of the Delete operation
 type SIMDeleteStubResult struct {
 	Err error
@@ -3667,6 +3973,7 @@ type SIMStub struct {
 	CreateStubResult             *SIMCreateStubResult
 	ReadStubResult               *SIMReadStubResult
 	UpdateStubResult             *SIMUpdateStubResult
+	PatchStubResult              *SIMPatchStubResult
 	DeleteStubResult             *SIMDeleteStubResult
 	ActivateStubResult           *SIMActivateStubResult
 	DeactivateStubResult         *SIMDeactivateStubResult
@@ -3716,6 +4023,14 @@ func (s *SIMStub) Update(ctx context.Context, id types.ID, param *sacloud.SIMUpd
 		log.Fatal("SIMStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.SIM, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *SIMStub) Patch(ctx context.Context, id types.ID, param *sacloud.SIMPatchRequest) (*sacloud.SIM, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("SIMStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.SIM, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -3842,6 +4157,12 @@ type SimpleMonitorUpdateStubResult struct {
 	Err           error
 }
 
+// SimpleMonitorPatchStubResult is expected values of the Patch operation
+type SimpleMonitorPatchStubResult struct {
+	SimpleMonitor *sacloud.SimpleMonitor
+	Err           error
+}
+
 // SimpleMonitorDeleteStubResult is expected values of the Delete operation
 type SimpleMonitorDeleteStubResult struct {
 	Err error
@@ -3865,6 +4186,7 @@ type SimpleMonitorStub struct {
 	CreateStubResult              *SimpleMonitorCreateStubResult
 	ReadStubResult                *SimpleMonitorReadStubResult
 	UpdateStubResult              *SimpleMonitorUpdateStubResult
+	PatchStubResult               *SimpleMonitorPatchStubResult
 	DeleteStubResult              *SimpleMonitorDeleteStubResult
 	MonitorResponseTimeStubResult *SimpleMonitorMonitorResponseTimeStubResult
 	HealthStatusStubResult        *SimpleMonitorHealthStatusStubResult
@@ -3905,6 +4227,14 @@ func (s *SimpleMonitorStub) Update(ctx context.Context, id types.ID, param *sacl
 		log.Fatal("SimpleMonitorStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.SimpleMonitor, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *SimpleMonitorStub) Patch(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorPatchRequest) (*sacloud.SimpleMonitor, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("SimpleMonitorStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.SimpleMonitor, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -3965,6 +4295,12 @@ type SSHKeyUpdateStubResult struct {
 	Err    error
 }
 
+// SSHKeyPatchStubResult is expected values of the Patch operation
+type SSHKeyPatchStubResult struct {
+	SSHKey *sacloud.SSHKey
+	Err    error
+}
+
 // SSHKeyDeleteStubResult is expected values of the Delete operation
 type SSHKeyDeleteStubResult struct {
 	Err error
@@ -3977,6 +4313,7 @@ type SSHKeyStub struct {
 	GenerateStubResult *SSHKeyGenerateStubResult
 	ReadStubResult     *SSHKeyReadStubResult
 	UpdateStubResult   *SSHKeyUpdateStubResult
+	PatchStubResult    *SSHKeyPatchStubResult
 	DeleteStubResult   *SSHKeyDeleteStubResult
 }
 
@@ -4025,6 +4362,14 @@ func (s *SSHKeyStub) Update(ctx context.Context, id types.ID, param *sacloud.SSH
 	return s.UpdateStubResult.SSHKey, s.UpdateStubResult.Err
 }
 
+// Patch is API call with trace log
+func (s *SSHKeyStub) Patch(ctx context.Context, id types.ID, param *sacloud.SSHKeyPatchRequest) (*sacloud.SSHKey, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("SSHKeyStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.SSHKey, s.PatchStubResult.Err
+}
+
 // Delete is API call with trace log
 func (s *SSHKeyStub) Delete(ctx context.Context, id types.ID) error {
 	if s.DeleteStubResult == nil {
@@ -4061,6 +4406,12 @@ type SwitchUpdateStubResult struct {
 	Err    error
 }
 
+// SwitchPatchStubResult is expected values of the Patch operation
+type SwitchPatchStubResult struct {
+	Switch *sacloud.Switch
+	Err    error
+}
+
 // SwitchDeleteStubResult is expected values of the Delete operation
 type SwitchDeleteStubResult struct {
 	Err error
@@ -4082,6 +4433,7 @@ type SwitchStub struct {
 	CreateStubResult               *SwitchCreateStubResult
 	ReadStubResult                 *SwitchReadStubResult
 	UpdateStubResult               *SwitchUpdateStubResult
+	PatchStubResult                *SwitchPatchStubResult
 	DeleteStubResult               *SwitchDeleteStubResult
 	ConnectToBridgeStubResult      *SwitchConnectToBridgeStubResult
 	DisconnectFromBridgeStubResult *SwitchDisconnectFromBridgeStubResult
@@ -4122,6 +4474,14 @@ func (s *SwitchStub) Update(ctx context.Context, zone string, id types.ID, param
 		log.Fatal("SwitchStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.Switch, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *SwitchStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.SwitchPatchRequest) (*sacloud.Switch, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("SwitchStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.Switch, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log
@@ -4172,6 +4532,12 @@ type VPCRouterReadStubResult struct {
 
 // VPCRouterUpdateStubResult is expected values of the Update operation
 type VPCRouterUpdateStubResult struct {
+	VPCRouter *sacloud.VPCRouter
+	Err       error
+}
+
+// VPCRouterPatchStubResult is expected values of the Patch operation
+type VPCRouterPatchStubResult struct {
 	VPCRouter *sacloud.VPCRouter
 	Err       error
 }
@@ -4229,6 +4595,7 @@ type VPCRouterStub struct {
 	CreateStubResult               *VPCRouterCreateStubResult
 	ReadStubResult                 *VPCRouterReadStubResult
 	UpdateStubResult               *VPCRouterUpdateStubResult
+	PatchStubResult                *VPCRouterPatchStubResult
 	DeleteStubResult               *VPCRouterDeleteStubResult
 	ConfigStubResult               *VPCRouterConfigStubResult
 	BootStubResult                 *VPCRouterBootStubResult
@@ -4275,6 +4642,14 @@ func (s *VPCRouterStub) Update(ctx context.Context, zone string, id types.ID, pa
 		log.Fatal("VPCRouterStub.UpdateStubResult is not set")
 	}
 	return s.UpdateStubResult.VPCRouter, s.UpdateStubResult.Err
+}
+
+// Patch is API call with trace log
+func (s *VPCRouterStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterPatchRequest) (*sacloud.VPCRouter, error) {
+	if s.PatchStubResult == nil {
+		log.Fatal("VPCRouterStub.PatchStubResult is not set")
+	}
+	return s.PatchStubResult.VPCRouter, s.PatchStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/test/archive_op_test.go
+++ b/sacloud/test/archive_op_test.go
@@ -29,6 +29,8 @@ func TestArchiveOpCRUD(t *testing.T) {
 					createArchiveParam.SourceArchiveID = a.ID
 					createArchiveExpected.SourceArchiveID = a.ID
 					createArchiveExpected.SourceArchiveAvailability = a.Availability
+					patchArchiveExpected.SourceArchiveID = a.ID
+					patchArchiveExpected.SourceArchiveAvailability = a.Availability
 					updateArchiveExpected.SourceArchiveID = a.ID
 					updateArchiveExpected.SourceArchiveAvailability = a.Availability
 					updateArchiveToMinExpected.SourceArchiveID = a.ID
@@ -57,6 +59,13 @@ func TestArchiveOpCRUD(t *testing.T) {
 		},
 
 		Updates: []*testutil.CRUDTestFunc{
+			{
+				Func: testArchivePatch,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchArchiveExpected,
+					IgnoreFields: ignoreArchiveFields,
+				}),
+			},
 			{
 				Func: testArchiveUpdate,
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
@@ -110,6 +119,17 @@ var (
 		Scope:       types.Scopes.User,
 		DiskPlanID:  types.DiskPlans.HDD,
 	}
+
+	patchArchiveParam = &sacloud.ArchivePatchRequest{
+		Description: "desc-patched",
+	}
+	patchArchiveExpected = &sacloud.Archive{
+		Name:        createArchiveParam.Name,
+		Description: patchArchiveParam.Description,
+		Tags:        createArchiveParam.Tags,
+		Scope:       types.Scopes.User,
+		DiskPlanID:  types.DiskPlans.HDD,
+	}
 	updateArchiveParam = &sacloud.ArchiveUpdateRequest{
 		Name:        testutil.ResourceName("archive-upd"),
 		Description: "desc-upd",
@@ -144,6 +164,11 @@ func testArchiveCreate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) 
 func testArchiveRead(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewArchiveOp(caller)
 	return client.Read(ctx, testZone, ctx.ID)
+}
+
+func testArchivePatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewArchiveOp(caller)
+	return client.Patch(ctx, testZone, ctx.ID, patchArchiveParam)
 }
 
 func testArchiveUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/sacloud/test/auto_backup_op_test.go
+++ b/sacloud/test/auto_backup_op_test.go
@@ -66,6 +66,13 @@ func TestAutoBackupOpCRUD(t *testing.T) {
 				}),
 			},
 			{
+				Func: testAutoBackupPatch,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchAutoBackupExpected,
+					IgnoreFields: ignoreAutoBackupFields,
+				}),
+			},
+			{
 				Func: testAutoBackupUpdateToMin,
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
 					ExpectValue:  updateAutoBackupToMinExpected,
@@ -142,6 +149,19 @@ var (
 		MaximumNumberOfArchives: updateAutoBackupParam.MaximumNumberOfArchives,
 		IconID:                  testIconID,
 	}
+	patchAutoBackupParam = &sacloud.AutoBackupPatchRequest{
+		Description:      "desc-pached",
+		PatchEmptyToTags: true,
+	}
+	patchAutoBackupExpected = &sacloud.AutoBackup{
+		Name:        updateAutoBackupParam.Name,
+		Description: patchAutoBackupParam.Description,
+		//Tags:                    updateAutoBackupParam.Tags,
+		Availability:            types.Availabilities.Available,
+		BackupSpanWeekdays:      updateAutoBackupParam.BackupSpanWeekdays,
+		MaximumNumberOfArchives: updateAutoBackupParam.MaximumNumberOfArchives,
+		IconID:                  testIconID,
+	}
 	updateAutoBackupToMinParam = &sacloud.AutoBackupUpdateRequest{
 		Name: testutil.ResourceName("auto-backup-to-min"),
 		BackupSpanWeekdays: []types.EBackupSpanWeekday{
@@ -170,6 +190,11 @@ func testAutoBackupRead(ctx *testutil.CRUDTestContext, caller sacloud.APICaller)
 func testAutoBackupUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewAutoBackupOp(caller)
 	return client.Update(ctx, testZone, ctx.ID, updateAutoBackupParam)
+}
+
+func testAutoBackupPatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewAutoBackupOp(caller)
+	return client.Patch(ctx, testZone, ctx.ID, patchAutoBackupParam)
 }
 
 func testAutoBackupUpdateToMin(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/sacloud/test/dns_op_test.go
+++ b/sacloud/test/dns_op_test.go
@@ -32,6 +32,13 @@ func TestDNSOp_CRUD(t *testing.T) {
 
 		Updates: []*testutil.CRUDTestFunc{
 			{
+				Func: testDNSPatch,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchDNSExpected,
+					IgnoreFields: ignoreDNSFields,
+				}),
+			},
+			{
 				Func: testDNSUpdate,
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
 					ExpectValue:  updateDNSExpected,
@@ -88,6 +95,33 @@ var (
 		DNSZone:      createDNSParam.Name,
 		Records:      createDNSParam.Records,
 	}
+	patchDNSParam = &sacloud.DNSPatchRequest{
+		Records: []*sacloud.DNSRecord{
+			{
+				Name:  "host1",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.11",
+			},
+			{
+				Name:  "host2",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.12",
+			},
+			{
+				Name:  "host3",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.13",
+			},
+		},
+	}
+	patchDNSExpected = &sacloud.DNS{
+		Name:         createDNSParam.Name,
+		Description:  createDNSParam.Description,
+		Tags:         createDNSParam.Tags,
+		Availability: types.Availabilities.Available,
+		DNSZone:      createDNSParam.Name,
+		Records:      patchDNSParam.Records,
+	}
 	updateDNSParam = &sacloud.DNSUpdateRequest{
 		Description: "desc-upd",
 		Tags:        []string{"tag1-upd", "tag2-upd"},
@@ -135,6 +169,11 @@ func testDNSCreate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (int
 func testDNSRead(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewDNSOp(caller)
 	return client.Read(ctx, ctx.ID)
+}
+
+func testDNSPatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewDNSOp(caller)
+	return client.Patch(ctx, ctx.ID, patchDNSParam)
 }
 
 func testDNSUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -320,6 +320,41 @@ func (t *ArchiveTracer) Update(ctx context.Context, zone string, id types.ID, pa
 	return resultArchive, err
 }
 
+// Patch is API call with trace log
+func (t *ArchiveTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.ArchivePatchRequest) (*sacloud.Archive, error) {
+	log.Println("[TRACE] ArchiveAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                     `json:"id"`
+		Argparam *sacloud.ArchivePatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ArchiveAPI.Patch end")
+	}()
+
+	resultArchive, err := t.Internal.Patch(ctx, zone, id, param)
+	targetResults := struct {
+		Archive *sacloud.Archive
+		Error   error
+	}{
+		Archive: resultArchive,
+		Error:   err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultArchive, err
+}
+
 // Delete is API call with trace log
 func (t *ArchiveTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] ArchiveAPI.Delete start")
@@ -597,6 +632,41 @@ func (t *AutoBackupTracer) Update(ctx context.Context, zone string, id types.ID,
 	}()
 
 	resultAutoBackup, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		AutoBackup *sacloud.AutoBackup
+		Error      error
+	}{
+		AutoBackup: resultAutoBackup,
+		Error:      err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultAutoBackup, err
+}
+
+// Patch is API call with trace log
+func (t *AutoBackupTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.AutoBackupPatchRequest) (*sacloud.AutoBackup, error) {
+	log.Println("[TRACE] AutoBackupAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                        `json:"id"`
+		Argparam *sacloud.AutoBackupPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoBackupAPI.Patch end")
+	}()
+
+	resultAutoBackup, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		AutoBackup *sacloud.AutoBackup
 		Error      error
@@ -1004,6 +1074,41 @@ func (t *BridgeTracer) Update(ctx context.Context, zone string, id types.ID, par
 	return resultBridge, err
 }
 
+// Patch is API call with trace log
+func (t *BridgeTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.BridgePatchRequest) (*sacloud.Bridge, error) {
+	log.Println("[TRACE] BridgeAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                    `json:"id"`
+		Argparam *sacloud.BridgePatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] BridgeAPI.Patch end")
+	}()
+
+	resultBridge, err := t.Internal.Patch(ctx, zone, id, param)
+	targetResults := struct {
+		Bridge *sacloud.Bridge
+		Error  error
+	}{
+		Bridge: resultBridge,
+		Error:  err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultBridge, err
+}
+
 // Delete is API call with trace log
 func (t *BridgeTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] BridgeAPI.Delete start")
@@ -1173,6 +1278,41 @@ func (t *CDROMTracer) Update(ctx context.Context, zone string, id types.ID, para
 	}()
 
 	resultCDROM, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		CDROM *sacloud.CDROM
+		Error error
+	}{
+		CDROM: resultCDROM,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultCDROM, err
+}
+
+// Patch is API call with trace log
+func (t *CDROMTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.CDROMPatchRequest) (*sacloud.CDROM, error) {
+	log.Println("[TRACE] CDROMAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                   `json:"id"`
+		Argparam *sacloud.CDROMPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] CDROMAPI.Patch end")
+	}()
+
+	resultCDROM, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		CDROM *sacloud.CDROM
 		Error error
@@ -1467,6 +1607,41 @@ func (t *DatabaseTracer) Update(ctx context.Context, zone string, id types.ID, p
 	}()
 
 	resultDatabase, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		Database *sacloud.Database
+		Error    error
+	}{
+		Database: resultDatabase,
+		Error:    err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultDatabase, err
+}
+
+// Patch is API call with trace log
+func (t *DatabaseTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.DatabasePatchRequest) (*sacloud.Database, error) {
+	log.Println("[TRACE] DatabaseAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                      `json:"id"`
+		Argparam *sacloud.DatabasePatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] DatabaseAPI.Patch end")
+	}()
+
+	resultDatabase, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		Database *sacloud.Database
 		Error    error
@@ -2198,6 +2373,41 @@ func (t *DiskTracer) Update(ctx context.Context, zone string, id types.ID, param
 	return resultDisk, err
 }
 
+// Patch is API call with trace log
+func (t *DiskTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.DiskPatchRequest) (*sacloud.Disk, error) {
+	log.Println("[TRACE] DiskAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                  `json:"id"`
+		Argparam *sacloud.DiskPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] DiskAPI.Patch end")
+	}()
+
+	resultDisk, err := t.Internal.Patch(ctx, zone, id, param)
+	targetResults := struct {
+		Disk  *sacloud.Disk
+		Error error
+	}{
+		Disk:  resultDisk,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultDisk, err
+}
+
 // Delete is API call with trace log
 func (t *DiskTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] DiskAPI.Delete start")
@@ -2488,6 +2698,39 @@ func (t *DNSTracer) Update(ctx context.Context, id types.ID, param *sacloud.DNSU
 	return resultDNS, err
 }
 
+// Patch is API call with trace log
+func (t *DNSTracer) Patch(ctx context.Context, id types.ID, param *sacloud.DNSPatchRequest) (*sacloud.DNS, error) {
+	log.Println("[TRACE] DNSAPI.Patch start")
+	targetArguments := struct {
+		Argid    types.ID                 `json:"id"`
+		Argparam *sacloud.DNSPatchRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] DNSAPI.Patch end")
+	}()
+
+	resultDNS, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		DNS   *sacloud.DNS
+		Error error
+	}{
+		DNS:   resultDNS,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultDNS, err
+}
+
 // Delete is API call with trace log
 func (t *DNSTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] DNSAPI.Delete start")
@@ -2645,6 +2888,39 @@ func (t *GSLBTracer) Update(ctx context.Context, id types.ID, param *sacloud.GSL
 	}()
 
 	resultGSLB, err := t.Internal.Update(ctx, id, param)
+	targetResults := struct {
+		GSLB  *sacloud.GSLB
+		Error error
+	}{
+		GSLB:  resultGSLB,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultGSLB, err
+}
+
+// Patch is API call with trace log
+func (t *GSLBTracer) Patch(ctx context.Context, id types.ID, param *sacloud.GSLBPatchRequest) (*sacloud.GSLB, error) {
+	log.Println("[TRACE] GSLBAPI.Patch start")
+	targetArguments := struct {
+		Argid    types.ID                  `json:"id"`
+		Argparam *sacloud.GSLBPatchRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] GSLBAPI.Patch end")
+	}()
+
+	resultGSLB, err := t.Internal.Patch(ctx, id, param)
 	targetResults := struct {
 		GSLB  *sacloud.GSLB
 		Error error
@@ -2830,6 +3106,39 @@ func (t *IconTracer) Update(ctx context.Context, id types.ID, param *sacloud.Ico
 	return resultIcon, err
 }
 
+// Patch is API call with trace log
+func (t *IconTracer) Patch(ctx context.Context, id types.ID, param *sacloud.IconPatchRequest) (*sacloud.Icon, error) {
+	log.Println("[TRACE] IconAPI.Patch start")
+	targetArguments := struct {
+		Argid    types.ID                  `json:"id"`
+		Argparam *sacloud.IconPatchRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] IconAPI.Patch end")
+	}()
+
+	resultIcon, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		Icon  *sacloud.Icon
+		Error error
+	}{
+		Icon:  resultIcon,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultIcon, err
+}
+
 // Delete is API call with trace log
 func (t *IconTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] IconAPI.Delete start")
@@ -2995,6 +3304,41 @@ func (t *InterfaceTracer) Update(ctx context.Context, zone string, id types.ID, 
 	}()
 
 	resultInterface, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		Interface *sacloud.Interface
+		Error     error
+	}{
+		Interface: resultInterface,
+		Error:     err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultInterface, err
+}
+
+// Patch is API call with trace log
+func (t *InterfaceTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.InterfacePatchRequest) (*sacloud.Interface, error) {
+	log.Println("[TRACE] InterfaceAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                       `json:"id"`
+		Argparam *sacloud.InterfacePatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] InterfaceAPI.Patch end")
+	}()
+
+	resultInterface, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		Interface *sacloud.Interface
 		Error     error
@@ -3370,6 +3714,41 @@ func (t *InternetTracer) Update(ctx context.Context, zone string, id types.ID, p
 	}()
 
 	resultInternet, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		Internet *sacloud.Internet
+		Error    error
+	}{
+		Internet: resultInternet,
+		Error:    err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultInternet, err
+}
+
+// Patch is API call with trace log
+func (t *InternetTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.InternetPatchRequest) (*sacloud.Internet, error) {
+	log.Println("[TRACE] InternetAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                      `json:"id"`
+		Argparam *sacloud.InternetPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] InternetAPI.Patch end")
+	}()
+
+	resultInternet, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		Internet *sacloud.Internet
 		Error    error
@@ -4256,6 +4635,39 @@ func (t *LicenseTracer) Update(ctx context.Context, id types.ID, param *sacloud.
 	return resultLicense, err
 }
 
+// Patch is API call with trace log
+func (t *LicenseTracer) Patch(ctx context.Context, id types.ID, param *sacloud.LicensePatchRequest) (*sacloud.License, error) {
+	log.Println("[TRACE] LicenseAPI.Patch start")
+	targetArguments := struct {
+		Argid    types.ID                     `json:"id"`
+		Argparam *sacloud.LicensePatchRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LicenseAPI.Patch end")
+	}()
+
+	resultLicense, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		License *sacloud.License
+		Error   error
+	}{
+		License: resultLicense,
+		Error:   err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLicense, err
+}
+
 // Delete is API call with trace log
 func (t *LicenseTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] LicenseAPI.Delete start")
@@ -4499,6 +4911,41 @@ func (t *LoadBalancerTracer) Update(ctx context.Context, zone string, id types.I
 	}()
 
 	resultLoadBalancer, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		LoadBalancer *sacloud.LoadBalancer
+		Error        error
+	}{
+		LoadBalancer: resultLoadBalancer,
+		Error:        err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLoadBalancer, err
+}
+
+// Patch is API call with trace log
+func (t *LoadBalancerTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerPatchRequest) (*sacloud.LoadBalancer, error) {
+	log.Println("[TRACE] LoadBalancerAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                          `json:"id"`
+		Argparam *sacloud.LoadBalancerPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LoadBalancerAPI.Patch end")
+	}()
+
+	resultLoadBalancer, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		LoadBalancer *sacloud.LoadBalancer
 		Error        error
@@ -4874,6 +5321,41 @@ func (t *MobileGatewayTracer) Update(ctx context.Context, zone string, id types.
 	}()
 
 	resultMobileGateway, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		MobileGateway *sacloud.MobileGateway
+		Error         error
+	}{
+		MobileGateway: resultMobileGateway,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultMobileGateway, err
+}
+
+// Patch is API call with trace log
+func (t *MobileGatewayTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayPatchRequest) (*sacloud.MobileGateway, error) {
+	log.Println("[TRACE] MobileGatewayAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                           `json:"id"`
+		Argparam *sacloud.MobileGatewayPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.Patch end")
+	}()
+
+	resultMobileGateway, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		MobileGateway *sacloud.MobileGateway
 		Error         error
@@ -5690,6 +6172,41 @@ func (t *NFSTracer) Update(ctx context.Context, zone string, id types.ID, param 
 	return resultNFS, err
 }
 
+// Patch is API call with trace log
+func (t *NFSTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.NFSPatchRequest) (*sacloud.NFS, error) {
+	log.Println("[TRACE] NFSAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                 `json:"id"`
+		Argparam *sacloud.NFSPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] NFSAPI.Patch end")
+	}()
+
+	resultNFS, err := t.Internal.Patch(ctx, zone, id, param)
+	targetResults := struct {
+		NFS   *sacloud.NFS
+		Error error
+	}{
+		NFS:   resultNFS,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultNFS, err
+}
+
 // Delete is API call with trace log
 func (t *NFSTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] NFSAPI.Delete start")
@@ -6028,6 +6545,39 @@ func (t *NoteTracer) Update(ctx context.Context, id types.ID, param *sacloud.Not
 	return resultNote, err
 }
 
+// Patch is API call with trace log
+func (t *NoteTracer) Patch(ctx context.Context, id types.ID, param *sacloud.NotePatchRequest) (*sacloud.Note, error) {
+	log.Println("[TRACE] NoteAPI.Patch start")
+	targetArguments := struct {
+		Argid    types.ID                  `json:"id"`
+		Argparam *sacloud.NotePatchRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] NoteAPI.Patch end")
+	}()
+
+	resultNote, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		Note  *sacloud.Note
+		Error error
+	}{
+		Note:  resultNote,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultNote, err
+}
+
 // Delete is API call with trace log
 func (t *NoteTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] NoteAPI.Delete start")
@@ -6193,6 +6743,41 @@ func (t *PacketFilterTracer) Update(ctx context.Context, zone string, id types.I
 	}()
 
 	resultPacketFilter, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		PacketFilter *sacloud.PacketFilter
+		Error        error
+	}{
+		PacketFilter: resultPacketFilter,
+		Error:        err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultPacketFilter, err
+}
+
+// Patch is API call with trace log
+func (t *PacketFilterTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.PacketFilterPatchRequest) (*sacloud.PacketFilter, error) {
+	log.Println("[TRACE] PacketFilterAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                          `json:"id"`
+		Argparam *sacloud.PacketFilterPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] PacketFilterAPI.Patch end")
+	}()
+
+	resultPacketFilter, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		PacketFilter *sacloud.PacketFilter
 		Error        error
@@ -6374,6 +6959,41 @@ func (t *PrivateHostTracer) Update(ctx context.Context, zone string, id types.ID
 	}()
 
 	resultPrivateHost, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		PrivateHost *sacloud.PrivateHost
+		Error       error
+	}{
+		PrivateHost: resultPrivateHost,
+		Error:       err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultPrivateHost, err
+}
+
+// Patch is API call with trace log
+func (t *PrivateHostTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.PrivateHostPatchRequest) (*sacloud.PrivateHost, error) {
+	log.Println("[TRACE] PrivateHostAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                         `json:"id"`
+		Argparam *sacloud.PrivateHostPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] PrivateHostAPI.Patch end")
+	}()
+
+	resultPrivateHost, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		PrivateHost *sacloud.PrivateHost
 		Error       error
@@ -6629,6 +7249,39 @@ func (t *ProxyLBTracer) Update(ctx context.Context, id types.ID, param *sacloud.
 	}()
 
 	resultProxyLB, err := t.Internal.Update(ctx, id, param)
+	targetResults := struct {
+		ProxyLB *sacloud.ProxyLB
+		Error   error
+	}{
+		ProxyLB: resultProxyLB,
+		Error:   err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultProxyLB, err
+}
+
+// Patch is API call with trace log
+func (t *ProxyLBTracer) Patch(ctx context.Context, id types.ID, param *sacloud.ProxyLBPatchRequest) (*sacloud.ProxyLB, error) {
+	log.Println("[TRACE] ProxyLBAPI.Patch start")
+	targetArguments := struct {
+		Argid    types.ID                     `json:"id"`
+		Argparam *sacloud.ProxyLBPatchRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ProxyLBAPI.Patch end")
+	}()
+
+	resultProxyLB, err := t.Internal.Patch(ctx, id, param)
 	targetResults := struct {
 		ProxyLB *sacloud.ProxyLB
 		Error   error
@@ -7105,6 +7758,41 @@ func (t *ServerTracer) Update(ctx context.Context, zone string, id types.ID, par
 	}()
 
 	resultServer, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		Server *sacloud.Server
+		Error  error
+	}{
+		Server: resultServer,
+		Error:  err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultServer, err
+}
+
+// Patch is API call with trace log
+func (t *ServerTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.ServerPatchRequest) (*sacloud.Server, error) {
+	log.Println("[TRACE] ServerAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                    `json:"id"`
+		Argparam *sacloud.ServerPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ServerAPI.Patch end")
+	}()
+
+	resultServer, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		Server *sacloud.Server
 		Error  error
@@ -7753,6 +8441,39 @@ func (t *SIMTracer) Update(ctx context.Context, id types.ID, param *sacloud.SIMU
 	return resultSIM, err
 }
 
+// Patch is API call with trace log
+func (t *SIMTracer) Patch(ctx context.Context, id types.ID, param *sacloud.SIMPatchRequest) (*sacloud.SIM, error) {
+	log.Println("[TRACE] SIMAPI.Patch start")
+	targetArguments := struct {
+		Argid    types.ID                 `json:"id"`
+		Argparam *sacloud.SIMPatchRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] SIMAPI.Patch end")
+	}()
+
+	resultSIM, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		SIM   *sacloud.SIM
+		Error error
+	}{
+		SIM:   resultSIM,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSIM, err
+}
+
 // Delete is API call with trace log
 func (t *SIMTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SIMAPI.Delete start")
@@ -8259,6 +8980,39 @@ func (t *SimpleMonitorTracer) Update(ctx context.Context, id types.ID, param *sa
 	return resultSimpleMonitor, err
 }
 
+// Patch is API call with trace log
+func (t *SimpleMonitorTracer) Patch(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorPatchRequest) (*sacloud.SimpleMonitor, error) {
+	log.Println("[TRACE] SimpleMonitorAPI.Patch start")
+	targetArguments := struct {
+		Argid    types.ID                           `json:"id"`
+		Argparam *sacloud.SimpleMonitorPatchRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] SimpleMonitorAPI.Patch end")
+	}()
+
+	resultSimpleMonitor, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		SimpleMonitor *sacloud.SimpleMonitor
+		Error         error
+	}{
+		SimpleMonitor: resultSimpleMonitor,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSimpleMonitor, err
+}
+
 // Delete is API call with trace log
 func (t *SimpleMonitorTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SimpleMonitorAPI.Delete start")
@@ -8525,6 +9279,39 @@ func (t *SSHKeyTracer) Update(ctx context.Context, id types.ID, param *sacloud.S
 	return resultSSHKey, err
 }
 
+// Patch is API call with trace log
+func (t *SSHKeyTracer) Patch(ctx context.Context, id types.ID, param *sacloud.SSHKeyPatchRequest) (*sacloud.SSHKey, error) {
+	log.Println("[TRACE] SSHKeyAPI.Patch start")
+	targetArguments := struct {
+		Argid    types.ID                    `json:"id"`
+		Argparam *sacloud.SSHKeyPatchRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] SSHKeyAPI.Patch end")
+	}()
+
+	resultSSHKey, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		SSHKey *sacloud.SSHKey
+		Error  error
+	}{
+		SSHKey: resultSSHKey,
+		Error:  err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSSHKey, err
+}
+
 // Delete is API call with trace log
 func (t *SSHKeyTracer) Delete(ctx context.Context, id types.ID) error {
 	log.Println("[TRACE] SSHKeyAPI.Delete start")
@@ -8690,6 +9477,41 @@ func (t *SwitchTracer) Update(ctx context.Context, zone string, id types.ID, par
 	}()
 
 	resultSwitch, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		Switch *sacloud.Switch
+		Error  error
+	}{
+		Switch: resultSwitch,
+		Error:  err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSwitch, err
+}
+
+// Patch is API call with trace log
+func (t *SwitchTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.SwitchPatchRequest) (*sacloud.Switch, error) {
+	log.Println("[TRACE] SwitchAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                    `json:"id"`
+		Argparam *sacloud.SwitchPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] SwitchAPI.Patch end")
+	}()
+
+	resultSwitch, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		Switch *sacloud.Switch
 		Error  error
@@ -8935,6 +9757,41 @@ func (t *VPCRouterTracer) Update(ctx context.Context, zone string, id types.ID, 
 	}()
 
 	resultVPCRouter, err := t.Internal.Update(ctx, zone, id, param)
+	targetResults := struct {
+		VPCRouter *sacloud.VPCRouter
+		Error     error
+	}{
+		VPCRouter: resultVPCRouter,
+		Error:     err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultVPCRouter, err
+}
+
+// Patch is API call with trace log
+func (t *VPCRouterTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterPatchRequest) (*sacloud.VPCRouter, error) {
+	log.Println("[TRACE] VPCRouterAPI.Patch start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                       `json:"id"`
+		Argparam *sacloud.VPCRouterPatchRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] VPCRouterAPI.Patch end")
+	}()
+
+	resultVPCRouter, err := t.Internal.Patch(ctx, zone, id, param)
 	targetResults := struct {
 		VPCRouter *sacloud.VPCRouter
 		Error     error

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -4,7 +4,9 @@ package sacloud
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/imdario/mergo"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
@@ -526,6 +528,67 @@ func (o *ArchiveOp) Update(ctx context.Context, zone string, id types.ID, param 
 	return results.Archive, nil
 }
 
+// Patch is API call
+func (o *ArchiveOp) Patch(ctx context.Context, zone string, id types.ID, param *ArchivePatchRequest) (*Archive, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Archive, nil
+}
+
 // Delete is API call
 func (o *ArchiveOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	// build request URL
@@ -821,6 +884,73 @@ func (o *AutoBackupOp) Update(ctx context.Context, zone string, id types.ID, par
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.AutoBackup, nil
+}
+
+// Patch is API call
+func (o *AutoBackupOp) Patch(ctx context.Context, zone string, id types.ID, param *AutoBackupPatchRequest) (*AutoBackup, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToBackupSpanWeekdays {
+		param.BackupSpanWeekdays = nil
+	}
+	if param.PatchEmptyToMaximumNumberOfArchives {
+		param.MaximumNumberOfArchives = 0
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -1224,6 +1354,61 @@ func (o *BridgeOp) Update(ctx context.Context, zone string, id types.ID, param *
 	return results.Bridge, nil
 }
 
+// Patch is API call
+func (o *BridgeOp) Patch(ctx context.Context, zone string, id types.ID, param *BridgePatchRequest) (*Bridge, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Bridge, nil
+}
+
 // Delete is API call
 func (o *BridgeOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	// build request URL
@@ -1405,6 +1590,67 @@ func (o *CDROMOp) Update(ctx context.Context, zone string, id types.ID, param *C
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.CDROM, nil
+}
+
+// Patch is API call
+func (o *CDROMOp) Patch(ctx context.Context, zone string, id types.ID, param *CDROMPatchRequest) (*CDROM, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -1707,6 +1953,76 @@ func (o *DatabaseOp) Update(ctx context.Context, zone string, id types.ID, param
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Database, nil
+}
+
+// Patch is API call
+func (o *DatabaseOp) Patch(ctx context.Context, zone string, id types.ID, param *DatabasePatchRequest) (*Database, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToCommonSetting {
+		param.CommonSetting = nil
+	}
+	if param.PatchEmptyToBackupSetting {
+		param.BackupSetting = nil
+	}
+	if param.PatchEmptyToReplicationSetting {
+		param.ReplicationSetting = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -2422,6 +2738,70 @@ func (o *DiskOp) Update(ctx context.Context, zone string, id types.ID, param *Di
 	return results.Disk, nil
 }
 
+// Patch is API call
+func (o *DiskOp) Patch(ctx context.Context, zone string, id types.ID, param *DiskPatchRequest) (*Disk, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToConnection {
+		param.Connection = types.EDiskConnection("")
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Disk, nil
+}
+
 // Delete is API call
 func (o *DiskOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	// build request URL
@@ -2732,6 +3112,70 @@ func (o *DNSOp) Update(ctx context.Context, id types.ID, param *DNSUpdateRequest
 	return results.DNS, nil
 }
 
+// Patch is API call
+func (o *DNSOp) Patch(ctx context.Context, id types.ID, param *DNSPatchRequest) (*DNS, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToRecords {
+		param.Records = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.DNS, nil
+}
+
 // Delete is API call
 func (o *DNSOp) Delete(ctx context.Context, id types.ID) error {
 	// build request URL
@@ -2913,6 +3357,82 @@ func (o *GSLBOp) Update(ctx context.Context, id types.ID, param *GSLBUpdateReque
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.GSLB, nil
+}
+
+// Patch is API call
+func (o *GSLBOp) Patch(ctx context.Context, id types.ID, param *GSLBPatchRequest) (*GSLB, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToHealthCheck {
+		param.HealthCheck = nil
+	}
+	if param.PatchEmptyToDelayLoop {
+		param.DelayLoop = 0
+	}
+	if param.PatchEmptyToWeighted {
+		param.Weighted = types.StringFlag(false)
+	}
+	if param.PatchEmptyToSorryServer {
+		param.SorryServer = ""
+	}
+	if param.PatchEmptyToDestinationServers {
+		param.DestinationServers = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -3106,6 +3626,61 @@ func (o *IconOp) Update(ctx context.Context, id types.ID, param *IconUpdateReque
 	return results.Icon, nil
 }
 
+// Patch is API call
+func (o *IconOp) Patch(ctx context.Context, id types.ID, param *IconPatchRequest) (*Icon, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Icon, nil
+}
+
 // Delete is API call
 func (o *IconOp) Delete(ctx context.Context, id types.ID) error {
 	// build request URL
@@ -3287,6 +3862,61 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Interface, nil
+}
+
+// Patch is API call
+func (o *InterfaceOp) Patch(ctx context.Context, zone string, id types.ID, param *InterfacePatchRequest) (*Interface, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToUserIPAddress {
+		param.UserIPAddress = ""
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -3653,6 +4283,67 @@ func (o *InternetOp) Update(ctx context.Context, zone string, id types.ID, param
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Internet, nil
+}
+
+// Patch is API call
+func (o *InternetOp) Patch(ctx context.Context, zone string, id types.ID, param *InternetPatchRequest) (*Internet, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -4554,6 +5245,58 @@ func (o *LicenseOp) Update(ctx context.Context, id types.ID, param *LicenseUpdat
 	return results.License, nil
 }
 
+// Patch is API call
+func (o *LicenseOp) Patch(ctx context.Context, id types.ID, param *LicensePatchRequest) (*License, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.License, nil
+}
+
 // Delete is API call
 func (o *LicenseOp) Delete(ctx context.Context, id types.ID) error {
 	// build request URL
@@ -4821,6 +5564,70 @@ func (o *LoadBalancerOp) Update(ctx context.Context, zone string, id types.ID, p
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LoadBalancer, nil
+}
+
+// Patch is API call
+func (o *LoadBalancerOp) Patch(ctx context.Context, zone string, id types.ID, param *LoadBalancerPatchRequest) (*LoadBalancer, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToVirtualIPAddresses {
+		param.VirtualIPAddresses = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -5194,6 +6001,70 @@ func (o *MobileGatewayOp) Update(ctx context.Context, zone string, id types.ID, 
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.MobileGateway, nil
+}
+
+// Patch is API call
+func (o *MobileGatewayOp) Patch(ctx context.Context, zone string, id types.ID, param *MobileGatewayPatchRequest) (*MobileGateway, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToSettings {
+		param.Settings = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -5979,6 +6850,67 @@ func (o *NFSOp) Update(ctx context.Context, zone string, id types.ID, param *NFS
 	return results.NFS, nil
 }
 
+// Patch is API call
+func (o *NFSOp) Patch(ctx context.Context, zone string, id types.ID, param *NFSPatchRequest) (*NFS, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.NFS, nil
+}
+
 // Delete is API call
 func (o *NFSOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	// build request URL
@@ -6330,6 +7262,70 @@ func (o *NoteOp) Update(ctx context.Context, id types.ID, param *NoteUpdateReque
 	return results.Note, nil
 }
 
+// Patch is API call
+func (o *NoteOp) Patch(ctx context.Context, id types.ID, param *NotePatchRequest) (*Note, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToClass {
+		param.Class = ""
+	}
+	if param.PatchEmptyToContent {
+		param.Content = ""
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Note, nil
+}
+
 // Delete is API call
 func (o *NoteOp) Delete(ctx context.Context, id types.ID) error {
 	// build request URL
@@ -6517,6 +7513,64 @@ func (o *PacketFilterOp) Update(ctx context.Context, zone string, id types.ID, p
 	return results.PacketFilter, nil
 }
 
+// Patch is API call
+func (o *PacketFilterOp) Patch(ctx context.Context, zone string, id types.ID, param *PacketFilterPatchRequest) (*PacketFilter, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToExpression {
+		param.Expression = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.PacketFilter, nil
+}
+
 // Delete is API call
 func (o *PacketFilterOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	// build request URL
@@ -6698,6 +7752,67 @@ func (o *PrivateHostOp) Update(ctx context.Context, zone string, id types.ID, pa
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.PrivateHost, nil
+}
+
+// Patch is API call
+func (o *PrivateHostOp) Patch(ctx context.Context, zone string, id types.ID, param *PrivateHostPatchRequest) (*PrivateHost, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -6971,6 +8086,85 @@ func (o *ProxyLBOp) Update(ctx context.Context, id types.ID, param *ProxyLBUpdat
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.ProxyLB, nil
+}
+
+// Patch is API call
+func (o *ProxyLBOp) Patch(ctx context.Context, id types.ID, param *ProxyLBPatchRequest) (*ProxyLB, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToHealthCheck {
+		param.HealthCheck = nil
+	}
+	if param.PatchEmptyToSorryServer {
+		param.SorryServer = nil
+	}
+	if param.PatchEmptyToBindPorts {
+		param.BindPorts = nil
+	}
+	if param.PatchEmptyToServers {
+		param.Servers = nil
+	}
+	if param.PatchEmptyToLetsEncrypt {
+		param.LetsEncrypt = nil
+	}
+	if param.PatchEmptyToStickySession {
+		param.StickySession = nil
+	}
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -7473,6 +8667,67 @@ func (o *ServerOp) Update(ctx context.Context, zone string, id types.ID, param *
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Server, nil
+}
+
+// Patch is API call
+func (o *ServerOp) Patch(ctx context.Context, zone string, id types.ID, param *ServerPatchRequest) (*Server, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -8138,6 +9393,67 @@ func (o *SIMOp) Update(ctx context.Context, id types.ID, param *SIMUpdateRequest
 	return results.SIM, nil
 }
 
+// Patch is API call
+func (o *SIMOp) Patch(ctx context.Context, id types.ID, param *SIMPatchRequest) (*SIM, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.SIM, nil
+}
+
 // Delete is API call
 func (o *SIMOp) Delete(ctx context.Context, id types.ID) error {
 	// build request URL
@@ -8669,6 +9985,88 @@ func (o *SimpleMonitorOp) Update(ctx context.Context, id types.ID, param *Simple
 	return results.SimpleMonitor, nil
 }
 
+// Patch is API call
+func (o *SimpleMonitorOp) Patch(ctx context.Context, id types.ID, param *SimpleMonitorPatchRequest) (*SimpleMonitor, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToDelayLoop {
+		param.DelayLoop = 0
+	}
+	if param.PatchEmptyToEnabled {
+		param.Enabled = types.StringFlag(false)
+	}
+	if param.PatchEmptyToHealthCheck {
+		param.HealthCheck = nil
+	}
+	if param.PatchEmptyToNotifyEmailEnabled {
+		param.NotifyEmailEnabled = types.StringFlag(false)
+	}
+	if param.PatchEmptyToNotifyEmailHTML {
+		param.NotifyEmailHTML = types.StringFlag(false)
+	}
+	if param.PatchEmptyToNotifySlackEnabled {
+		param.NotifySlackEnabled = types.StringFlag(false)
+	}
+	if param.PatchEmptyToSlackWebhooksURL {
+		param.SlackWebhooksURL = ""
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.SimpleMonitor, nil
+}
+
 // Delete is API call
 func (o *SimpleMonitorOp) Delete(ctx context.Context, id types.ID) error {
 	// build request URL
@@ -8960,6 +10358,61 @@ func (o *SSHKeyOp) Update(ctx context.Context, id types.ID, param *SSHKeyUpdateR
 	return results.SSHKey, nil
 }
 
+// Patch is API call
+func (o *SSHKeyOp) Patch(ctx context.Context, id types.ID, param *SSHKeyPatchRequest) (*SSHKey, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.SSHKey, nil
+}
+
 // Delete is API call
 func (o *SSHKeyOp) Delete(ctx context.Context, id types.ID) error {
 	// build request URL
@@ -9141,6 +10594,73 @@ func (o *SwitchOp) Update(ctx context.Context, zone string, id types.ID, param *
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Switch, nil
+}
+
+// Patch is API call
+func (o *SwitchOp) Patch(ctx context.Context, zone string, id types.ID, param *SwitchPatchRequest) (*Switch, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToNetworkMaskLen {
+		param.NetworkMaskLen = 0
+	}
+	if param.PatchEmptyToDefaultRoute {
+		param.DefaultRoute = ""
+	}
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}
@@ -9385,6 +10905,70 @@ func (o *VPCRouterOp) Update(ctx context.Context, zone string, id types.ID, para
 
 	// build results
 	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.VPCRouter, nil
+}
+
+// Patch is API call
+func (o *VPCRouterOp) Patch(ctx context.Context, zone string, id types.ID, param *VPCRouterPatchRequest) (*VPCRouter, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDescription {
+		param.Description = ""
+	}
+	if param.PatchEmptyToTags {
+		param.Tags = nil
+	}
+	if param.PatchEmptyToIconID {
+		param.IconID = types.ID(int64(0))
+	}
+	if param.PatchEmptyToSettings {
+		param.Settings = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchResults(data)
 	if err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -167,6 +167,49 @@ func (o *ArchiveOp) transformUpdateResults(data []byte) (*archiveUpdateResult, e
 	return results, nil
 }
 
+func (o *ArchiveOp) transformPatchArgs(id types.ID, param *ArchivePatchRequest) (*archivePatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &ArchivePatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Archive,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &archivePatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ArchiveOp) transformPatchResults(data []byte) (*archivePatchResult, error) {
+	nakedResponse := &archivePatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &archivePatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *ArchiveOp) transformOpenFTPArgs(id types.ID, openOption *OpenFTPRequest) (*archiveOpenFTPRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -341,6 +384,49 @@ func (o *AutoBackupOp) transformUpdateResults(data []byte) (*autoBackupUpdateRes
 	}
 
 	results := &autoBackupUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *AutoBackupOp) transformPatchArgs(id types.ID, param *AutoBackupPatchRequest) (*autoBackupPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &AutoBackupPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &autoBackupPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *AutoBackupOp) transformPatchResults(data []byte) (*autoBackupPatchResult, error) {
+	nakedResponse := &autoBackupPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &autoBackupPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -549,6 +635,49 @@ func (o *BridgeOp) transformUpdateResults(data []byte) (*bridgeUpdateResult, err
 	return results, nil
 }
 
+func (o *BridgeOp) transformPatchArgs(id types.ID, param *BridgePatchRequest) (*bridgePatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &BridgePatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Bridge,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &bridgePatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *BridgeOp) transformPatchResults(data []byte) (*bridgePatchResult, error) {
+	nakedResponse := &bridgePatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &bridgePatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *CDROMOp) transformFindArgs(conditions *FindCondition) (*cDROMFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}
@@ -667,6 +796,49 @@ func (o *CDROMOp) transformUpdateResults(data []byte) (*cDROMUpdateResult, error
 	}
 
 	results := &cDROMUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *CDROMOp) transformPatchArgs(id types.ID, param *CDROMPatchRequest) (*cDROMPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &CDROMPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CDROM,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &cDROMPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *CDROMOp) transformPatchResults(data []byte) (*cDROMPatchResult, error) {
+	nakedResponse := &cDROMPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &cDROMPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -847,6 +1019,49 @@ func (o *DatabaseOp) transformUpdateResults(data []byte) (*databaseUpdateResult,
 	}
 
 	results := &databaseUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *DatabaseOp) transformPatchArgs(id types.ID, param *DatabasePatchRequest) (*databasePatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &DatabasePatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &databasePatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *DatabaseOp) transformPatchResults(data []byte) (*databasePatchResult, error) {
+	nakedResponse := &databasePatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &databasePatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -1344,6 +1559,49 @@ func (o *DiskOp) transformUpdateResults(data []byte) (*diskUpdateResult, error) 
 	return results, nil
 }
 
+func (o *DiskOp) transformPatchArgs(id types.ID, param *DiskPatchRequest) (*diskPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &DiskPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Disk,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &diskPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *DiskOp) transformPatchResults(data []byte) (*diskPatchResult, error) {
+	nakedResponse := &diskPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &diskPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *DiskOp) transformMonitorArgs(id types.ID, condition *MonitorCondition) (*diskMonitorRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -1558,6 +1816,49 @@ func (o *DNSOp) transformUpdateResults(data []byte) (*dNSUpdateResult, error) {
 	return results, nil
 }
 
+func (o *DNSOp) transformPatchArgs(id types.ID, param *DNSPatchRequest) (*dNSPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &DNSPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &dNSPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *DNSOp) transformPatchResults(data []byte) (*dNSPatchResult, error) {
+	nakedResponse := &dNSPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &dNSPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *GSLBOp) transformFindArgs(conditions *FindCondition) (*gSLBFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}
@@ -1676,6 +1977,49 @@ func (o *GSLBOp) transformUpdateResults(data []byte) (*gSLBUpdateResult, error) 
 	}
 
 	results := &gSLBUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *GSLBOp) transformPatchArgs(id types.ID, param *GSLBPatchRequest) (*gSLBPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &GSLBPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &gSLBPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *GSLBOp) transformPatchResults(data []byte) (*gSLBPatchResult, error) {
+	nakedResponse := &gSLBPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &gSLBPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -1806,6 +2150,49 @@ func (o *IconOp) transformUpdateResults(data []byte) (*iconUpdateResult, error) 
 	return results, nil
 }
 
+func (o *IconOp) transformPatchArgs(id types.ID, param *IconPatchRequest) (*iconPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &IconPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Icon,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &iconPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *IconOp) transformPatchResults(data []byte) (*iconPatchResult, error) {
+	nakedResponse := &iconPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &iconPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *InterfaceOp) transformFindArgs(conditions *FindCondition) (*interfaceFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}
@@ -1924,6 +2311,49 @@ func (o *InterfaceOp) transformUpdateResults(data []byte) (*interfaceUpdateResul
 	}
 
 	results := &interfaceUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *InterfaceOp) transformPatchArgs(id types.ID, param *InterfacePatchRequest) (*interfacePatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &InterfacePatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Interface,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &interfacePatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *InterfaceOp) transformPatchResults(data []byte) (*interfacePatchResult, error) {
+	nakedResponse := &interfacePatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &interfacePatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -2091,6 +2521,49 @@ func (o *InternetOp) transformUpdateResults(data []byte) (*internetUpdateResult,
 	}
 
 	results := &internetUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *InternetOp) transformPatchArgs(id types.ID, param *InternetPatchRequest) (*internetPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &InternetPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Internet,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &internetPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *InternetOp) transformPatchResults(data []byte) (*internetPatchResult, error) {
+	nakedResponse := &internetPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &internetPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -2681,6 +3154,49 @@ func (o *LicenseOp) transformUpdateResults(data []byte) (*licenseUpdateResult, e
 	return results, nil
 }
 
+func (o *LicenseOp) transformPatchArgs(id types.ID, param *LicensePatchRequest) (*licensePatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &LicensePatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"License,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &licensePatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LicenseOp) transformPatchResults(data []byte) (*licensePatchResult, error) {
+	nakedResponse := &licensePatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &licensePatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *LicenseInfoOp) transformFindArgs(conditions *FindCondition) (*licenseInfoFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}
@@ -2846,6 +3362,49 @@ func (o *LoadBalancerOp) transformUpdateResults(data []byte) (*loadBalancerUpdat
 	}
 
 	results := &loadBalancerUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LoadBalancerOp) transformPatchArgs(id types.ID, param *LoadBalancerPatchRequest) (*loadBalancerPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &LoadBalancerPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &loadBalancerPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LoadBalancerOp) transformPatchResults(data []byte) (*loadBalancerPatchResult, error) {
+	nakedResponse := &loadBalancerPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &loadBalancerPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -3056,6 +3615,49 @@ func (o *MobileGatewayOp) transformUpdateResults(data []byte) (*mobileGatewayUpd
 	}
 
 	results := &mobileGatewayUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *MobileGatewayOp) transformPatchArgs(id types.ID, param *MobileGatewayPatchRequest) (*mobileGatewayPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &MobileGatewayPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &mobileGatewayPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *MobileGatewayOp) transformPatchResults(data []byte) (*mobileGatewayPatchResult, error) {
+	nakedResponse := &mobileGatewayPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -3466,6 +4068,49 @@ func (o *NFSOp) transformUpdateResults(data []byte) (*nFSUpdateResult, error) {
 	return results, nil
 }
 
+func (o *NFSOp) transformPatchArgs(id types.ID, param *NFSPatchRequest) (*nFSPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &NFSPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &nFSPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *NFSOp) transformPatchResults(data []byte) (*nFSPatchResult, error) {
+	nakedResponse := &nFSPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &nFSPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *NFSOp) transformShutdownArgs(id types.ID, shutdownOption *ShutdownOption) (*nFSShutdownRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -3706,6 +4351,49 @@ func (o *NoteOp) transformUpdateResults(data []byte) (*noteUpdateResult, error) 
 	return results, nil
 }
 
+func (o *NoteOp) transformPatchArgs(id types.ID, param *NotePatchRequest) (*notePatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &NotePatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Note,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &notePatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *NoteOp) transformPatchResults(data []byte) (*notePatchResult, error) {
+	nakedResponse := &notePatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &notePatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *PacketFilterOp) transformFindArgs(conditions *FindCondition) (*packetFilterFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}
@@ -3830,6 +4518,49 @@ func (o *PacketFilterOp) transformUpdateResults(data []byte) (*packetFilterUpdat
 	return results, nil
 }
 
+func (o *PacketFilterOp) transformPatchArgs(id types.ID, param *PacketFilterPatchRequest) (*packetFilterPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &PacketFilterPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"PacketFilter,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &packetFilterPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *PacketFilterOp) transformPatchResults(data []byte) (*packetFilterPatchResult, error) {
+	nakedResponse := &packetFilterPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &packetFilterPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *PrivateHostOp) transformFindArgs(conditions *FindCondition) (*privateHostFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}
@@ -3948,6 +4679,49 @@ func (o *PrivateHostOp) transformUpdateResults(data []byte) (*privateHostUpdateR
 	}
 
 	results := &privateHostUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *PrivateHostOp) transformPatchArgs(id types.ID, param *PrivateHostPatchRequest) (*privateHostPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &PrivateHostPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"PrivateHost,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &privateHostPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *PrivateHostOp) transformPatchResults(data []byte) (*privateHostPatchResult, error) {
+	nakedResponse := &privateHostPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &privateHostPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -4119,6 +4893,49 @@ func (o *ProxyLBOp) transformUpdateResults(data []byte) (*proxyLBUpdateResult, e
 	}
 
 	results := &proxyLBUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *ProxyLBOp) transformPatchArgs(id types.ID, param *ProxyLBPatchRequest) (*proxyLBPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &ProxyLBPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &proxyLBPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ProxyLBOp) transformPatchResults(data []byte) (*proxyLBPatchResult, error) {
+	nakedResponse := &proxyLBPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &proxyLBPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -4445,6 +5262,49 @@ func (o *ServerOp) transformUpdateResults(data []byte) (*serverUpdateResult, err
 	}
 
 	results := &serverUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *ServerOp) transformPatchArgs(id types.ID, param *ServerPatchRequest) (*serverPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &ServerPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Server,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &serverPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ServerOp) transformPatchResults(data []byte) (*serverPatchResult, error) {
+	nakedResponse := &serverPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &serverPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}
@@ -4905,6 +5765,49 @@ func (o *SIMOp) transformUpdateResults(data []byte) (*sIMUpdateResult, error) {
 	return results, nil
 }
 
+func (o *SIMOp) transformPatchArgs(id types.ID, param *SIMPatchRequest) (*sIMPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &SIMPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &sIMPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *SIMOp) transformPatchResults(data []byte) (*sIMPatchResult, error) {
+	nakedResponse := &sIMPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &sIMPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *SIMOp) transformAssignIPArgs(id types.ID, param *SIMAssignIPRequest) (*sIMAssignIPRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -5201,6 +6104,49 @@ func (o *SimpleMonitorOp) transformUpdateResults(data []byte) (*simpleMonitorUpd
 	return results, nil
 }
 
+func (o *SimpleMonitorOp) transformPatchArgs(id types.ID, param *SimpleMonitorPatchRequest) (*simpleMonitorPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &SimpleMonitorPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &simpleMonitorPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *SimpleMonitorOp) transformPatchResults(data []byte) (*simpleMonitorPatchResult, error) {
+	nakedResponse := &simpleMonitorPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &simpleMonitorPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *SimpleMonitorOp) transformMonitorResponseTimeArgs(id types.ID, condition *MonitorCondition) (*simpleMonitorMonitorResponseTimeRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -5415,6 +6361,49 @@ func (o *SSHKeyOp) transformUpdateResults(data []byte) (*sSHKeyUpdateResult, err
 	return results, nil
 }
 
+func (o *SSHKeyOp) transformPatchArgs(id types.ID, param *SSHKeyPatchRequest) (*sSHKeyPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &SSHKeyPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"SSHKey,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &sSHKeyPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *SSHKeyOp) transformPatchResults(data []byte) (*sSHKeyPatchResult, error) {
+	nakedResponse := &sSHKeyPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &sSHKeyPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *SwitchOp) transformFindArgs(conditions *FindCondition) (*switchFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}
@@ -5539,6 +6528,49 @@ func (o *SwitchOp) transformUpdateResults(data []byte) (*switchUpdateResult, err
 	return results, nil
 }
 
+func (o *SwitchOp) transformPatchArgs(id types.ID, param *SwitchPatchRequest) (*switchPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &SwitchPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Switch,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &switchPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *SwitchOp) transformPatchResults(data []byte) (*switchPatchResult, error) {
+	nakedResponse := &switchPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &switchPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *VPCRouterOp) transformFindArgs(conditions *FindCondition) (*vPCRouterFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}
@@ -5657,6 +6689,49 @@ func (o *VPCRouterOp) transformUpdateResults(data []byte) (*vPCRouterUpdateResul
 	}
 
 	results := &vPCRouterUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *VPCRouterOp) transformPatchArgs(id types.ID, param *VPCRouterPatchRequest) (*vPCRouterPatchRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &VPCRouterPatchRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &vPCRouterPatchRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *VPCRouterOp) transformPatchResults(data []byte) (*vPCRouterPatchResult, error) {
+	nakedResponse := &vPCRouterPatchResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &vPCRouterPatchResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -19,6 +19,7 @@ type ArchiveAPI interface {
 	CreateBlank(ctx context.Context, zone string, param *ArchiveCreateBlankRequest) (*Archive, *FTPServer, error)
 	Read(ctx context.Context, zone string, id types.ID) (*Archive, error)
 	Update(ctx context.Context, zone string, id types.ID, param *ArchiveUpdateRequest) (*Archive, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *ArchivePatchRequest) (*Archive, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	OpenFTP(ctx context.Context, zone string, id types.ID, openOption *OpenFTPRequest) (*FTPServer, error)
 	CloseFTP(ctx context.Context, zone string, id types.ID) error
@@ -43,6 +44,7 @@ type AutoBackupAPI interface {
 	Create(ctx context.Context, zone string, param *AutoBackupCreateRequest) (*AutoBackup, error)
 	Read(ctx context.Context, zone string, id types.ID) (*AutoBackup, error)
 	Update(ctx context.Context, zone string, id types.ID, param *AutoBackupUpdateRequest) (*AutoBackup, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *AutoBackupPatchRequest) (*AutoBackup, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 }
 
@@ -70,6 +72,7 @@ type BridgeAPI interface {
 	Create(ctx context.Context, zone string, param *BridgeCreateRequest) (*Bridge, error)
 	Read(ctx context.Context, zone string, id types.ID) (*Bridge, error)
 	Update(ctx context.Context, zone string, id types.ID, param *BridgeUpdateRequest) (*Bridge, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *BridgePatchRequest) (*Bridge, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 }
 
@@ -83,6 +86,7 @@ type CDROMAPI interface {
 	Create(ctx context.Context, zone string, param *CDROMCreateRequest) (*CDROM, *FTPServer, error)
 	Read(ctx context.Context, zone string, id types.ID) (*CDROM, error)
 	Update(ctx context.Context, zone string, id types.ID, param *CDROMUpdateRequest) (*CDROM, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *CDROMPatchRequest) (*CDROM, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	OpenFTP(ctx context.Context, zone string, id types.ID, openOption *OpenFTPRequest) (*FTPServer, error)
 	CloseFTP(ctx context.Context, zone string, id types.ID) error
@@ -107,6 +111,7 @@ type DatabaseAPI interface {
 	Create(ctx context.Context, zone string, param *DatabaseCreateRequest) (*Database, error)
 	Read(ctx context.Context, zone string, id types.ID) (*Database, error)
 	Update(ctx context.Context, zone string, id types.ID, param *DatabaseUpdateRequest) (*Database, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *DatabasePatchRequest) (*Database, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Config(ctx context.Context, zone string, id types.ID) error
 	Boot(ctx context.Context, zone string, id types.ID) error
@@ -136,6 +141,7 @@ type DiskAPI interface {
 	Install(ctx context.Context, zone string, id types.ID, installParam *DiskInstallRequest, distantFrom []types.ID) (*Disk, error)
 	Read(ctx context.Context, zone string, id types.ID) (*Disk, error)
 	Update(ctx context.Context, zone string, id types.ID, param *DiskUpdateRequest) (*Disk, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *DiskPatchRequest) (*Disk, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Monitor(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*DiskActivity, error)
 }
@@ -160,6 +166,7 @@ type DNSAPI interface {
 	Create(ctx context.Context, param *DNSCreateRequest) (*DNS, error)
 	Read(ctx context.Context, id types.ID) (*DNS, error)
 	Update(ctx context.Context, id types.ID, param *DNSUpdateRequest) (*DNS, error)
+	Patch(ctx context.Context, id types.ID, param *DNSPatchRequest) (*DNS, error)
 	Delete(ctx context.Context, id types.ID) error
 }
 
@@ -173,6 +180,7 @@ type GSLBAPI interface {
 	Create(ctx context.Context, param *GSLBCreateRequest) (*GSLB, error)
 	Read(ctx context.Context, id types.ID) (*GSLB, error)
 	Update(ctx context.Context, id types.ID, param *GSLBUpdateRequest) (*GSLB, error)
+	Patch(ctx context.Context, id types.ID, param *GSLBPatchRequest) (*GSLB, error)
 	Delete(ctx context.Context, id types.ID) error
 }
 
@@ -186,6 +194,7 @@ type IconAPI interface {
 	Create(ctx context.Context, param *IconCreateRequest) (*Icon, error)
 	Read(ctx context.Context, id types.ID) (*Icon, error)
 	Update(ctx context.Context, id types.ID, param *IconUpdateRequest) (*Icon, error)
+	Patch(ctx context.Context, id types.ID, param *IconPatchRequest) (*Icon, error)
 	Delete(ctx context.Context, id types.ID) error
 }
 
@@ -199,6 +208,7 @@ type InterfaceAPI interface {
 	Create(ctx context.Context, zone string, param *InterfaceCreateRequest) (*Interface, error)
 	Read(ctx context.Context, zone string, id types.ID) (*Interface, error)
 	Update(ctx context.Context, zone string, id types.ID, param *InterfaceUpdateRequest) (*Interface, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *InterfacePatchRequest) (*Interface, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Monitor(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*InterfaceActivity, error)
 	ConnectToSharedSegment(ctx context.Context, zone string, id types.ID) error
@@ -218,6 +228,7 @@ type InternetAPI interface {
 	Create(ctx context.Context, zone string, param *InternetCreateRequest) (*Internet, error)
 	Read(ctx context.Context, zone string, id types.ID) (*Internet, error)
 	Update(ctx context.Context, zone string, id types.ID, param *InternetUpdateRequest) (*Internet, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *InternetPatchRequest) (*Internet, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	UpdateBandWidth(ctx context.Context, zone string, id types.ID, param *InternetUpdateBandWidthRequest) (*Internet, error)
 	AddSubnet(ctx context.Context, zone string, id types.ID, param *InternetAddSubnetRequest) (*InternetSubnetOperationResult, error)
@@ -282,6 +293,7 @@ type LicenseAPI interface {
 	Create(ctx context.Context, param *LicenseCreateRequest) (*License, error)
 	Read(ctx context.Context, id types.ID) (*License, error)
 	Update(ctx context.Context, id types.ID, param *LicenseUpdateRequest) (*License, error)
+	Patch(ctx context.Context, id types.ID, param *LicensePatchRequest) (*License, error)
 	Delete(ctx context.Context, id types.ID) error
 }
 
@@ -305,6 +317,7 @@ type LoadBalancerAPI interface {
 	Create(ctx context.Context, zone string, param *LoadBalancerCreateRequest) (*LoadBalancer, error)
 	Read(ctx context.Context, zone string, id types.ID) (*LoadBalancer, error)
 	Update(ctx context.Context, zone string, id types.ID, param *LoadBalancerUpdateRequest) (*LoadBalancer, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *LoadBalancerPatchRequest) (*LoadBalancer, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Config(ctx context.Context, zone string, id types.ID) error
 	Boot(ctx context.Context, zone string, id types.ID) error
@@ -324,6 +337,7 @@ type MobileGatewayAPI interface {
 	Create(ctx context.Context, zone string, param *MobileGatewayCreateRequest) (*MobileGateway, error)
 	Read(ctx context.Context, zone string, id types.ID) (*MobileGateway, error)
 	Update(ctx context.Context, zone string, id types.ID, param *MobileGatewayUpdateRequest) (*MobileGateway, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *MobileGatewayPatchRequest) (*MobileGateway, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Config(ctx context.Context, zone string, id types.ID) error
 	Boot(ctx context.Context, zone string, id types.ID) error
@@ -356,6 +370,7 @@ type NFSAPI interface {
 	Create(ctx context.Context, zone string, param *NFSCreateRequest) (*NFS, error)
 	Read(ctx context.Context, zone string, id types.ID) (*NFS, error)
 	Update(ctx context.Context, zone string, id types.ID, param *NFSUpdateRequest) (*NFS, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *NFSPatchRequest) (*NFS, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Boot(ctx context.Context, zone string, id types.ID) error
 	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *ShutdownOption) error
@@ -374,6 +389,7 @@ type NoteAPI interface {
 	Create(ctx context.Context, param *NoteCreateRequest) (*Note, error)
 	Read(ctx context.Context, id types.ID) (*Note, error)
 	Update(ctx context.Context, id types.ID, param *NoteUpdateRequest) (*Note, error)
+	Patch(ctx context.Context, id types.ID, param *NotePatchRequest) (*Note, error)
 	Delete(ctx context.Context, id types.ID) error
 }
 
@@ -387,6 +403,7 @@ type PacketFilterAPI interface {
 	Create(ctx context.Context, zone string, param *PacketFilterCreateRequest) (*PacketFilter, error)
 	Read(ctx context.Context, zone string, id types.ID) (*PacketFilter, error)
 	Update(ctx context.Context, zone string, id types.ID, param *PacketFilterUpdateRequest) (*PacketFilter, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *PacketFilterPatchRequest) (*PacketFilter, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 }
 
@@ -400,6 +417,7 @@ type PrivateHostAPI interface {
 	Create(ctx context.Context, zone string, param *PrivateHostCreateRequest) (*PrivateHost, error)
 	Read(ctx context.Context, zone string, id types.ID) (*PrivateHost, error)
 	Update(ctx context.Context, zone string, id types.ID, param *PrivateHostUpdateRequest) (*PrivateHost, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *PrivateHostPatchRequest) (*PrivateHost, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 }
 
@@ -423,6 +441,7 @@ type ProxyLBAPI interface {
 	Create(ctx context.Context, param *ProxyLBCreateRequest) (*ProxyLB, error)
 	Read(ctx context.Context, id types.ID) (*ProxyLB, error)
 	Update(ctx context.Context, id types.ID, param *ProxyLBUpdateRequest) (*ProxyLB, error)
+	Patch(ctx context.Context, id types.ID, param *ProxyLBPatchRequest) (*ProxyLB, error)
 	Delete(ctx context.Context, id types.ID) error
 	ChangePlan(ctx context.Context, id types.ID, param *ProxyLBChangePlanRequest) (*ProxyLB, error)
 	GetCertificates(ctx context.Context, id types.ID) (*ProxyLBCertificates, error)
@@ -453,6 +472,7 @@ type ServerAPI interface {
 	Create(ctx context.Context, zone string, param *ServerCreateRequest) (*Server, error)
 	Read(ctx context.Context, zone string, id types.ID) (*Server, error)
 	Update(ctx context.Context, zone string, id types.ID, param *ServerUpdateRequest) (*Server, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *ServerPatchRequest) (*Server, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	DeleteWithDisks(ctx context.Context, zone string, id types.ID, disks *ServerDeleteWithDisksRequest) error
 	ChangePlan(ctx context.Context, zone string, id types.ID, plan *ServerChangePlanRequest) (*Server, error)
@@ -495,6 +515,7 @@ type SIMAPI interface {
 	Create(ctx context.Context, param *SIMCreateRequest) (*SIM, error)
 	Read(ctx context.Context, id types.ID) (*SIM, error)
 	Update(ctx context.Context, id types.ID, param *SIMUpdateRequest) (*SIM, error)
+	Patch(ctx context.Context, id types.ID, param *SIMPatchRequest) (*SIM, error)
 	Delete(ctx context.Context, id types.ID) error
 	Activate(ctx context.Context, id types.ID) error
 	Deactivate(ctx context.Context, id types.ID) error
@@ -519,6 +540,7 @@ type SimpleMonitorAPI interface {
 	Create(ctx context.Context, param *SimpleMonitorCreateRequest) (*SimpleMonitor, error)
 	Read(ctx context.Context, id types.ID) (*SimpleMonitor, error)
 	Update(ctx context.Context, id types.ID, param *SimpleMonitorUpdateRequest) (*SimpleMonitor, error)
+	Patch(ctx context.Context, id types.ID, param *SimpleMonitorPatchRequest) (*SimpleMonitor, error)
 	Delete(ctx context.Context, id types.ID) error
 	MonitorResponseTime(ctx context.Context, id types.ID, condition *MonitorCondition) (*ResponseTimeSecActivity, error)
 	HealthStatus(ctx context.Context, id types.ID) (*SimpleMonitorHealthStatus, error)
@@ -535,6 +557,7 @@ type SSHKeyAPI interface {
 	Generate(ctx context.Context, param *SSHKeyGenerateRequest) (*SSHKeyGenerated, error)
 	Read(ctx context.Context, id types.ID) (*SSHKey, error)
 	Update(ctx context.Context, id types.ID, param *SSHKeyUpdateRequest) (*SSHKey, error)
+	Patch(ctx context.Context, id types.ID, param *SSHKeyPatchRequest) (*SSHKey, error)
 	Delete(ctx context.Context, id types.ID) error
 }
 
@@ -548,6 +571,7 @@ type SwitchAPI interface {
 	Create(ctx context.Context, zone string, param *SwitchCreateRequest) (*Switch, error)
 	Read(ctx context.Context, zone string, id types.ID) (*Switch, error)
 	Update(ctx context.Context, zone string, id types.ID, param *SwitchUpdateRequest) (*Switch, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *SwitchPatchRequest) (*Switch, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	ConnectToBridge(ctx context.Context, zone string, id types.ID, bridgeID types.ID) error
 	DisconnectFromBridge(ctx context.Context, zone string, id types.ID) error
@@ -563,6 +587,7 @@ type VPCRouterAPI interface {
 	Create(ctx context.Context, zone string, param *VPCRouterCreateRequest) (*VPCRouter, error)
 	Read(ctx context.Context, zone string, id types.ID) (*VPCRouter, error)
 	Update(ctx context.Context, zone string, id types.ID, param *VPCRouterUpdateRequest) (*VPCRouter, error)
+	Patch(ctx context.Context, zone string, id types.ID, param *VPCRouterPatchRequest) (*VPCRouter, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Config(ctx context.Context, zone string, id types.ID) error
 	Boot(ctx context.Context, zone string, id types.ID) error

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -77,6 +77,19 @@ type archiveUpdateResponseEnvelope struct {
 	Archive *naked.Archive `json:",omitempty"`
 }
 
+// archivePatchRequestEnvelope is envelop of API request
+type archivePatchRequestEnvelope struct {
+	Archive *naked.Archive `json:",omitempty"`
+}
+
+// archivePatchResponseEnvelope is envelop of API response
+type archivePatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Archive *naked.Archive `json:",omitempty"`
+}
+
 // archiveOpenFTPRequestEnvelope is envelop of API request
 type archiveOpenFTPRequestEnvelope struct {
 	ChangePassword bool `json:",omitempty"`
@@ -145,6 +158,19 @@ type autoBackupUpdateRequestEnvelope struct {
 
 // autoBackupUpdateResponseEnvelope is envelop of API response
 type autoBackupUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.AutoBackup `json:",omitempty"`
+}
+
+// autoBackupPatchRequestEnvelope is envelop of API request
+type autoBackupPatchRequestEnvelope struct {
+	CommonServiceItem *naked.AutoBackup `json:",omitempty"`
+}
+
+// autoBackupPatchResponseEnvelope is envelop of API response
+type autoBackupPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -257,6 +283,19 @@ type bridgeUpdateResponseEnvelope struct {
 	Bridge *naked.Bridge `json:",omitempty"`
 }
 
+// bridgePatchRequestEnvelope is envelop of API request
+type bridgePatchRequestEnvelope struct {
+	Bridge *naked.Bridge `json:",omitempty"`
+}
+
+// bridgePatchResponseEnvelope is envelop of API response
+type bridgePatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Bridge *naked.Bridge `json:",omitempty"`
+}
+
 // cDROMFindRequestEnvelope is envelop of API request
 type cDROMFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`
@@ -305,6 +344,19 @@ type cDROMUpdateRequestEnvelope struct {
 
 // cDROMUpdateResponseEnvelope is envelop of API response
 type cDROMUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CDROM *naked.CDROM `json:",omitempty"`
+}
+
+// cDROMPatchRequestEnvelope is envelop of API request
+type cDROMPatchRequestEnvelope struct {
+	CDROM *naked.CDROM `json:",omitempty"`
+}
+
+// cDROMPatchResponseEnvelope is envelop of API response
+type cDROMPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -380,6 +432,19 @@ type databaseUpdateRequestEnvelope struct {
 
 // databaseUpdateResponseEnvelope is envelop of API response
 type databaseUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.Database `json:",omitempty"`
+}
+
+// databasePatchRequestEnvelope is envelop of API request
+type databasePatchRequestEnvelope struct {
+	Appliance *naked.Database `json:",omitempty"`
+}
+
+// databasePatchResponseEnvelope is envelop of API response
+type databasePatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -553,6 +618,19 @@ type diskUpdateResponseEnvelope struct {
 	Disk *naked.Disk `json:",omitempty"`
 }
 
+// diskPatchRequestEnvelope is envelop of API request
+type diskPatchRequestEnvelope struct {
+	Disk *naked.Disk `json:",omitempty"`
+}
+
+// diskPatchResponseEnvelope is envelop of API response
+type diskPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Disk *naked.Disk `json:",omitempty"`
+}
+
 // diskMonitorRequestEnvelope is envelop of API request
 type diskMonitorRequestEnvelope struct {
 	Start time.Time `json:",omitempty"`
@@ -647,6 +725,19 @@ type dNSUpdateResponseEnvelope struct {
 	CommonServiceItem *naked.DNS `json:",omitempty"`
 }
 
+// dNSPatchRequestEnvelope is envelop of API request
+type dNSPatchRequestEnvelope struct {
+	CommonServiceItem *naked.DNS `json:",omitempty"`
+}
+
+// dNSPatchResponseEnvelope is envelop of API response
+type dNSPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.DNS `json:",omitempty"`
+}
+
 // gSLBFindRequestEnvelope is envelop of API request
 type gSLBFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`
@@ -694,6 +785,19 @@ type gSLBUpdateRequestEnvelope struct {
 
 // gSLBUpdateResponseEnvelope is envelop of API response
 type gSLBUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.GSLB `json:",omitempty"`
+}
+
+// gSLBPatchRequestEnvelope is envelop of API request
+type gSLBPatchRequestEnvelope struct {
+	CommonServiceItem *naked.GSLB `json:",omitempty"`
+}
+
+// gSLBPatchResponseEnvelope is envelop of API response
+type gSLBPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -753,6 +857,19 @@ type iconUpdateResponseEnvelope struct {
 	Icon *naked.Icon `json:",omitempty"`
 }
 
+// iconPatchRequestEnvelope is envelop of API request
+type iconPatchRequestEnvelope struct {
+	Icon *naked.Icon `json:",omitempty"`
+}
+
+// iconPatchResponseEnvelope is envelop of API response
+type iconPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Icon *naked.Icon `json:",omitempty"`
+}
+
 // interfaceFindRequestEnvelope is envelop of API request
 type interfaceFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`
@@ -800,6 +917,19 @@ type interfaceUpdateRequestEnvelope struct {
 
 // interfaceUpdateResponseEnvelope is envelop of API response
 type interfaceUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Interface *naked.Interface `json:",omitempty"`
+}
+
+// interfacePatchRequestEnvelope is envelop of API request
+type interfacePatchRequestEnvelope struct {
+	Interface *naked.Interface `json:",omitempty"`
+}
+
+// interfacePatchResponseEnvelope is envelop of API response
+type interfacePatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -867,6 +997,19 @@ type internetUpdateRequestEnvelope struct {
 
 // internetUpdateResponseEnvelope is envelop of API response
 type internetUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Internet *naked.Internet `json:",omitempty"`
+}
+
+// internetPatchRequestEnvelope is envelop of API request
+type internetPatchRequestEnvelope struct {
+	Internet *naked.Internet `json:",omitempty"`
+}
+
+// internetPatchResponseEnvelope is envelop of API response
+type internetPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -1115,6 +1258,19 @@ type licenseUpdateResponseEnvelope struct {
 	License *naked.License `json:",omitempty"`
 }
 
+// licensePatchRequestEnvelope is envelop of API request
+type licensePatchRequestEnvelope struct {
+	License *naked.License `json:",omitempty"`
+}
+
+// licensePatchResponseEnvelope is envelop of API response
+type licensePatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	License *naked.License `json:",omitempty"`
+}
+
 // licenseInfoFindRequestEnvelope is envelop of API request
 type licenseInfoFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`
@@ -1189,6 +1345,19 @@ type loadBalancerUpdateRequestEnvelope struct {
 
 // loadBalancerUpdateResponseEnvelope is envelop of API response
 type loadBalancerUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.LoadBalancer `json:",omitempty"`
+}
+
+// loadBalancerPatchRequestEnvelope is envelop of API request
+type loadBalancerPatchRequestEnvelope struct {
+	Appliance *naked.LoadBalancer `json:",omitempty"`
+}
+
+// loadBalancerPatchResponseEnvelope is envelop of API response
+type loadBalancerPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -1270,6 +1439,19 @@ type mobileGatewayUpdateRequestEnvelope struct {
 
 // mobileGatewayUpdateResponseEnvelope is envelop of API response
 type mobileGatewayUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.MobileGateway `json:",omitempty"`
+}
+
+// mobileGatewayPatchRequestEnvelope is envelop of API request
+type mobileGatewayPatchRequestEnvelope struct {
+	Appliance *naked.MobileGateway `json:",omitempty"`
+}
+
+// mobileGatewayPatchResponseEnvelope is envelop of API response
+type mobileGatewayPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -1416,6 +1598,19 @@ type nFSUpdateResponseEnvelope struct {
 	Appliance *naked.NFS `json:",omitempty"`
 }
 
+// nFSPatchRequestEnvelope is envelop of API request
+type nFSPatchRequestEnvelope struct {
+	Appliance *naked.NFS `json:",omitempty"`
+}
+
+// nFSPatchResponseEnvelope is envelop of API response
+type nFSPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.NFS `json:",omitempty"`
+}
+
 // nFSShutdownRequestEnvelope is envelop of API request
 type nFSShutdownRequestEnvelope struct {
 	Force bool `json:",omitempty"`
@@ -1502,6 +1697,19 @@ type noteUpdateResponseEnvelope struct {
 	Note *naked.Note `json:",omitempty"`
 }
 
+// notePatchRequestEnvelope is envelop of API request
+type notePatchRequestEnvelope struct {
+	Note *naked.Note `json:",omitempty"`
+}
+
+// notePatchResponseEnvelope is envelop of API response
+type notePatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Note *naked.Note `json:",omitempty"`
+}
+
 // packetFilterFindRequestEnvelope is envelop of API request
 type packetFilterFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`
@@ -1555,6 +1763,19 @@ type packetFilterUpdateResponseEnvelope struct {
 	PacketFilter *naked.PacketFilter `json:",omitempty"`
 }
 
+// packetFilterPatchRequestEnvelope is envelop of API request
+type packetFilterPatchRequestEnvelope struct {
+	PacketFilter *naked.PacketFilter `json:",omitempty"`
+}
+
+// packetFilterPatchResponseEnvelope is envelop of API response
+type packetFilterPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	PacketFilter *naked.PacketFilter `json:",omitempty"`
+}
+
 // privateHostFindRequestEnvelope is envelop of API request
 type privateHostFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`
@@ -1602,6 +1823,19 @@ type privateHostUpdateRequestEnvelope struct {
 
 // privateHostUpdateResponseEnvelope is envelop of API response
 type privateHostUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	PrivateHost *naked.PrivateHost `json:",omitempty"`
+}
+
+// privateHostPatchRequestEnvelope is envelop of API request
+type privateHostPatchRequestEnvelope struct {
+	PrivateHost *naked.PrivateHost `json:",omitempty"`
+}
+
+// privateHostPatchResponseEnvelope is envelop of API response
+type privateHostPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -1682,6 +1916,19 @@ type proxyLBUpdateRequestEnvelope struct {
 
 // proxyLBUpdateResponseEnvelope is envelop of API response
 type proxyLBUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.ProxyLB `json:",omitempty"`
+}
+
+// proxyLBPatchRequestEnvelope is envelop of API request
+type proxyLBPatchRequestEnvelope struct {
+	CommonServiceItem *naked.ProxyLB `json:",omitempty"`
+}
+
+// proxyLBPatchResponseEnvelope is envelop of API response
+type proxyLBPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -1818,6 +2065,19 @@ type serverUpdateRequestEnvelope struct {
 
 // serverUpdateResponseEnvelope is envelop of API response
 type serverUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Server *naked.Server `json:",omitempty"`
+}
+
+// serverPatchRequestEnvelope is envelop of API request
+type serverPatchRequestEnvelope struct {
+	Server *naked.Server `json:",omitempty"`
+}
+
+// serverPatchResponseEnvelope is envelop of API response
+type serverPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
@@ -1987,6 +2247,19 @@ type sIMUpdateResponseEnvelope struct {
 	CommonServiceItem *naked.SIM `json:",omitempty"`
 }
 
+// sIMPatchRequestEnvelope is envelop of API request
+type sIMPatchRequestEnvelope struct {
+	CommonServiceItem *naked.SIM `json:",omitempty"`
+}
+
+// sIMPatchResponseEnvelope is envelop of API response
+type sIMPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.SIM `json:",omitempty"`
+}
+
 // sIMAssignIPRequestEnvelope is envelop of API request
 type sIMAssignIPRequestEnvelope struct {
 	SIM *naked.SIMAssignIPRequest `json:"sim"`
@@ -2094,6 +2367,19 @@ type simpleMonitorUpdateResponseEnvelope struct {
 	CommonServiceItem *naked.SimpleMonitor `json:",omitempty"`
 }
 
+// simpleMonitorPatchRequestEnvelope is envelop of API request
+type simpleMonitorPatchRequestEnvelope struct {
+	CommonServiceItem *naked.SimpleMonitor `json:",omitempty"`
+}
+
+// simpleMonitorPatchResponseEnvelope is envelop of API response
+type simpleMonitorPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.SimpleMonitor `json:",omitempty"`
+}
+
 // simpleMonitorMonitorResponseTimeRequestEnvelope is envelop of API request
 type simpleMonitorMonitorResponseTimeRequestEnvelope struct {
 	Start time.Time `json:",omitempty"`
@@ -2182,6 +2468,19 @@ type sSHKeyUpdateResponseEnvelope struct {
 	SSHKey *naked.SSHKey `json:",omitempty"`
 }
 
+// sSHKeyPatchRequestEnvelope is envelop of API request
+type sSHKeyPatchRequestEnvelope struct {
+	SSHKey *naked.SSHKey `json:",omitempty"`
+}
+
+// sSHKeyPatchResponseEnvelope is envelop of API response
+type sSHKeyPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	SSHKey *naked.SSHKey `json:",omitempty"`
+}
+
 // switchFindRequestEnvelope is envelop of API request
 type switchFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`
@@ -2235,6 +2534,19 @@ type switchUpdateResponseEnvelope struct {
 	Switch *naked.Switch `json:",omitempty"`
 }
 
+// switchPatchRequestEnvelope is envelop of API request
+type switchPatchRequestEnvelope struct {
+	Switch *naked.Switch `json:",omitempty"`
+}
+
+// switchPatchResponseEnvelope is envelop of API response
+type switchPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Switch *naked.Switch `json:",omitempty"`
+}
+
 // vPCRouterFindRequestEnvelope is envelop of API request
 type vPCRouterFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`
@@ -2282,6 +2594,19 @@ type vPCRouterUpdateRequestEnvelope struct {
 
 // vPCRouterUpdateResponseEnvelope is envelop of API response
 type vPCRouterUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.VPCRouter `json:",omitempty"`
+}
+
+// vPCRouterPatchRequestEnvelope is envelop of API request
+type vPCRouterPatchRequestEnvelope struct {
+	Appliance *naked.VPCRouter `json:",omitempty"`
+}
+
+// vPCRouterPatchResponseEnvelope is envelop of API response
+type vPCRouterPatchResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -1129,6 +1129,137 @@ func (o *ArchiveUpdateRequest) SetIconID(v types.ID) {
 }
 
 /*************************************************
+* ArchivePatchRequest
+*************************************************/
+
+// ArchivePatchRequest represents API parameter/response structure
+type ArchivePatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+}
+
+// Validate validates by field tags
+func (o *ArchivePatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ArchivePatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+	}
+}
+
+// GetName returns value of Name
+func (o *ArchivePatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *ArchivePatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *ArchivePatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *ArchivePatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *ArchivePatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *ArchivePatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *ArchivePatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *ArchivePatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *ArchivePatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *ArchivePatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *ArchivePatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *ArchivePatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *ArchivePatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *ArchivePatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *ArchivePatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *ArchivePatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *ArchivePatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *ArchivePatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+/*************************************************
 * OpenFTPRequest
 *************************************************/
 
@@ -1857,6 +1988,204 @@ func (o *AutoBackupUpdateRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *AutoBackupUpdateRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* AutoBackupPatchRequest
+*************************************************/
+
+// AutoBackupPatchRequest represents API parameter/response structure
+type AutoBackupPatchRequest struct {
+	Name                                string `validate:"required"`
+	Description                         string `validate:"min=0,max=512"`
+	PatchEmptyToDescription             bool
+	Tags                                types.Tags
+	PatchEmptyToTags                    bool
+	IconID                              types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID                  bool
+	BackupSpanWeekdays                  []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
+	PatchEmptyToBackupSpanWeekdays      bool
+	MaximumNumberOfArchives             int `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
+	PatchEmptyToMaximumNumberOfArchives bool
+	SettingsHash                        string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *AutoBackupPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *AutoBackupPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                                string `validate:"required"`
+		Description                         string `validate:"min=0,max=512"`
+		PatchEmptyToDescription             bool
+		Tags                                types.Tags
+		PatchEmptyToTags                    bool
+		IconID                              types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID                  bool
+		BackupSpanWeekdays                  []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
+		PatchEmptyToBackupSpanWeekdays      bool
+		MaximumNumberOfArchives             int `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
+		PatchEmptyToMaximumNumberOfArchives bool
+		SettingsHash                        string                `json:",omitempty" mapconv:",omitempty"`
+		BackupSpanType                      types.EBackupSpanType `mapconv:"Settings.Autobackup.BackupSpanType"`
+	}{
+		Name:                                o.GetName(),
+		Description:                         o.GetDescription(),
+		PatchEmptyToDescription:             o.GetPatchEmptyToDescription(),
+		Tags:                                o.GetTags(),
+		PatchEmptyToTags:                    o.GetPatchEmptyToTags(),
+		IconID:                              o.GetIconID(),
+		PatchEmptyToIconID:                  o.GetPatchEmptyToIconID(),
+		BackupSpanWeekdays:                  o.GetBackupSpanWeekdays(),
+		PatchEmptyToBackupSpanWeekdays:      o.GetPatchEmptyToBackupSpanWeekdays(),
+		MaximumNumberOfArchives:             o.GetMaximumNumberOfArchives(),
+		PatchEmptyToMaximumNumberOfArchives: o.GetPatchEmptyToMaximumNumberOfArchives(),
+		SettingsHash:                        o.GetSettingsHash(),
+		BackupSpanType:                      types.BackupSpanTypes.Weekdays,
+	}
+}
+
+// GetName returns value of Name
+func (o *AutoBackupPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *AutoBackupPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *AutoBackupPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *AutoBackupPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *AutoBackupPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *AutoBackupPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *AutoBackupPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *AutoBackupPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *AutoBackupPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *AutoBackupPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *AutoBackupPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *AutoBackupPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *AutoBackupPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *AutoBackupPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *AutoBackupPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *AutoBackupPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *AutoBackupPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *AutoBackupPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetBackupSpanWeekdays returns value of BackupSpanWeekdays
+func (o *AutoBackupPatchRequest) GetBackupSpanWeekdays() []types.EBackupSpanWeekday {
+	return o.BackupSpanWeekdays
+}
+
+// SetBackupSpanWeekdays sets value to BackupSpanWeekdays
+func (o *AutoBackupPatchRequest) SetBackupSpanWeekdays(v []types.EBackupSpanWeekday) {
+	o.BackupSpanWeekdays = v
+}
+
+// GetPatchEmptyToBackupSpanWeekdays returns value of PatchEmptyToBackupSpanWeekdays
+func (o *AutoBackupPatchRequest) GetPatchEmptyToBackupSpanWeekdays() bool {
+	return o.PatchEmptyToBackupSpanWeekdays
+}
+
+// SetPatchEmptyToBackupSpanWeekdays sets value to PatchEmptyToBackupSpanWeekdays
+func (o *AutoBackupPatchRequest) SetPatchEmptyToBackupSpanWeekdays(v bool) {
+	o.PatchEmptyToBackupSpanWeekdays = v
+}
+
+// GetMaximumNumberOfArchives returns value of MaximumNumberOfArchives
+func (o *AutoBackupPatchRequest) GetMaximumNumberOfArchives() int {
+	return o.MaximumNumberOfArchives
+}
+
+// SetMaximumNumberOfArchives sets value to MaximumNumberOfArchives
+func (o *AutoBackupPatchRequest) SetMaximumNumberOfArchives(v int) {
+	o.MaximumNumberOfArchives = v
+}
+
+// GetPatchEmptyToMaximumNumberOfArchives returns value of PatchEmptyToMaximumNumberOfArchives
+func (o *AutoBackupPatchRequest) GetPatchEmptyToMaximumNumberOfArchives() bool {
+	return o.PatchEmptyToMaximumNumberOfArchives
+}
+
+// SetPatchEmptyToMaximumNumberOfArchives sets value to PatchEmptyToMaximumNumberOfArchives
+func (o *AutoBackupPatchRequest) SetPatchEmptyToMaximumNumberOfArchives(v bool) {
+	o.PatchEmptyToMaximumNumberOfArchives = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *AutoBackupPatchRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *AutoBackupPatchRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 
@@ -2720,6 +3049,65 @@ func (o *BridgeUpdateRequest) SetDescription(v string) {
 }
 
 /*************************************************
+* BridgePatchRequest
+*************************************************/
+
+// BridgePatchRequest represents API parameter/response structure
+type BridgePatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+}
+
+// Validate validates by field tags
+func (o *BridgePatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *BridgePatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+	}
+}
+
+// GetName returns value of Name
+func (o *BridgePatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *BridgePatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *BridgePatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *BridgePatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *BridgePatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *BridgePatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+/*************************************************
 * CDROM
 *************************************************/
 
@@ -3127,6 +3515,137 @@ func (o *CDROMUpdateRequest) GetIconID() types.ID {
 // SetIconID sets value to IconID
 func (o *CDROMUpdateRequest) SetIconID(v types.ID) {
 	o.IconID = v
+}
+
+/*************************************************
+* CDROMPatchRequest
+*************************************************/
+
+// CDROMPatchRequest represents API parameter/response structure
+type CDROMPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+}
+
+// Validate validates by field tags
+func (o *CDROMPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *CDROMPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+	}
+}
+
+// GetName returns value of Name
+func (o *CDROMPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *CDROMPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *CDROMPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *CDROMPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *CDROMPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *CDROMPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *CDROMPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *CDROMPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *CDROMPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *CDROMPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *CDROMPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *CDROMPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *CDROMPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *CDROMPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *CDROMPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *CDROMPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *CDROMPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *CDROMPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
 }
 
 /*************************************************
@@ -4697,6 +5216,228 @@ func (o *DatabaseSettingCommonUpdate) GetUserPassword() string {
 // SetUserPassword sets value to UserPassword
 func (o *DatabaseSettingCommonUpdate) SetUserPassword(v string) {
 	o.UserPassword = v
+}
+
+/*************************************************
+* DatabasePatchRequest
+*************************************************/
+
+// DatabasePatchRequest represents API parameter/response structure
+type DatabasePatchRequest struct {
+	Name                           string `validate:"required"`
+	Description                    string `validate:"min=0,max=512"`
+	PatchEmptyToDescription        bool
+	Tags                           types.Tags
+	PatchEmptyToTags               bool
+	IconID                         types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID             bool
+	CommonSetting                  *DatabaseSettingCommonUpdate `mapconv:"Settings.DBConf.Common,recursive"`
+	PatchEmptyToCommonSetting      bool
+	BackupSetting                  *DatabaseSettingBackup `mapconv:"Settings.DBConf.Backup,recursive"`
+	PatchEmptyToBackupSetting      bool
+	ReplicationSetting             *DatabaseReplicationSetting `mapconv:"Settings.DBConf.Replication,recursive"`
+	PatchEmptyToReplicationSetting bool
+	SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *DatabasePatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *DatabasePatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                           string `validate:"required"`
+		Description                    string `validate:"min=0,max=512"`
+		PatchEmptyToDescription        bool
+		Tags                           types.Tags
+		PatchEmptyToTags               bool
+		IconID                         types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID             bool
+		CommonSetting                  *DatabaseSettingCommonUpdate `mapconv:"Settings.DBConf.Common,recursive"`
+		PatchEmptyToCommonSetting      bool
+		BackupSetting                  *DatabaseSettingBackup `mapconv:"Settings.DBConf.Backup,recursive"`
+		PatchEmptyToBackupSetting      bool
+		ReplicationSetting             *DatabaseReplicationSetting `mapconv:"Settings.DBConf.Replication,recursive"`
+		PatchEmptyToReplicationSetting bool
+		SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Name:                           o.GetName(),
+		Description:                    o.GetDescription(),
+		PatchEmptyToDescription:        o.GetPatchEmptyToDescription(),
+		Tags:                           o.GetTags(),
+		PatchEmptyToTags:               o.GetPatchEmptyToTags(),
+		IconID:                         o.GetIconID(),
+		PatchEmptyToIconID:             o.GetPatchEmptyToIconID(),
+		CommonSetting:                  o.GetCommonSetting(),
+		PatchEmptyToCommonSetting:      o.GetPatchEmptyToCommonSetting(),
+		BackupSetting:                  o.GetBackupSetting(),
+		PatchEmptyToBackupSetting:      o.GetPatchEmptyToBackupSetting(),
+		ReplicationSetting:             o.GetReplicationSetting(),
+		PatchEmptyToReplicationSetting: o.GetPatchEmptyToReplicationSetting(),
+		SettingsHash:                   o.GetSettingsHash(),
+	}
+}
+
+// GetName returns value of Name
+func (o *DatabasePatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *DatabasePatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *DatabasePatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *DatabasePatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *DatabasePatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *DatabasePatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *DatabasePatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *DatabasePatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *DatabasePatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *DatabasePatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *DatabasePatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *DatabasePatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *DatabasePatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *DatabasePatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *DatabasePatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *DatabasePatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *DatabasePatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *DatabasePatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetCommonSetting returns value of CommonSetting
+func (o *DatabasePatchRequest) GetCommonSetting() *DatabaseSettingCommonUpdate {
+	return o.CommonSetting
+}
+
+// SetCommonSetting sets value to CommonSetting
+func (o *DatabasePatchRequest) SetCommonSetting(v *DatabaseSettingCommonUpdate) {
+	o.CommonSetting = v
+}
+
+// GetPatchEmptyToCommonSetting returns value of PatchEmptyToCommonSetting
+func (o *DatabasePatchRequest) GetPatchEmptyToCommonSetting() bool {
+	return o.PatchEmptyToCommonSetting
+}
+
+// SetPatchEmptyToCommonSetting sets value to PatchEmptyToCommonSetting
+func (o *DatabasePatchRequest) SetPatchEmptyToCommonSetting(v bool) {
+	o.PatchEmptyToCommonSetting = v
+}
+
+// GetBackupSetting returns value of BackupSetting
+func (o *DatabasePatchRequest) GetBackupSetting() *DatabaseSettingBackup {
+	return o.BackupSetting
+}
+
+// SetBackupSetting sets value to BackupSetting
+func (o *DatabasePatchRequest) SetBackupSetting(v *DatabaseSettingBackup) {
+	o.BackupSetting = v
+}
+
+// GetPatchEmptyToBackupSetting returns value of PatchEmptyToBackupSetting
+func (o *DatabasePatchRequest) GetPatchEmptyToBackupSetting() bool {
+	return o.PatchEmptyToBackupSetting
+}
+
+// SetPatchEmptyToBackupSetting sets value to PatchEmptyToBackupSetting
+func (o *DatabasePatchRequest) SetPatchEmptyToBackupSetting(v bool) {
+	o.PatchEmptyToBackupSetting = v
+}
+
+// GetReplicationSetting returns value of ReplicationSetting
+func (o *DatabasePatchRequest) GetReplicationSetting() *DatabaseReplicationSetting {
+	return o.ReplicationSetting
+}
+
+// SetReplicationSetting sets value to ReplicationSetting
+func (o *DatabasePatchRequest) SetReplicationSetting(v *DatabaseReplicationSetting) {
+	o.ReplicationSetting = v
+}
+
+// GetPatchEmptyToReplicationSetting returns value of PatchEmptyToReplicationSetting
+func (o *DatabasePatchRequest) GetPatchEmptyToReplicationSetting() bool {
+	return o.PatchEmptyToReplicationSetting
+}
+
+// SetPatchEmptyToReplicationSetting sets value to PatchEmptyToReplicationSetting
+func (o *DatabasePatchRequest) SetPatchEmptyToReplicationSetting(v bool) {
+	o.PatchEmptyToReplicationSetting = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *DatabasePatchRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *DatabasePatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
 }
 
 /*************************************************
@@ -6535,6 +7276,163 @@ func (o *DiskUpdateRequest) SetConnection(v types.EDiskConnection) {
 }
 
 /*************************************************
+* DiskPatchRequest
+*************************************************/
+
+// DiskPatchRequest represents API parameter/response structure
+type DiskPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+	Connection              types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
+	PatchEmptyToConnection  bool
+}
+
+// Validate validates by field tags
+func (o *DiskPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *DiskPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+		Connection              types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
+		PatchEmptyToConnection  bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+		Connection:              o.GetConnection(),
+		PatchEmptyToConnection:  o.GetPatchEmptyToConnection(),
+	}
+}
+
+// GetName returns value of Name
+func (o *DiskPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *DiskPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *DiskPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *DiskPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *DiskPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *DiskPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *DiskPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *DiskPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *DiskPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *DiskPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *DiskPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *DiskPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *DiskPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *DiskPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *DiskPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *DiskPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *DiskPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *DiskPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetConnection returns value of Connection
+func (o *DiskPatchRequest) GetConnection() types.EDiskConnection {
+	return o.Connection
+}
+
+// SetConnection sets value to Connection
+func (o *DiskPatchRequest) SetConnection(v types.EDiskConnection) {
+	o.Connection = v
+}
+
+// GetPatchEmptyToConnection returns value of PatchEmptyToConnection
+func (o *DiskPatchRequest) GetPatchEmptyToConnection() bool {
+	return o.PatchEmptyToConnection
+}
+
+// SetPatchEmptyToConnection sets value to PatchEmptyToConnection
+func (o *DiskPatchRequest) SetPatchEmptyToConnection(v bool) {
+	o.PatchEmptyToConnection = v
+}
+
+/*************************************************
 * DiskPlan
 *************************************************/
 
@@ -7218,6 +8116,163 @@ func (o *DNSUpdateRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *DNSUpdateRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* DNSPatchRequest
+*************************************************/
+
+// DNSPatchRequest represents API parameter/response structure
+type DNSPatchRequest struct {
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+	Records                 []*DNSRecord `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+	PatchEmptyToRecords     bool
+	SettingsHash            string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *DNSPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *DNSPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+		Records                 []*DNSRecord `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+		PatchEmptyToRecords     bool
+		SettingsHash            string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+		Records:                 o.GetRecords(),
+		PatchEmptyToRecords:     o.GetPatchEmptyToRecords(),
+		SettingsHash:            o.GetSettingsHash(),
+	}
+}
+
+// GetDescription returns value of Description
+func (o *DNSPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *DNSPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *DNSPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *DNSPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *DNSPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *DNSPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *DNSPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *DNSPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *DNSPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *DNSPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *DNSPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *DNSPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *DNSPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *DNSPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *DNSPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *DNSPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetRecords returns value of Records
+func (o *DNSPatchRequest) GetRecords() []*DNSRecord {
+	return o.Records
+}
+
+// SetRecords sets value to Records
+func (o *DNSPatchRequest) SetRecords(v []*DNSRecord) {
+	o.Records = v
+}
+
+// GetPatchEmptyToRecords returns value of PatchEmptyToRecords
+func (o *DNSPatchRequest) GetPatchEmptyToRecords() bool {
+	return o.PatchEmptyToRecords
+}
+
+// SetPatchEmptyToRecords sets value to PatchEmptyToRecords
+func (o *DNSPatchRequest) SetPatchEmptyToRecords(v bool) {
+	o.PatchEmptyToRecords = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *DNSPatchRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *DNSPatchRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 
@@ -7959,6 +9014,283 @@ func (o *GSLBUpdateRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* GSLBPatchRequest
+*************************************************/
+
+// GSLBPatchRequest represents API parameter/response structure
+type GSLBPatchRequest struct {
+	Name                           string `validate:"required"`
+	Description                    string `validate:"min=0,max=512"`
+	PatchEmptyToDescription        bool
+	Tags                           types.Tags
+	PatchEmptyToTags               bool
+	IconID                         types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID             bool
+	HealthCheck                    *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
+	PatchEmptyToHealthCheck        bool
+	DelayLoop                      int `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+	PatchEmptyToDelayLoop          bool
+	Weighted                       types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
+	PatchEmptyToWeighted           bool
+	SorryServer                    string `mapconv:"Settings.GSLB.SorryServer"`
+	PatchEmptyToSorryServer        bool
+	DestinationServers             []*GSLBServer `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+	PatchEmptyToDestinationServers bool
+	SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *GSLBPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *GSLBPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                           string `validate:"required"`
+		Description                    string `validate:"min=0,max=512"`
+		PatchEmptyToDescription        bool
+		Tags                           types.Tags
+		PatchEmptyToTags               bool
+		IconID                         types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID             bool
+		HealthCheck                    *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
+		PatchEmptyToHealthCheck        bool
+		DelayLoop                      int `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+		PatchEmptyToDelayLoop          bool
+		Weighted                       types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
+		PatchEmptyToWeighted           bool
+		SorryServer                    string `mapconv:"Settings.GSLB.SorryServer"`
+		PatchEmptyToSorryServer        bool
+		DestinationServers             []*GSLBServer `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+		PatchEmptyToDestinationServers bool
+		SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Name:                           o.GetName(),
+		Description:                    o.GetDescription(),
+		PatchEmptyToDescription:        o.GetPatchEmptyToDescription(),
+		Tags:                           o.GetTags(),
+		PatchEmptyToTags:               o.GetPatchEmptyToTags(),
+		IconID:                         o.GetIconID(),
+		PatchEmptyToIconID:             o.GetPatchEmptyToIconID(),
+		HealthCheck:                    o.GetHealthCheck(),
+		PatchEmptyToHealthCheck:        o.GetPatchEmptyToHealthCheck(),
+		DelayLoop:                      o.GetDelayLoop(),
+		PatchEmptyToDelayLoop:          o.GetPatchEmptyToDelayLoop(),
+		Weighted:                       o.GetWeighted(),
+		PatchEmptyToWeighted:           o.GetPatchEmptyToWeighted(),
+		SorryServer:                    o.GetSorryServer(),
+		PatchEmptyToSorryServer:        o.GetPatchEmptyToSorryServer(),
+		DestinationServers:             o.GetDestinationServers(),
+		PatchEmptyToDestinationServers: o.GetPatchEmptyToDestinationServers(),
+		SettingsHash:                   o.GetSettingsHash(),
+	}
+}
+
+// GetName returns value of Name
+func (o *GSLBPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *GSLBPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *GSLBPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *GSLBPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *GSLBPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *GSLBPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *GSLBPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *GSLBPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *GSLBPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *GSLBPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *GSLBPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *GSLBPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *GSLBPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *GSLBPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *GSLBPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *GSLBPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *GSLBPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *GSLBPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetHealthCheck returns value of HealthCheck
+func (o *GSLBPatchRequest) GetHealthCheck() *GSLBHealthCheck {
+	return o.HealthCheck
+}
+
+// SetHealthCheck sets value to HealthCheck
+func (o *GSLBPatchRequest) SetHealthCheck(v *GSLBHealthCheck) {
+	o.HealthCheck = v
+}
+
+// GetPatchEmptyToHealthCheck returns value of PatchEmptyToHealthCheck
+func (o *GSLBPatchRequest) GetPatchEmptyToHealthCheck() bool {
+	return o.PatchEmptyToHealthCheck
+}
+
+// SetPatchEmptyToHealthCheck sets value to PatchEmptyToHealthCheck
+func (o *GSLBPatchRequest) SetPatchEmptyToHealthCheck(v bool) {
+	o.PatchEmptyToHealthCheck = v
+}
+
+// GetDelayLoop returns value of DelayLoop
+func (o *GSLBPatchRequest) GetDelayLoop() int {
+	if o.DelayLoop == 0 {
+		return 10
+	}
+	return o.DelayLoop
+}
+
+// SetDelayLoop sets value to DelayLoop
+func (o *GSLBPatchRequest) SetDelayLoop(v int) {
+	o.DelayLoop = v
+}
+
+// GetPatchEmptyToDelayLoop returns value of PatchEmptyToDelayLoop
+func (o *GSLBPatchRequest) GetPatchEmptyToDelayLoop() bool {
+	return o.PatchEmptyToDelayLoop
+}
+
+// SetPatchEmptyToDelayLoop sets value to PatchEmptyToDelayLoop
+func (o *GSLBPatchRequest) SetPatchEmptyToDelayLoop(v bool) {
+	o.PatchEmptyToDelayLoop = v
+}
+
+// GetWeighted returns value of Weighted
+func (o *GSLBPatchRequest) GetWeighted() types.StringFlag {
+	return o.Weighted
+}
+
+// SetWeighted sets value to Weighted
+func (o *GSLBPatchRequest) SetWeighted(v types.StringFlag) {
+	o.Weighted = v
+}
+
+// GetPatchEmptyToWeighted returns value of PatchEmptyToWeighted
+func (o *GSLBPatchRequest) GetPatchEmptyToWeighted() bool {
+	return o.PatchEmptyToWeighted
+}
+
+// SetPatchEmptyToWeighted sets value to PatchEmptyToWeighted
+func (o *GSLBPatchRequest) SetPatchEmptyToWeighted(v bool) {
+	o.PatchEmptyToWeighted = v
+}
+
+// GetSorryServer returns value of SorryServer
+func (o *GSLBPatchRequest) GetSorryServer() string {
+	return o.SorryServer
+}
+
+// SetSorryServer sets value to SorryServer
+func (o *GSLBPatchRequest) SetSorryServer(v string) {
+	o.SorryServer = v
+}
+
+// GetPatchEmptyToSorryServer returns value of PatchEmptyToSorryServer
+func (o *GSLBPatchRequest) GetPatchEmptyToSorryServer() bool {
+	return o.PatchEmptyToSorryServer
+}
+
+// SetPatchEmptyToSorryServer sets value to PatchEmptyToSorryServer
+func (o *GSLBPatchRequest) SetPatchEmptyToSorryServer(v bool) {
+	o.PatchEmptyToSorryServer = v
+}
+
+// GetDestinationServers returns value of DestinationServers
+func (o *GSLBPatchRequest) GetDestinationServers() []*GSLBServer {
+	return o.DestinationServers
+}
+
+// SetDestinationServers sets value to DestinationServers
+func (o *GSLBPatchRequest) SetDestinationServers(v []*GSLBServer) {
+	o.DestinationServers = v
+}
+
+// GetPatchEmptyToDestinationServers returns value of PatchEmptyToDestinationServers
+func (o *GSLBPatchRequest) GetPatchEmptyToDestinationServers() bool {
+	return o.PatchEmptyToDestinationServers
+}
+
+// SetPatchEmptyToDestinationServers sets value to PatchEmptyToDestinationServers
+func (o *GSLBPatchRequest) SetPatchEmptyToDestinationServers(v bool) {
+	o.PatchEmptyToDestinationServers = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *GSLBPatchRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *GSLBPatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * Icon
 *************************************************/
 
@@ -8268,6 +9600,85 @@ func (o *IconUpdateRequest) ClearTags() {
 }
 
 /*************************************************
+* IconPatchRequest
+*************************************************/
+
+// IconPatchRequest represents API parameter/response structure
+type IconPatchRequest struct {
+	Name             string `validate:"required"`
+	Tags             types.Tags
+	PatchEmptyToTags bool
+}
+
+// Validate validates by field tags
+func (o *IconPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *IconPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name             string `validate:"required"`
+		Tags             types.Tags
+		PatchEmptyToTags bool
+	}{
+		Name:             o.GetName(),
+		Tags:             o.GetTags(),
+		PatchEmptyToTags: o.GetPatchEmptyToTags(),
+	}
+}
+
+// GetName returns value of Name
+func (o *IconPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *IconPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetTags returns value of Tags
+func (o *IconPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *IconPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *IconPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *IconPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *IconPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *IconPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *IconPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *IconPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+/*************************************************
 * Interface
 *************************************************/
 
@@ -8488,6 +9899,52 @@ func (o *InterfaceUpdateRequest) GetUserIPAddress() string {
 // SetUserIPAddress sets value to UserIPAddress
 func (o *InterfaceUpdateRequest) SetUserIPAddress(v string) {
 	o.UserIPAddress = v
+}
+
+/*************************************************
+* InterfacePatchRequest
+*************************************************/
+
+// InterfacePatchRequest represents API parameter/response structure
+type InterfacePatchRequest struct {
+	UserIPAddress             string
+	PatchEmptyToUserIPAddress bool
+}
+
+// Validate validates by field tags
+func (o *InterfacePatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *InterfacePatchRequest) setDefaults() interface{} {
+	return &struct {
+		UserIPAddress             string
+		PatchEmptyToUserIPAddress bool
+	}{
+		UserIPAddress:             o.GetUserIPAddress(),
+		PatchEmptyToUserIPAddress: o.GetPatchEmptyToUserIPAddress(),
+	}
+}
+
+// GetUserIPAddress returns value of UserIPAddress
+func (o *InterfacePatchRequest) GetUserIPAddress() string {
+	return o.UserIPAddress
+}
+
+// SetUserIPAddress sets value to UserIPAddress
+func (o *InterfacePatchRequest) SetUserIPAddress(v string) {
+	o.UserIPAddress = v
+}
+
+// GetPatchEmptyToUserIPAddress returns value of PatchEmptyToUserIPAddress
+func (o *InterfacePatchRequest) GetPatchEmptyToUserIPAddress() bool {
+	return o.PatchEmptyToUserIPAddress
+}
+
+// SetPatchEmptyToUserIPAddress sets value to PatchEmptyToUserIPAddress
+func (o *InterfacePatchRequest) SetPatchEmptyToUserIPAddress(v bool) {
+	o.PatchEmptyToUserIPAddress = v
 }
 
 /*************************************************
@@ -9223,6 +10680,137 @@ func (o *InternetUpdateRequest) GetIconID() types.ID {
 // SetIconID sets value to IconID
 func (o *InternetUpdateRequest) SetIconID(v types.ID) {
 	o.IconID = v
+}
+
+/*************************************************
+* InternetPatchRequest
+*************************************************/
+
+// InternetPatchRequest represents API parameter/response structure
+type InternetPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+}
+
+// Validate validates by field tags
+func (o *InternetPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *InternetPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+	}
+}
+
+// GetName returns value of Name
+func (o *InternetPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *InternetPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *InternetPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *InternetPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *InternetPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *InternetPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *InternetPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *InternetPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *InternetPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *InternetPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *InternetPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *InternetPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *InternetPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *InternetPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *InternetPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *InternetPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *InternetPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *InternetPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
 }
 
 /*************************************************
@@ -10256,6 +11844,39 @@ func (o *LicenseUpdateRequest) SetName(v string) {
 }
 
 /*************************************************
+* LicensePatchRequest
+*************************************************/
+
+// LicensePatchRequest represents API parameter/response structure
+type LicensePatchRequest struct {
+	Name string `validate:"required"`
+}
+
+// Validate validates by field tags
+func (o *LicensePatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LicensePatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name string `validate:"required"`
+	}{
+		Name: o.GetName(),
+	}
+}
+
+// GetName returns value of Name
+func (o *LicensePatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *LicensePatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+/*************************************************
 * LicenseInfo
 *************************************************/
 
@@ -11251,6 +12872,176 @@ func (o *LoadBalancerUpdateRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *LoadBalancerUpdateRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* LoadBalancerPatchRequest
+*************************************************/
+
+// LoadBalancerPatchRequest represents API parameter/response structure
+type LoadBalancerPatchRequest struct {
+	Name                           string `validate:"required"`
+	Description                    string `validate:"min=0,max=512"`
+	PatchEmptyToDescription        bool
+	Tags                           types.Tags
+	PatchEmptyToTags               bool
+	IconID                         types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID             bool
+	VirtualIPAddresses             []*LoadBalancerVirtualIPAddress `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+	PatchEmptyToVirtualIPAddresses bool
+	SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *LoadBalancerPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LoadBalancerPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                           string `validate:"required"`
+		Description                    string `validate:"min=0,max=512"`
+		PatchEmptyToDescription        bool
+		Tags                           types.Tags
+		PatchEmptyToTags               bool
+		IconID                         types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID             bool
+		VirtualIPAddresses             []*LoadBalancerVirtualIPAddress `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+		PatchEmptyToVirtualIPAddresses bool
+		SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Name:                           o.GetName(),
+		Description:                    o.GetDescription(),
+		PatchEmptyToDescription:        o.GetPatchEmptyToDescription(),
+		Tags:                           o.GetTags(),
+		PatchEmptyToTags:               o.GetPatchEmptyToTags(),
+		IconID:                         o.GetIconID(),
+		PatchEmptyToIconID:             o.GetPatchEmptyToIconID(),
+		VirtualIPAddresses:             o.GetVirtualIPAddresses(),
+		PatchEmptyToVirtualIPAddresses: o.GetPatchEmptyToVirtualIPAddresses(),
+		SettingsHash:                   o.GetSettingsHash(),
+	}
+}
+
+// GetName returns value of Name
+func (o *LoadBalancerPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *LoadBalancerPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *LoadBalancerPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *LoadBalancerPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *LoadBalancerPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *LoadBalancerPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *LoadBalancerPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *LoadBalancerPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *LoadBalancerPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *LoadBalancerPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *LoadBalancerPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *LoadBalancerPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *LoadBalancerPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *LoadBalancerPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *LoadBalancerPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *LoadBalancerPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *LoadBalancerPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *LoadBalancerPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetVirtualIPAddresses returns value of VirtualIPAddresses
+func (o *LoadBalancerPatchRequest) GetVirtualIPAddresses() []*LoadBalancerVirtualIPAddress {
+	return o.VirtualIPAddresses
+}
+
+// SetVirtualIPAddresses sets value to VirtualIPAddresses
+func (o *LoadBalancerPatchRequest) SetVirtualIPAddresses(v []*LoadBalancerVirtualIPAddress) {
+	o.VirtualIPAddresses = v
+}
+
+// GetPatchEmptyToVirtualIPAddresses returns value of PatchEmptyToVirtualIPAddresses
+func (o *LoadBalancerPatchRequest) GetPatchEmptyToVirtualIPAddresses() bool {
+	return o.PatchEmptyToVirtualIPAddresses
+}
+
+// SetPatchEmptyToVirtualIPAddresses sets value to PatchEmptyToVirtualIPAddresses
+func (o *LoadBalancerPatchRequest) SetPatchEmptyToVirtualIPAddresses(v bool) {
+	o.PatchEmptyToVirtualIPAddresses = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *LoadBalancerPatchRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *LoadBalancerPatchRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 
@@ -12428,6 +14219,176 @@ func (o *MobileGatewayUpdateRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *MobileGatewayUpdateRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* MobileGatewayPatchRequest
+*************************************************/
+
+// MobileGatewayPatchRequest represents API parameter/response structure
+type MobileGatewayPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+	Settings                *MobileGatewaySetting `json:",omitempty" mapconv:",omitempty,recursive"`
+	PatchEmptyToSettings    bool
+	SettingsHash            string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *MobileGatewayPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+		Settings                *MobileGatewaySetting `json:",omitempty" mapconv:",omitempty,recursive"`
+		PatchEmptyToSettings    bool
+		SettingsHash            string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+		Settings:                o.GetSettings(),
+		PatchEmptyToSettings:    o.GetPatchEmptyToSettings(),
+		SettingsHash:            o.GetSettingsHash(),
+	}
+}
+
+// GetName returns value of Name
+func (o *MobileGatewayPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *MobileGatewayPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *MobileGatewayPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *MobileGatewayPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *MobileGatewayPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *MobileGatewayPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *MobileGatewayPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *MobileGatewayPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *MobileGatewayPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *MobileGatewayPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *MobileGatewayPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *MobileGatewayPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *MobileGatewayPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *MobileGatewayPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *MobileGatewayPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *MobileGatewayPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *MobileGatewayPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *MobileGatewayPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetSettings returns value of Settings
+func (o *MobileGatewayPatchRequest) GetSettings() *MobileGatewaySetting {
+	return o.Settings
+}
+
+// SetSettings sets value to Settings
+func (o *MobileGatewayPatchRequest) SetSettings(v *MobileGatewaySetting) {
+	o.Settings = v
+}
+
+// GetPatchEmptyToSettings returns value of PatchEmptyToSettings
+func (o *MobileGatewayPatchRequest) GetPatchEmptyToSettings() bool {
+	return o.PatchEmptyToSettings
+}
+
+// SetPatchEmptyToSettings sets value to PatchEmptyToSettings
+func (o *MobileGatewayPatchRequest) SetPatchEmptyToSettings(v bool) {
+	o.PatchEmptyToSettings = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *MobileGatewayPatchRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *MobileGatewayPatchRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 
@@ -13690,6 +15651,137 @@ func (o *NFSUpdateRequest) SetIconID(v types.ID) {
 }
 
 /*************************************************
+* NFSPatchRequest
+*************************************************/
+
+// NFSPatchRequest represents API parameter/response structure
+type NFSPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+}
+
+// Validate validates by field tags
+func (o *NFSPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *NFSPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+	}
+}
+
+// GetName returns value of Name
+func (o *NFSPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *NFSPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *NFSPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *NFSPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *NFSPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *NFSPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *NFSPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *NFSPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *NFSPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *NFSPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *NFSPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *NFSPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *NFSPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *NFSPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *NFSPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *NFSPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *NFSPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *NFSPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+/*************************************************
 * FreeDiskSizeActivity
 *************************************************/
 
@@ -14182,6 +16274,163 @@ func (o *NoteUpdateRequest) SetContent(v string) {
 }
 
 /*************************************************
+* NotePatchRequest
+*************************************************/
+
+// NotePatchRequest represents API parameter/response structure
+type NotePatchRequest struct {
+	Name                string `validate:"required"`
+	Tags                types.Tags
+	PatchEmptyToTags    bool
+	IconID              types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID  bool
+	Class               string
+	PatchEmptyToClass   bool
+	Content             string
+	PatchEmptyToContent bool
+}
+
+// Validate validates by field tags
+func (o *NotePatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *NotePatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                string `validate:"required"`
+		Tags                types.Tags
+		PatchEmptyToTags    bool
+		IconID              types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID  bool
+		Class               string
+		PatchEmptyToClass   bool
+		Content             string
+		PatchEmptyToContent bool
+	}{
+		Name:                o.GetName(),
+		Tags:                o.GetTags(),
+		PatchEmptyToTags:    o.GetPatchEmptyToTags(),
+		IconID:              o.GetIconID(),
+		PatchEmptyToIconID:  o.GetPatchEmptyToIconID(),
+		Class:               o.GetClass(),
+		PatchEmptyToClass:   o.GetPatchEmptyToClass(),
+		Content:             o.GetContent(),
+		PatchEmptyToContent: o.GetPatchEmptyToContent(),
+	}
+}
+
+// GetName returns value of Name
+func (o *NotePatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *NotePatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetTags returns value of Tags
+func (o *NotePatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *NotePatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *NotePatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *NotePatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *NotePatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *NotePatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *NotePatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *NotePatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *NotePatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *NotePatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *NotePatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *NotePatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetClass returns value of Class
+func (o *NotePatchRequest) GetClass() string {
+	return o.Class
+}
+
+// SetClass sets value to Class
+func (o *NotePatchRequest) SetClass(v string) {
+	o.Class = v
+}
+
+// GetPatchEmptyToClass returns value of PatchEmptyToClass
+func (o *NotePatchRequest) GetPatchEmptyToClass() bool {
+	return o.PatchEmptyToClass
+}
+
+// SetPatchEmptyToClass sets value to PatchEmptyToClass
+func (o *NotePatchRequest) SetPatchEmptyToClass(v bool) {
+	o.PatchEmptyToClass = v
+}
+
+// GetContent returns value of Content
+func (o *NotePatchRequest) GetContent() string {
+	return o.Content
+}
+
+// SetContent sets value to Content
+func (o *NotePatchRequest) SetContent(v string) {
+	o.Content = v
+}
+
+// GetPatchEmptyToContent returns value of PatchEmptyToContent
+func (o *NotePatchRequest) GetPatchEmptyToContent() bool {
+	return o.PatchEmptyToContent
+}
+
+// SetPatchEmptyToContent sets value to PatchEmptyToContent
+func (o *NotePatchRequest) SetPatchEmptyToContent(v bool) {
+	o.PatchEmptyToContent = v
+}
+
+/*************************************************
 * PacketFilter
 *************************************************/
 
@@ -14513,6 +16762,91 @@ func (o *PacketFilterUpdateRequest) GetExpression() []*PacketFilterExpression {
 // SetExpression sets value to Expression
 func (o *PacketFilterUpdateRequest) SetExpression(v []*PacketFilterExpression) {
 	o.Expression = v
+}
+
+/*************************************************
+* PacketFilterPatchRequest
+*************************************************/
+
+// PacketFilterPatchRequest represents API parameter/response structure
+type PacketFilterPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Expression              []*PacketFilterExpression `mapconv:"[]Expression,recursive"`
+	PatchEmptyToExpression  bool
+}
+
+// Validate validates by field tags
+func (o *PacketFilterPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *PacketFilterPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Expression              []*PacketFilterExpression `mapconv:"[]Expression,recursive"`
+		PatchEmptyToExpression  bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Expression:              o.GetExpression(),
+		PatchEmptyToExpression:  o.GetPatchEmptyToExpression(),
+	}
+}
+
+// GetName returns value of Name
+func (o *PacketFilterPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *PacketFilterPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *PacketFilterPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *PacketFilterPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *PacketFilterPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *PacketFilterPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetExpression returns value of Expression
+func (o *PacketFilterPatchRequest) GetExpression() []*PacketFilterExpression {
+	return o.Expression
+}
+
+// SetExpression sets value to Expression
+func (o *PacketFilterPatchRequest) SetExpression(v []*PacketFilterExpression) {
+	o.Expression = v
+}
+
+// GetPatchEmptyToExpression returns value of PatchEmptyToExpression
+func (o *PacketFilterPatchRequest) GetPatchEmptyToExpression() bool {
+	return o.PatchEmptyToExpression
+}
+
+// SetPatchEmptyToExpression sets value to PatchEmptyToExpression
+func (o *PacketFilterPatchRequest) SetPatchEmptyToExpression(v bool) {
+	o.PatchEmptyToExpression = v
 }
 
 /*************************************************
@@ -14962,6 +17296,137 @@ func (o *PrivateHostUpdateRequest) GetIconID() types.ID {
 // SetIconID sets value to IconID
 func (o *PrivateHostUpdateRequest) SetIconID(v types.ID) {
 	o.IconID = v
+}
+
+/*************************************************
+* PrivateHostPatchRequest
+*************************************************/
+
+// PrivateHostPatchRequest represents API parameter/response structure
+type PrivateHostPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+}
+
+// Validate validates by field tags
+func (o *PrivateHostPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *PrivateHostPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+	}
+}
+
+// GetName returns value of Name
+func (o *PrivateHostPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *PrivateHostPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *PrivateHostPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *PrivateHostPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *PrivateHostPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *PrivateHostPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *PrivateHostPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *PrivateHostPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *PrivateHostPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *PrivateHostPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *PrivateHostPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *PrivateHostPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *PrivateHostPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *PrivateHostPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *PrivateHostPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *PrivateHostPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *PrivateHostPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *PrivateHostPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
 }
 
 /*************************************************
@@ -16145,6 +18610,306 @@ func (o *ProxyLBUpdateRequest) GetIconID() types.ID {
 // SetIconID sets value to IconID
 func (o *ProxyLBUpdateRequest) SetIconID(v types.ID) {
 	o.IconID = v
+}
+
+/*************************************************
+* ProxyLBPatchRequest
+*************************************************/
+
+// ProxyLBPatchRequest represents API parameter/response structure
+type ProxyLBPatchRequest struct {
+	HealthCheck               *ProxyLBHealthCheck `mapconv:"Settings.ProxyLB.HealthCheck,recursive"`
+	PatchEmptyToHealthCheck   bool
+	SorryServer               *ProxyLBSorryServer `mapconv:"Settings.ProxyLB.SorryServer,recursive"`
+	PatchEmptyToSorryServer   bool
+	BindPorts                 []*ProxyLBBindPort `mapconv:"Settings.ProxyLB.[]BindPorts,recursive"`
+	PatchEmptyToBindPorts     bool
+	Servers                   []*ProxyLBServer `mapconv:"Settings.ProxyLB.[]Servers,recursive"`
+	PatchEmptyToServers       bool
+	LetsEncrypt               *ProxyLBACMESetting `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
+	PatchEmptyToLetsEncrypt   bool
+	StickySession             *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
+	PatchEmptyToStickySession bool
+	SettingsHash              string `json:",omitempty" mapconv:",omitempty"`
+	Name                      string `validate:"required"`
+	Description               string `validate:"min=0,max=512"`
+	PatchEmptyToDescription   bool
+	Tags                      types.Tags
+	PatchEmptyToTags          bool
+	IconID                    types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID        bool
+}
+
+// Validate validates by field tags
+func (o *ProxyLBPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ProxyLBPatchRequest) setDefaults() interface{} {
+	return &struct {
+		HealthCheck               *ProxyLBHealthCheck `mapconv:"Settings.ProxyLB.HealthCheck,recursive"`
+		PatchEmptyToHealthCheck   bool
+		SorryServer               *ProxyLBSorryServer `mapconv:"Settings.ProxyLB.SorryServer,recursive"`
+		PatchEmptyToSorryServer   bool
+		BindPorts                 []*ProxyLBBindPort `mapconv:"Settings.ProxyLB.[]BindPorts,recursive"`
+		PatchEmptyToBindPorts     bool
+		Servers                   []*ProxyLBServer `mapconv:"Settings.ProxyLB.[]Servers,recursive"`
+		PatchEmptyToServers       bool
+		LetsEncrypt               *ProxyLBACMESetting `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
+		PatchEmptyToLetsEncrypt   bool
+		StickySession             *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
+		PatchEmptyToStickySession bool
+		SettingsHash              string `json:",omitempty" mapconv:",omitempty"`
+		Name                      string `validate:"required"`
+		Description               string `validate:"min=0,max=512"`
+		PatchEmptyToDescription   bool
+		Tags                      types.Tags
+		PatchEmptyToTags          bool
+		IconID                    types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID        bool
+	}{
+		HealthCheck:               o.GetHealthCheck(),
+		PatchEmptyToHealthCheck:   o.GetPatchEmptyToHealthCheck(),
+		SorryServer:               o.GetSorryServer(),
+		PatchEmptyToSorryServer:   o.GetPatchEmptyToSorryServer(),
+		BindPorts:                 o.GetBindPorts(),
+		PatchEmptyToBindPorts:     o.GetPatchEmptyToBindPorts(),
+		Servers:                   o.GetServers(),
+		PatchEmptyToServers:       o.GetPatchEmptyToServers(),
+		LetsEncrypt:               o.GetLetsEncrypt(),
+		PatchEmptyToLetsEncrypt:   o.GetPatchEmptyToLetsEncrypt(),
+		StickySession:             o.GetStickySession(),
+		PatchEmptyToStickySession: o.GetPatchEmptyToStickySession(),
+		SettingsHash:              o.GetSettingsHash(),
+		Name:                      o.GetName(),
+		Description:               o.GetDescription(),
+		PatchEmptyToDescription:   o.GetPatchEmptyToDescription(),
+		Tags:                      o.GetTags(),
+		PatchEmptyToTags:          o.GetPatchEmptyToTags(),
+		IconID:                    o.GetIconID(),
+		PatchEmptyToIconID:        o.GetPatchEmptyToIconID(),
+	}
+}
+
+// GetHealthCheck returns value of HealthCheck
+func (o *ProxyLBPatchRequest) GetHealthCheck() *ProxyLBHealthCheck {
+	return o.HealthCheck
+}
+
+// SetHealthCheck sets value to HealthCheck
+func (o *ProxyLBPatchRequest) SetHealthCheck(v *ProxyLBHealthCheck) {
+	o.HealthCheck = v
+}
+
+// GetPatchEmptyToHealthCheck returns value of PatchEmptyToHealthCheck
+func (o *ProxyLBPatchRequest) GetPatchEmptyToHealthCheck() bool {
+	return o.PatchEmptyToHealthCheck
+}
+
+// SetPatchEmptyToHealthCheck sets value to PatchEmptyToHealthCheck
+func (o *ProxyLBPatchRequest) SetPatchEmptyToHealthCheck(v bool) {
+	o.PatchEmptyToHealthCheck = v
+}
+
+// GetSorryServer returns value of SorryServer
+func (o *ProxyLBPatchRequest) GetSorryServer() *ProxyLBSorryServer {
+	return o.SorryServer
+}
+
+// SetSorryServer sets value to SorryServer
+func (o *ProxyLBPatchRequest) SetSorryServer(v *ProxyLBSorryServer) {
+	o.SorryServer = v
+}
+
+// GetPatchEmptyToSorryServer returns value of PatchEmptyToSorryServer
+func (o *ProxyLBPatchRequest) GetPatchEmptyToSorryServer() bool {
+	return o.PatchEmptyToSorryServer
+}
+
+// SetPatchEmptyToSorryServer sets value to PatchEmptyToSorryServer
+func (o *ProxyLBPatchRequest) SetPatchEmptyToSorryServer(v bool) {
+	o.PatchEmptyToSorryServer = v
+}
+
+// GetBindPorts returns value of BindPorts
+func (o *ProxyLBPatchRequest) GetBindPorts() []*ProxyLBBindPort {
+	return o.BindPorts
+}
+
+// SetBindPorts sets value to BindPorts
+func (o *ProxyLBPatchRequest) SetBindPorts(v []*ProxyLBBindPort) {
+	o.BindPorts = v
+}
+
+// GetPatchEmptyToBindPorts returns value of PatchEmptyToBindPorts
+func (o *ProxyLBPatchRequest) GetPatchEmptyToBindPorts() bool {
+	return o.PatchEmptyToBindPorts
+}
+
+// SetPatchEmptyToBindPorts sets value to PatchEmptyToBindPorts
+func (o *ProxyLBPatchRequest) SetPatchEmptyToBindPorts(v bool) {
+	o.PatchEmptyToBindPorts = v
+}
+
+// GetServers returns value of Servers
+func (o *ProxyLBPatchRequest) GetServers() []*ProxyLBServer {
+	return o.Servers
+}
+
+// SetServers sets value to Servers
+func (o *ProxyLBPatchRequest) SetServers(v []*ProxyLBServer) {
+	o.Servers = v
+}
+
+// GetPatchEmptyToServers returns value of PatchEmptyToServers
+func (o *ProxyLBPatchRequest) GetPatchEmptyToServers() bool {
+	return o.PatchEmptyToServers
+}
+
+// SetPatchEmptyToServers sets value to PatchEmptyToServers
+func (o *ProxyLBPatchRequest) SetPatchEmptyToServers(v bool) {
+	o.PatchEmptyToServers = v
+}
+
+// GetLetsEncrypt returns value of LetsEncrypt
+func (o *ProxyLBPatchRequest) GetLetsEncrypt() *ProxyLBACMESetting {
+	return o.LetsEncrypt
+}
+
+// SetLetsEncrypt sets value to LetsEncrypt
+func (o *ProxyLBPatchRequest) SetLetsEncrypt(v *ProxyLBACMESetting) {
+	o.LetsEncrypt = v
+}
+
+// GetPatchEmptyToLetsEncrypt returns value of PatchEmptyToLetsEncrypt
+func (o *ProxyLBPatchRequest) GetPatchEmptyToLetsEncrypt() bool {
+	return o.PatchEmptyToLetsEncrypt
+}
+
+// SetPatchEmptyToLetsEncrypt sets value to PatchEmptyToLetsEncrypt
+func (o *ProxyLBPatchRequest) SetPatchEmptyToLetsEncrypt(v bool) {
+	o.PatchEmptyToLetsEncrypt = v
+}
+
+// GetStickySession returns value of StickySession
+func (o *ProxyLBPatchRequest) GetStickySession() *ProxyLBStickySession {
+	return o.StickySession
+}
+
+// SetStickySession sets value to StickySession
+func (o *ProxyLBPatchRequest) SetStickySession(v *ProxyLBStickySession) {
+	o.StickySession = v
+}
+
+// GetPatchEmptyToStickySession returns value of PatchEmptyToStickySession
+func (o *ProxyLBPatchRequest) GetPatchEmptyToStickySession() bool {
+	return o.PatchEmptyToStickySession
+}
+
+// SetPatchEmptyToStickySession sets value to PatchEmptyToStickySession
+func (o *ProxyLBPatchRequest) SetPatchEmptyToStickySession(v bool) {
+	o.PatchEmptyToStickySession = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *ProxyLBPatchRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *ProxyLBPatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+// GetName returns value of Name
+func (o *ProxyLBPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *ProxyLBPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *ProxyLBPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *ProxyLBPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *ProxyLBPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *ProxyLBPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *ProxyLBPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *ProxyLBPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *ProxyLBPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *ProxyLBPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *ProxyLBPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *ProxyLBPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *ProxyLBPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *ProxyLBPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *ProxyLBPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *ProxyLBPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *ProxyLBPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *ProxyLBPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
 }
 
 /*************************************************
@@ -17636,6 +20401,137 @@ func (o *ServerUpdateRequest) SetIconID(v types.ID) {
 }
 
 /*************************************************
+* ServerPatchRequest
+*************************************************/
+
+// ServerPatchRequest represents API parameter/response structure
+type ServerPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+}
+
+// Validate validates by field tags
+func (o *ServerPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ServerPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+	}
+}
+
+// GetName returns value of Name
+func (o *ServerPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *ServerPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *ServerPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *ServerPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *ServerPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *ServerPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *ServerPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *ServerPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *ServerPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *ServerPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *ServerPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *ServerPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *ServerPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *ServerPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *ServerPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *ServerPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *ServerPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *ServerPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+/*************************************************
 * ServerDeleteWithDisksRequest
 *************************************************/
 
@@ -18965,6 +21861,137 @@ func (o *SIMUpdateRequest) SetIconID(v types.ID) {
 }
 
 /*************************************************
+* SIMPatchRequest
+*************************************************/
+
+// SIMPatchRequest represents API parameter/response structure
+type SIMPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+}
+
+// Validate validates by field tags
+func (o *SIMPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *SIMPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+	}
+}
+
+// GetName returns value of Name
+func (o *SIMPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *SIMPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *SIMPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *SIMPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *SIMPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *SIMPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *SIMPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *SIMPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *SIMPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *SIMPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *SIMPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *SIMPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *SIMPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *SIMPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *SIMPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *SIMPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *SIMPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *SIMPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+/*************************************************
 * SIMAssignIPRequest
 *************************************************/
 
@@ -20140,6 +23167,322 @@ func (o *SimpleMonitorUpdateRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* SimpleMonitorPatchRequest
+*************************************************/
+
+// SimpleMonitorPatchRequest represents API parameter/response structure
+type SimpleMonitorPatchRequest struct {
+	Description                    string `validate:"min=0,max=512"`
+	PatchEmptyToDescription        bool
+	Tags                           types.Tags
+	PatchEmptyToTags               bool
+	IconID                         types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID             bool
+	DelayLoop                      int `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+	PatchEmptyToDelayLoop          bool
+	Enabled                        types.StringFlag `mapconv:"Settings.SimpleMonitor.Enabled"`
+	PatchEmptyToEnabled            bool
+	HealthCheck                    *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
+	PatchEmptyToHealthCheck        bool
+	NotifyEmailEnabled             types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
+	PatchEmptyToNotifyEmailEnabled bool
+	NotifyEmailHTML                types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
+	PatchEmptyToNotifyEmailHTML    bool
+	NotifySlackEnabled             types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
+	PatchEmptyToNotifySlackEnabled bool
+	SlackWebhooksURL               string `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
+	PatchEmptyToSlackWebhooksURL   bool
+	SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *SimpleMonitorPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *SimpleMonitorPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Description                    string `validate:"min=0,max=512"`
+		PatchEmptyToDescription        bool
+		Tags                           types.Tags
+		PatchEmptyToTags               bool
+		IconID                         types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID             bool
+		DelayLoop                      int `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+		PatchEmptyToDelayLoop          bool
+		Enabled                        types.StringFlag `mapconv:"Settings.SimpleMonitor.Enabled"`
+		PatchEmptyToEnabled            bool
+		HealthCheck                    *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
+		PatchEmptyToHealthCheck        bool
+		NotifyEmailEnabled             types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
+		PatchEmptyToNotifyEmailEnabled bool
+		NotifyEmailHTML                types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
+		PatchEmptyToNotifyEmailHTML    bool
+		NotifySlackEnabled             types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
+		PatchEmptyToNotifySlackEnabled bool
+		SlackWebhooksURL               string `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
+		PatchEmptyToSlackWebhooksURL   bool
+		SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Description:                    o.GetDescription(),
+		PatchEmptyToDescription:        o.GetPatchEmptyToDescription(),
+		Tags:                           o.GetTags(),
+		PatchEmptyToTags:               o.GetPatchEmptyToTags(),
+		IconID:                         o.GetIconID(),
+		PatchEmptyToIconID:             o.GetPatchEmptyToIconID(),
+		DelayLoop:                      o.GetDelayLoop(),
+		PatchEmptyToDelayLoop:          o.GetPatchEmptyToDelayLoop(),
+		Enabled:                        o.GetEnabled(),
+		PatchEmptyToEnabled:            o.GetPatchEmptyToEnabled(),
+		HealthCheck:                    o.GetHealthCheck(),
+		PatchEmptyToHealthCheck:        o.GetPatchEmptyToHealthCheck(),
+		NotifyEmailEnabled:             o.GetNotifyEmailEnabled(),
+		PatchEmptyToNotifyEmailEnabled: o.GetPatchEmptyToNotifyEmailEnabled(),
+		NotifyEmailHTML:                o.GetNotifyEmailHTML(),
+		PatchEmptyToNotifyEmailHTML:    o.GetPatchEmptyToNotifyEmailHTML(),
+		NotifySlackEnabled:             o.GetNotifySlackEnabled(),
+		PatchEmptyToNotifySlackEnabled: o.GetPatchEmptyToNotifySlackEnabled(),
+		SlackWebhooksURL:               o.GetSlackWebhooksURL(),
+		PatchEmptyToSlackWebhooksURL:   o.GetPatchEmptyToSlackWebhooksURL(),
+		SettingsHash:                   o.GetSettingsHash(),
+	}
+}
+
+// GetDescription returns value of Description
+func (o *SimpleMonitorPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *SimpleMonitorPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *SimpleMonitorPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *SimpleMonitorPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *SimpleMonitorPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *SimpleMonitorPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *SimpleMonitorPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *SimpleMonitorPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *SimpleMonitorPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *SimpleMonitorPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetDelayLoop returns value of DelayLoop
+func (o *SimpleMonitorPatchRequest) GetDelayLoop() int {
+	if o.DelayLoop == 0 {
+		return 60
+	}
+	return o.DelayLoop
+}
+
+// SetDelayLoop sets value to DelayLoop
+func (o *SimpleMonitorPatchRequest) SetDelayLoop(v int) {
+	o.DelayLoop = v
+}
+
+// GetPatchEmptyToDelayLoop returns value of PatchEmptyToDelayLoop
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToDelayLoop() bool {
+	return o.PatchEmptyToDelayLoop
+}
+
+// SetPatchEmptyToDelayLoop sets value to PatchEmptyToDelayLoop
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToDelayLoop(v bool) {
+	o.PatchEmptyToDelayLoop = v
+}
+
+// GetEnabled returns value of Enabled
+func (o *SimpleMonitorPatchRequest) GetEnabled() types.StringFlag {
+	return o.Enabled
+}
+
+// SetEnabled sets value to Enabled
+func (o *SimpleMonitorPatchRequest) SetEnabled(v types.StringFlag) {
+	o.Enabled = v
+}
+
+// GetPatchEmptyToEnabled returns value of PatchEmptyToEnabled
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToEnabled() bool {
+	return o.PatchEmptyToEnabled
+}
+
+// SetPatchEmptyToEnabled sets value to PatchEmptyToEnabled
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToEnabled(v bool) {
+	o.PatchEmptyToEnabled = v
+}
+
+// GetHealthCheck returns value of HealthCheck
+func (o *SimpleMonitorPatchRequest) GetHealthCheck() *SimpleMonitorHealthCheck {
+	return o.HealthCheck
+}
+
+// SetHealthCheck sets value to HealthCheck
+func (o *SimpleMonitorPatchRequest) SetHealthCheck(v *SimpleMonitorHealthCheck) {
+	o.HealthCheck = v
+}
+
+// GetPatchEmptyToHealthCheck returns value of PatchEmptyToHealthCheck
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToHealthCheck() bool {
+	return o.PatchEmptyToHealthCheck
+}
+
+// SetPatchEmptyToHealthCheck sets value to PatchEmptyToHealthCheck
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToHealthCheck(v bool) {
+	o.PatchEmptyToHealthCheck = v
+}
+
+// GetNotifyEmailEnabled returns value of NotifyEmailEnabled
+func (o *SimpleMonitorPatchRequest) GetNotifyEmailEnabled() types.StringFlag {
+	return o.NotifyEmailEnabled
+}
+
+// SetNotifyEmailEnabled sets value to NotifyEmailEnabled
+func (o *SimpleMonitorPatchRequest) SetNotifyEmailEnabled(v types.StringFlag) {
+	o.NotifyEmailEnabled = v
+}
+
+// GetPatchEmptyToNotifyEmailEnabled returns value of PatchEmptyToNotifyEmailEnabled
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToNotifyEmailEnabled() bool {
+	return o.PatchEmptyToNotifyEmailEnabled
+}
+
+// SetPatchEmptyToNotifyEmailEnabled sets value to PatchEmptyToNotifyEmailEnabled
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToNotifyEmailEnabled(v bool) {
+	o.PatchEmptyToNotifyEmailEnabled = v
+}
+
+// GetNotifyEmailHTML returns value of NotifyEmailHTML
+func (o *SimpleMonitorPatchRequest) GetNotifyEmailHTML() types.StringFlag {
+	return o.NotifyEmailHTML
+}
+
+// SetNotifyEmailHTML sets value to NotifyEmailHTML
+func (o *SimpleMonitorPatchRequest) SetNotifyEmailHTML(v types.StringFlag) {
+	o.NotifyEmailHTML = v
+}
+
+// GetPatchEmptyToNotifyEmailHTML returns value of PatchEmptyToNotifyEmailHTML
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToNotifyEmailHTML() bool {
+	return o.PatchEmptyToNotifyEmailHTML
+}
+
+// SetPatchEmptyToNotifyEmailHTML sets value to PatchEmptyToNotifyEmailHTML
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToNotifyEmailHTML(v bool) {
+	o.PatchEmptyToNotifyEmailHTML = v
+}
+
+// GetNotifySlackEnabled returns value of NotifySlackEnabled
+func (o *SimpleMonitorPatchRequest) GetNotifySlackEnabled() types.StringFlag {
+	return o.NotifySlackEnabled
+}
+
+// SetNotifySlackEnabled sets value to NotifySlackEnabled
+func (o *SimpleMonitorPatchRequest) SetNotifySlackEnabled(v types.StringFlag) {
+	o.NotifySlackEnabled = v
+}
+
+// GetPatchEmptyToNotifySlackEnabled returns value of PatchEmptyToNotifySlackEnabled
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToNotifySlackEnabled() bool {
+	return o.PatchEmptyToNotifySlackEnabled
+}
+
+// SetPatchEmptyToNotifySlackEnabled sets value to PatchEmptyToNotifySlackEnabled
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToNotifySlackEnabled(v bool) {
+	o.PatchEmptyToNotifySlackEnabled = v
+}
+
+// GetSlackWebhooksURL returns value of SlackWebhooksURL
+func (o *SimpleMonitorPatchRequest) GetSlackWebhooksURL() string {
+	return o.SlackWebhooksURL
+}
+
+// SetSlackWebhooksURL sets value to SlackWebhooksURL
+func (o *SimpleMonitorPatchRequest) SetSlackWebhooksURL(v string) {
+	o.SlackWebhooksURL = v
+}
+
+// GetPatchEmptyToSlackWebhooksURL returns value of PatchEmptyToSlackWebhooksURL
+func (o *SimpleMonitorPatchRequest) GetPatchEmptyToSlackWebhooksURL() bool {
+	return o.PatchEmptyToSlackWebhooksURL
+}
+
+// SetPatchEmptyToSlackWebhooksURL sets value to PatchEmptyToSlackWebhooksURL
+func (o *SimpleMonitorPatchRequest) SetPatchEmptyToSlackWebhooksURL(v bool) {
+	o.PatchEmptyToSlackWebhooksURL = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *SimpleMonitorPatchRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *SimpleMonitorPatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * ResponseTimeSecActivity
 *************************************************/
 
@@ -20690,6 +24033,65 @@ func (o *SSHKeyUpdateRequest) GetDescription() string {
 // SetDescription sets value to Description
 func (o *SSHKeyUpdateRequest) SetDescription(v string) {
 	o.Description = v
+}
+
+/*************************************************
+* SSHKeyPatchRequest
+*************************************************/
+
+// SSHKeyPatchRequest represents API parameter/response structure
+type SSHKeyPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+}
+
+// Validate validates by field tags
+func (o *SSHKeyPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *SSHKeyPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+	}
+}
+
+// GetName returns value of Name
+func (o *SSHKeyPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *SSHKeyPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *SSHKeyPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *SSHKeyPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *SSHKeyPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *SSHKeyPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
 }
 
 /*************************************************
@@ -21304,6 +24706,189 @@ func (o *SwitchUpdateRequest) GetIconID() types.ID {
 // SetIconID sets value to IconID
 func (o *SwitchUpdateRequest) SetIconID(v types.ID) {
 	o.IconID = v
+}
+
+/*************************************************
+* SwitchPatchRequest
+*************************************************/
+
+// SwitchPatchRequest represents API parameter/response structure
+type SwitchPatchRequest struct {
+	Name                       string `validate:"required"`
+	NetworkMaskLen             int    `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
+	PatchEmptyToNetworkMaskLen bool
+	DefaultRoute               string `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
+	PatchEmptyToDefaultRoute   bool
+	Description                string `validate:"min=0,max=512"`
+	PatchEmptyToDescription    bool
+	Tags                       types.Tags
+	PatchEmptyToTags           bool
+	IconID                     types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID         bool
+}
+
+// Validate validates by field tags
+func (o *SwitchPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *SwitchPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                       string `validate:"required"`
+		NetworkMaskLen             int    `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
+		PatchEmptyToNetworkMaskLen bool
+		DefaultRoute               string `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
+		PatchEmptyToDefaultRoute   bool
+		Description                string `validate:"min=0,max=512"`
+		PatchEmptyToDescription    bool
+		Tags                       types.Tags
+		PatchEmptyToTags           bool
+		IconID                     types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID         bool
+	}{
+		Name:                       o.GetName(),
+		NetworkMaskLen:             o.GetNetworkMaskLen(),
+		PatchEmptyToNetworkMaskLen: o.GetPatchEmptyToNetworkMaskLen(),
+		DefaultRoute:               o.GetDefaultRoute(),
+		PatchEmptyToDefaultRoute:   o.GetPatchEmptyToDefaultRoute(),
+		Description:                o.GetDescription(),
+		PatchEmptyToDescription:    o.GetPatchEmptyToDescription(),
+		Tags:                       o.GetTags(),
+		PatchEmptyToTags:           o.GetPatchEmptyToTags(),
+		IconID:                     o.GetIconID(),
+		PatchEmptyToIconID:         o.GetPatchEmptyToIconID(),
+	}
+}
+
+// GetName returns value of Name
+func (o *SwitchPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *SwitchPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetNetworkMaskLen returns value of NetworkMaskLen
+func (o *SwitchPatchRequest) GetNetworkMaskLen() int {
+	return o.NetworkMaskLen
+}
+
+// SetNetworkMaskLen sets value to NetworkMaskLen
+func (o *SwitchPatchRequest) SetNetworkMaskLen(v int) {
+	o.NetworkMaskLen = v
+}
+
+// GetPatchEmptyToNetworkMaskLen returns value of PatchEmptyToNetworkMaskLen
+func (o *SwitchPatchRequest) GetPatchEmptyToNetworkMaskLen() bool {
+	return o.PatchEmptyToNetworkMaskLen
+}
+
+// SetPatchEmptyToNetworkMaskLen sets value to PatchEmptyToNetworkMaskLen
+func (o *SwitchPatchRequest) SetPatchEmptyToNetworkMaskLen(v bool) {
+	o.PatchEmptyToNetworkMaskLen = v
+}
+
+// GetDefaultRoute returns value of DefaultRoute
+func (o *SwitchPatchRequest) GetDefaultRoute() string {
+	return o.DefaultRoute
+}
+
+// SetDefaultRoute sets value to DefaultRoute
+func (o *SwitchPatchRequest) SetDefaultRoute(v string) {
+	o.DefaultRoute = v
+}
+
+// GetPatchEmptyToDefaultRoute returns value of PatchEmptyToDefaultRoute
+func (o *SwitchPatchRequest) GetPatchEmptyToDefaultRoute() bool {
+	return o.PatchEmptyToDefaultRoute
+}
+
+// SetPatchEmptyToDefaultRoute sets value to PatchEmptyToDefaultRoute
+func (o *SwitchPatchRequest) SetPatchEmptyToDefaultRoute(v bool) {
+	o.PatchEmptyToDefaultRoute = v
+}
+
+// GetDescription returns value of Description
+func (o *SwitchPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *SwitchPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *SwitchPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *SwitchPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *SwitchPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *SwitchPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *SwitchPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *SwitchPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *SwitchPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *SwitchPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *SwitchPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *SwitchPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *SwitchPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *SwitchPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *SwitchPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *SwitchPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
 }
 
 /*************************************************
@@ -23130,6 +26715,176 @@ func (o *VPCRouterUpdateRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *VPCRouterUpdateRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* VPCRouterPatchRequest
+*************************************************/
+
+// VPCRouterPatchRequest represents API parameter/response structure
+type VPCRouterPatchRequest struct {
+	Name                    string `validate:"required"`
+	Description             string `validate:"min=0,max=512"`
+	PatchEmptyToDescription bool
+	Tags                    types.Tags
+	PatchEmptyToTags        bool
+	IconID                  types.ID `mapconv:"Icon.ID"`
+	PatchEmptyToIconID      bool
+	Settings                *VPCRouterSetting `mapconv:",omitempty,recursive"`
+	PatchEmptyToSettings    bool
+	SettingsHash            string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *VPCRouterPatchRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *VPCRouterPatchRequest) setDefaults() interface{} {
+	return &struct {
+		Name                    string `validate:"required"`
+		Description             string `validate:"min=0,max=512"`
+		PatchEmptyToDescription bool
+		Tags                    types.Tags
+		PatchEmptyToTags        bool
+		IconID                  types.ID `mapconv:"Icon.ID"`
+		PatchEmptyToIconID      bool
+		Settings                *VPCRouterSetting `mapconv:",omitempty,recursive"`
+		PatchEmptyToSettings    bool
+		SettingsHash            string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Name:                    o.GetName(),
+		Description:             o.GetDescription(),
+		PatchEmptyToDescription: o.GetPatchEmptyToDescription(),
+		Tags:                    o.GetTags(),
+		PatchEmptyToTags:        o.GetPatchEmptyToTags(),
+		IconID:                  o.GetIconID(),
+		PatchEmptyToIconID:      o.GetPatchEmptyToIconID(),
+		Settings:                o.GetSettings(),
+		PatchEmptyToSettings:    o.GetPatchEmptyToSettings(),
+		SettingsHash:            o.GetSettingsHash(),
+	}
+}
+
+// GetName returns value of Name
+func (o *VPCRouterPatchRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *VPCRouterPatchRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *VPCRouterPatchRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *VPCRouterPatchRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetPatchEmptyToDescription returns value of PatchEmptyToDescription
+func (o *VPCRouterPatchRequest) GetPatchEmptyToDescription() bool {
+	return o.PatchEmptyToDescription
+}
+
+// SetPatchEmptyToDescription sets value to PatchEmptyToDescription
+func (o *VPCRouterPatchRequest) SetPatchEmptyToDescription(v bool) {
+	o.PatchEmptyToDescription = v
+}
+
+// GetTags returns value of Tags
+func (o *VPCRouterPatchRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *VPCRouterPatchRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *VPCRouterPatchRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *VPCRouterPatchRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *VPCRouterPatchRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *VPCRouterPatchRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetPatchEmptyToTags returns value of PatchEmptyToTags
+func (o *VPCRouterPatchRequest) GetPatchEmptyToTags() bool {
+	return o.PatchEmptyToTags
+}
+
+// SetPatchEmptyToTags sets value to PatchEmptyToTags
+func (o *VPCRouterPatchRequest) SetPatchEmptyToTags(v bool) {
+	o.PatchEmptyToTags = v
+}
+
+// GetIconID returns value of IconID
+func (o *VPCRouterPatchRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *VPCRouterPatchRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetPatchEmptyToIconID returns value of PatchEmptyToIconID
+func (o *VPCRouterPatchRequest) GetPatchEmptyToIconID() bool {
+	return o.PatchEmptyToIconID
+}
+
+// SetPatchEmptyToIconID sets value to PatchEmptyToIconID
+func (o *VPCRouterPatchRequest) SetPatchEmptyToIconID(v bool) {
+	o.PatchEmptyToIconID = v
+}
+
+// GetSettings returns value of Settings
+func (o *VPCRouterPatchRequest) GetSettings() *VPCRouterSetting {
+	return o.Settings
+}
+
+// SetSettings sets value to Settings
+func (o *VPCRouterPatchRequest) SetSettings(v *VPCRouterSetting) {
+	o.Settings = v
+}
+
+// GetPatchEmptyToSettings returns value of PatchEmptyToSettings
+func (o *VPCRouterPatchRequest) GetPatchEmptyToSettings() bool {
+	return o.PatchEmptyToSettings
+}
+
+// SetPatchEmptyToSettings sets value to PatchEmptyToSettings
+func (o *VPCRouterPatchRequest) SetPatchEmptyToSettings(v bool) {
+	o.PatchEmptyToSettings = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *VPCRouterPatchRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *VPCRouterPatchRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -40,6 +40,13 @@ type archiveUpdateResult struct {
 	Archive *Archive `json:",omitempty" mapconv:"Archive,omitempty,recursive"`
 }
 
+// archivePatchResult represents the Result of API
+type archivePatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Archive *Archive `json:",omitempty" mapconv:"Archive,omitempty,recursive"`
+}
+
 // archiveOpenFTPResult represents the Result of API
 type archiveOpenFTPResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
@@ -79,6 +86,13 @@ type autoBackupReadResult struct {
 
 // autoBackupUpdateResult represents the Result of API
 type autoBackupUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	AutoBackup *AutoBackup `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// autoBackupPatchResult represents the Result of API
+type autoBackupPatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	AutoBackup *AutoBackup `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
@@ -166,6 +180,13 @@ type bridgeUpdateResult struct {
 	Bridge *Bridge `json:",omitempty" mapconv:"Bridge,omitempty,recursive"`
 }
 
+// bridgePatchResult represents the Result of API
+type bridgePatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Bridge *Bridge `json:",omitempty" mapconv:"Bridge,omitempty,recursive"`
+}
+
 // CDROMFindResult represents the Result of API
 type CDROMFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -192,6 +213,13 @@ type cDROMReadResult struct {
 
 // cDROMUpdateResult represents the Result of API
 type cDROMUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	CDROM *CDROM `json:",omitempty" mapconv:"CDROM,omitempty,recursive"`
+}
+
+// cDROMPatchResult represents the Result of API
+type cDROMPatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	CDROM *CDROM `json:",omitempty" mapconv:"CDROM,omitempty,recursive"`
@@ -238,6 +266,13 @@ type databaseReadResult struct {
 
 // databaseUpdateResult represents the Result of API
 type databaseUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Database *Database `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// databasePatchResult represents the Result of API
+type databasePatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	Database *Database `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
@@ -322,6 +357,13 @@ type diskUpdateResult struct {
 	Disk *Disk `json:",omitempty" mapconv:"Disk,omitempty,recursive"`
 }
 
+// diskPatchResult represents the Result of API
+type diskPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Disk *Disk `json:",omitempty" mapconv:"Disk,omitempty,recursive"`
+}
+
 // diskMonitorResult represents the Result of API
 type diskMonitorResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
@@ -375,6 +417,13 @@ type dNSUpdateResult struct {
 	DNS *DNS `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
 }
 
+// dNSPatchResult represents the Result of API
+type dNSPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	DNS *DNS `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
 // GSLBFindResult represents the Result of API
 type GSLBFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -400,6 +449,13 @@ type gSLBReadResult struct {
 
 // gSLBUpdateResult represents the Result of API
 type gSLBUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	GSLB *GSLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// gSLBPatchResult represents the Result of API
+type gSLBPatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	GSLB *GSLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
@@ -435,6 +491,13 @@ type iconUpdateResult struct {
 	Icon *Icon `json:",omitempty" mapconv:"Icon,omitempty,recursive"`
 }
 
+// iconPatchResult represents the Result of API
+type iconPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Icon *Icon `json:",omitempty" mapconv:"Icon,omitempty,recursive"`
+}
+
 // InterfaceFindResult represents the Result of API
 type InterfaceFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -460,6 +523,13 @@ type interfaceReadResult struct {
 
 // interfaceUpdateResult represents the Result of API
 type interfaceUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Interface *Interface `json:",omitempty" mapconv:"Interface,omitempty,recursive"`
+}
+
+// interfacePatchResult represents the Result of API
+type interfacePatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	Interface *Interface `json:",omitempty" mapconv:"Interface,omitempty,recursive"`
@@ -497,6 +567,13 @@ type internetReadResult struct {
 
 // internetUpdateResult represents the Result of API
 type internetUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Internet *Internet `json:",omitempty" mapconv:"Internet,omitempty,recursive"`
+}
+
+// internetPatchResult represents the Result of API
+type internetPatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	Internet *Internet `json:",omitempty" mapconv:"Internet,omitempty,recursive"`
@@ -652,6 +729,13 @@ type licenseUpdateResult struct {
 	License *License `json:",omitempty" mapconv:"License,omitempty,recursive"`
 }
 
+// licensePatchResult represents the Result of API
+type licensePatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	License *License `json:",omitempty" mapconv:"License,omitempty,recursive"`
+}
+
 // LicenseInfoFindResult represents the Result of API
 type LicenseInfoFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -698,6 +782,13 @@ type loadBalancerUpdateResult struct {
 	LoadBalancer *LoadBalancer `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
 }
 
+// loadBalancerPatchResult represents the Result of API
+type loadBalancerPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LoadBalancer *LoadBalancer `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
 // loadBalancerMonitorInterfaceResult represents the Result of API
 type loadBalancerMonitorInterfaceResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
@@ -739,6 +830,13 @@ type mobileGatewayReadResult struct {
 
 // mobileGatewayUpdateResult represents the Result of API
 type mobileGatewayUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	MobileGateway *MobileGateway `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// mobileGatewayPatchResult represents the Result of API
+type mobileGatewayPatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	MobileGateway *MobileGateway `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
@@ -823,6 +921,13 @@ type nFSUpdateResult struct {
 	NFS *NFS `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
 }
 
+// nFSPatchResult represents the Result of API
+type nFSPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	NFS *NFS `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
 // nFSMonitorFreeDiskSizeResult represents the Result of API
 type nFSMonitorFreeDiskSizeResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
@@ -867,6 +972,13 @@ type noteUpdateResult struct {
 	Note *Note `json:",omitempty" mapconv:"Note,omitempty,recursive"`
 }
 
+// notePatchResult represents the Result of API
+type notePatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Note *Note `json:",omitempty" mapconv:"Note,omitempty,recursive"`
+}
+
 // PacketFilterFindResult represents the Result of API
 type PacketFilterFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -897,6 +1009,13 @@ type packetFilterUpdateResult struct {
 	PacketFilter *PacketFilter `json:",omitempty" mapconv:"PacketFilter,omitempty,recursive"`
 }
 
+// packetFilterPatchResult represents the Result of API
+type packetFilterPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	PacketFilter *PacketFilter `json:",omitempty" mapconv:"PacketFilter,omitempty,recursive"`
+}
+
 // PrivateHostFindResult represents the Result of API
 type PrivateHostFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -922,6 +1041,13 @@ type privateHostReadResult struct {
 
 // privateHostUpdateResult represents the Result of API
 type privateHostUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	PrivateHost *PrivateHost `json:",omitempty" mapconv:"PrivateHost,omitempty,recursive"`
+}
+
+// privateHostPatchResult represents the Result of API
+type privateHostPatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	PrivateHost *PrivateHost `json:",omitempty" mapconv:"PrivateHost,omitempty,recursive"`
@@ -968,6 +1094,13 @@ type proxyLBReadResult struct {
 
 // proxyLBUpdateResult represents the Result of API
 type proxyLBUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	ProxyLB *ProxyLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// proxyLBPatchResult represents the Result of API
+type proxyLBPatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	ProxyLB *ProxyLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
@@ -1054,6 +1187,13 @@ type serverUpdateResult struct {
 	Server *Server `json:",omitempty" mapconv:"Server,omitempty,recursive"`
 }
 
+// serverPatchResult represents the Result of API
+type serverPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Server *Server `json:",omitempty" mapconv:"Server,omitempty,recursive"`
+}
+
 // serverChangePlanResult represents the Result of API
 type serverChangePlanResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
@@ -1130,6 +1270,13 @@ type sIMUpdateResult struct {
 	SIM *SIM `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
 }
 
+// sIMPatchResult represents the Result of API
+type sIMPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	SIM *SIM `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
 // SIMLogsResult represents the Result of API
 type SIMLogsResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -1190,6 +1337,13 @@ type simpleMonitorUpdateResult struct {
 	SimpleMonitor *SimpleMonitor `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
 }
 
+// simpleMonitorPatchResult represents the Result of API
+type simpleMonitorPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	SimpleMonitor *SimpleMonitor `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
 // simpleMonitorMonitorResponseTimeResult represents the Result of API
 type simpleMonitorMonitorResponseTimeResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
@@ -1241,6 +1395,13 @@ type sSHKeyUpdateResult struct {
 	SSHKey *SSHKey `json:",omitempty" mapconv:"SSHKey,omitempty,recursive"`
 }
 
+// sSHKeyPatchResult represents the Result of API
+type sSHKeyPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	SSHKey *SSHKey `json:",omitempty" mapconv:"SSHKey,omitempty,recursive"`
+}
+
 // SwitchFindResult represents the Result of API
 type SwitchFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -1271,6 +1432,13 @@ type switchUpdateResult struct {
 	Switch *Switch `json:",omitempty" mapconv:"Switch,omitempty,recursive"`
 }
 
+// switchPatchResult represents the Result of API
+type switchPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Switch *Switch `json:",omitempty" mapconv:"Switch,omitempty,recursive"`
+}
+
 // VPCRouterFindResult represents the Result of API
 type VPCRouterFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources
@@ -1296,6 +1464,13 @@ type vPCRouterReadResult struct {
 
 // vPCRouterUpdateResult represents the Result of API
 type vPCRouterUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	VPCRouter *VPCRouter `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// vPCRouterPatchResult represents the Result of API
+type vPCRouterPatchResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	VPCRouter *VPCRouter `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`


### PR DESCRIPTION
fixes #240 

各リソースにおいて`Patch`操作をサポートする。

- Patch操作はUpdateの定義から派生し、Updateと同様のパラメータ+クリア用のパラメータを持つ
- Patchでは指定されたパラメータのみ更新される
- Patch操作の内部では以下のような処理が行われる

```go
	// まずReadして現在の値を取得する
	original, err := o.Read(ctx, zone, id)
	if err != nil {
		return nil, err
	}

	patchParam := make(map[string]interface{})
	// オリジナルの値をMapに投入
	if err := mergo.Map(&patchParam, original); err != nil {
		return nil, fmt.Errorf("patch is failed: %s", err)
	}
	// Patchの引数のうち、指定されている値を上書き
	if err := mergo.Map(&patchParam, param); err != nil {
		return nil, fmt.Errorf("patch is failed: %s", err)
	}
	// 最後にUpdate時のパラメータに上書き
	if err := mergo.Map(param, &patchParam); err != nil {
		return nil, fmt.Errorf("patch is failed: %s", err)
	}
	// その後クリア用パラメータを判定しUpdateパラメータをクリアしていく

	// 最終的にUpdateを呼ぶ
```

パラメータの上書き処理は[mergo](https://github.com/imdario/mergo)を利用する。

- クリア用のパラメータは必須でない、かつdslでの定義時に明示的にPatchでのクリアを無視するという設定がない場合にコード生成される。このため、PatchとUpdateがほぼ同等のパラメータとなっているリソースもあるが、統一性を重視してそのようなリソースにもPatchを定義した。
(`SettingsHash`フィールドがPatchでのクリアを無視する設定となっている)

Note: Patch/Update用のパラメータとReadの戻り値の間でフィールド名が同じであるという前提の処理となっている。このため異なるフィールド名にマッピングするようなケースではうまく動かない。(現状そのようなケースは存在しないはず)