### PR TITLE
ID.String(): 値が0の時に空文字を返す

### DIFF
--- a/sacloud/types/id.go
+++ b/sacloud/types/id.go
@@ -36,6 +36,9 @@ func (i ID) IsEmpty() bool {
 
 // String returns the literal text of the number.
 func (i ID) String() string {
+	if i.IsEmpty() {
+		return ""
+	}
 	return fmt.Sprintf("%d", i)
 }
 


### PR DESCRIPTION
types.IDのString()で値が0の時に空文字を返すようにする。

Notes:
- types.IDではInt64() funcも提供しているため、数値型として扱いたい場合はこちらを利用すればOK。
- 従来はtypes.IDのIsEmpty()を用いて空か判定する処理をユーザー側で行ない、String()では単純にint64の文字列表現を返す実装だったが、空文字を返す方が利用シーンが多そうなためこのPRを作成した