### PR TITLE
Switch API: サーバ数/サーバ取得API追加

### DIFF
--- a/internal/define/switch.go
+++ b/internal/define/switch.go
@@ -66,6 +66,7 @@ var (
 			fields.CreatedAt(),
 			fields.ModifiedAt(),
 			fields.Scope(),
+			fields.Def("ServerCount", meta.TypeInt),
 			fields.UserSubnetNetworkMaskLen(),
 			fields.UserSubnetDefaultRoute(),
 			{

--- a/internal/define/switch.go
+++ b/internal/define/switch.go
@@ -65,7 +65,7 @@ var switchAPI = &dsl.Resource{
 			}),
 			Results: dsl.Results{
 				{
-					SourceField: serverAPIName,
+					SourceField: names.ResourceFieldName(serverAPIName, dsl.PayloadForms.Plural),
 					DestField:   names.ResourceFieldName(serverAPIName, dsl.PayloadForms.Plural),
 					IsPlural:    true,
 					Model:       serverView,

--- a/internal/define/switch.go
+++ b/internal/define/switch.go
@@ -48,6 +48,30 @@ var switchAPI = &dsl.Resource{
 
 		// disconnect from bridge
 		ops.WithIDAction(switchAPIName, "DisconnectFromBridge", http.MethodDelete, "to/bridge/"),
+
+		// find connected servers
+		{
+			ResourceName:     switchAPIName,
+			Name:             "GetServers",
+			PathFormat:       dsl.IDAndSuffixPathFormat("server"),
+			Method:           http.MethodGet,
+			UseWrappedResult: true,
+			Arguments: dsl.Arguments{
+				dsl.ArgumentID,
+			},
+			ResponseEnvelope: dsl.ResponseEnvelopePlural(&dsl.EnvelopePayloadDesc{
+				Type: serverNakedType,
+				Name: names.ResourceFieldName(serverAPIName, dsl.PayloadForms.Plural),
+			}),
+			Results: dsl.Results{
+				{
+					SourceField: serverAPIName,
+					DestField:   names.ResourceFieldName(serverAPIName, dsl.PayloadForms.Plural),
+					IsPlural:    true,
+					Model:       serverView,
+				},
+			},
+		},
 	},
 }
 

--- a/sacloud/fake/ops_interface.go
+++ b/sacloud/fake/ops_interface.go
@@ -151,8 +151,15 @@ func (o *InterfaceOp) ConnectToSwitch(ctx context.Context, zone string, id types
 	}
 	if !value.SwitchID.IsEmpty() {
 		return newErrorConflict(o.key, id,
-			fmt.Sprintf("Interface[%d] is already connected to switch[%d]", value.ID, value.SwitchID))
+			fmt.Sprintf("Interface[%d] is already connected to switch[%d]", value.ID, switchID))
 	}
+
+	sw, err := NewSwitchOp().Read(ctx, zone, switchID)
+	if err != nil {
+		return err
+	}
+	sw.ServerCount++
+	putSwitch(zone, sw)
 
 	value.SwitchID = switchID
 	putInterface(zone, value)

--- a/sacloud/fake/ops_switch.go
+++ b/sacloud/fake/ops_switch.go
@@ -177,3 +177,28 @@ func (o *SwitchOp) DisconnectFromBridge(ctx context.Context, zone string, id typ
 	putSwitch(zone, value)
 	return nil
 }
+
+// GetServers is fake implementation
+func (o *SwitchOp) GetServers(ctx context.Context, zone string, id types.ID) (*sacloud.SwitchGetServersResult, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	res := &sacloud.SwitchGetServersResult{}
+	if value.ServerCount == 0 {
+		return res, nil
+	}
+
+	searched, err := NewServerOp().Find(ctx, zone, nil)
+	for _, server := range searched.Servers {
+		for _, nic := range server.Interfaces {
+			if nic.SwitchID == id {
+				res.Servers = append(res.Servers, server)
+				res.Count++
+				res.Total++
+				break
+			}
+		}
+	}
+	return res, nil
+}

--- a/sacloud/naked/switch.go
+++ b/sacloud/naked/switch.go
@@ -23,4 +23,5 @@ type Switch struct {
 	Subnets     []*Subnet    `json:",omitempty" yaml:"subnets,omitempty" structs:",omitempty"`
 	IPv6Nets    []*IPv6Net   `json:",omitempty" yaml:"ipv6nets,omitempty" structs:",omitempty"`
 	Bridge      *Bridge      `json:",omitempty" yaml:"bridge,omitempty" structs:",omitempty"`
+	ServerCount int          `json:",omitempty" yaml:"server_count,omitempty" structs:",omitempty"`
 }

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -4427,6 +4427,12 @@ type SwitchDisconnectFromBridgeStubResult struct {
 	Err error
 }
 
+// SwitchGetServersStubResult is expected values of the GetServers operation
+type SwitchGetServersStubResult struct {
+	Values *sacloud.SwitchGetServersResult
+	Err    error
+}
+
 // SwitchStub is for trace SwitchOp operations
 type SwitchStub struct {
 	FindStubResult                 *SwitchFindStubResult
@@ -4437,6 +4443,7 @@ type SwitchStub struct {
 	DeleteStubResult               *SwitchDeleteStubResult
 	ConnectToBridgeStubResult      *SwitchConnectToBridgeStubResult
 	DisconnectFromBridgeStubResult *SwitchDisconnectFromBridgeStubResult
+	GetServersStubResult           *SwitchGetServersStubResult
 }
 
 // NewSwitchStub creates new SwitchStub instance
@@ -4506,6 +4513,14 @@ func (s *SwitchStub) DisconnectFromBridge(ctx context.Context, zone string, id t
 		log.Fatal("SwitchStub.DisconnectFromBridgeStubResult is not set")
 	}
 	return s.DisconnectFromBridgeStubResult.Err
+}
+
+// GetServers is API call with trace log
+func (s *SwitchStub) GetServers(ctx context.Context, zone string, id types.ID) (*sacloud.SwitchGetServersResult, error) {
+	if s.GetServersStubResult == nil {
+		log.Fatal("SwitchStub.GetServersStubResult is not set")
+	}
+	return s.GetServersStubResult.Values, s.GetServersStubResult.Err
 }
 
 /*************************************************

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -9621,6 +9621,39 @@ func (t *SwitchTracer) DisconnectFromBridge(ctx context.Context, zone string, id
 	return err
 }
 
+// GetServers is API call with trace log
+func (t *SwitchTracer) GetServers(ctx context.Context, zone string, id types.ID) (*sacloud.SwitchGetServersResult, error) {
+	log.Println("[TRACE] SwitchAPI.GetServers start")
+	targetArguments := struct {
+		Argzone string
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] SwitchAPI.GetServers end")
+	}()
+
+	result, err := t.Internal.GetServers(ctx, zone, id)
+	targetResults := struct {
+		Result *sacloud.SwitchGetServersResult
+		Error  error
+	}{
+		Result: result,
+		Error:  err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return result, err
+}
+
 /*************************************************
 * VPCRouterTracer
 *************************************************/

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -10752,6 +10752,37 @@ func (o *SwitchOp) DisconnectFromBridge(ctx context.Context, zone string, id typ
 	return nil
 }
 
+// GetServers is API call
+func (o *SwitchOp) GetServers(ctx context.Context, zone string, id types.ID) (*SwitchGetServersResult, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/server", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformGetServersResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results, err
+}
+
 /*************************************************
 * VPCRouterOp
 *************************************************/

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -6571,6 +6571,19 @@ func (o *SwitchOp) transformPatchResults(data []byte) (*switchPatchResult, error
 	return results, nil
 }
 
+func (o *SwitchOp) transformGetServersResults(data []byte) (*SwitchGetServersResult, error) {
+	nakedResponse := &switchGetServersResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &SwitchGetServersResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *VPCRouterOp) transformFindArgs(conditions *FindCondition) (*vPCRouterFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -575,6 +575,7 @@ type SwitchAPI interface {
 	Delete(ctx context.Context, zone string, id types.ID) error
 	ConnectToBridge(ctx context.Context, zone string, id types.ID, bridgeID types.ID) error
 	DisconnectFromBridge(ctx context.Context, zone string, id types.ID) error
+	GetServers(ctx context.Context, zone string, id types.ID) (*SwitchGetServersResult, error)
 }
 
 /*************************************************

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -2547,6 +2547,15 @@ type switchPatchResponseEnvelope struct {
 	Switch *naked.Switch `json:",omitempty"`
 }
 
+// switchGetServersResponseEnvelope is envelop of API response
+type switchGetServersResponseEnvelope struct {
+	Total int `json:",omitempty"` // トータル件数
+	From  int `json:",omitempty"` // ページング開始ページ
+	Count int `json:",omitempty"` // 件数
+
+	Servers []*naked.Server `json:",omitempty"`
+}
+
 // vPCRouterFindRequestEnvelope is envelop of API request
 type vPCRouterFindRequestEnvelope struct {
 	Count   int             `json:",omitempty"`

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -24144,6 +24144,7 @@ type Switch struct {
 	CreatedAt      time.Time
 	ModifiedAt     time.Time
 	Scope          types.EScope
+	ServerCount    int
 	NetworkMaskLen int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
 	DefaultRoute   string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
 	Subnets        []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
@@ -24166,6 +24167,7 @@ func (o *Switch) setDefaults() interface{} {
 		CreatedAt      time.Time
 		ModifiedAt     time.Time
 		Scope          types.EScope
+		ServerCount    int
 		NetworkMaskLen int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
 		DefaultRoute   string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
 		Subnets        []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
@@ -24179,6 +24181,7 @@ func (o *Switch) setDefaults() interface{} {
 		CreatedAt:      o.GetCreatedAt(),
 		ModifiedAt:     o.GetModifiedAt(),
 		Scope:          o.GetScope(),
+		ServerCount:    o.GetServerCount(),
 		NetworkMaskLen: o.GetNetworkMaskLen(),
 		DefaultRoute:   o.GetDefaultRoute(),
 		Subnets:        o.GetSubnets(),
@@ -24304,6 +24307,16 @@ func (o *Switch) GetScope() types.EScope {
 // SetScope sets value to Scope
 func (o *Switch) SetScope(v types.EScope) {
 	o.Scope = v
+}
+
+// GetServerCount returns value of ServerCount
+func (o *Switch) GetServerCount() int {
+	return o.ServerCount
+}
+
+// SetServerCount sets value to ServerCount
+func (o *Switch) SetServerCount(v int) {
+	o.ServerCount = v
 }
 
 // GetNetworkMaskLen returns value of NetworkMaskLen

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -1439,6 +1439,15 @@ type switchPatchResult struct {
 	Switch *Switch `json:",omitempty" mapconv:"Switch,omitempty,recursive"`
 }
 
+// SwitchGetServersResult represents the Result of API
+type SwitchGetServersResult struct {
+	Total int `json:",omitempty"` // Total count of target resources
+	From  int `json:",omitempty"` // Current page number
+	Count int `json:",omitempty"` // Count of current page
+
+	Servers []*Server `json:",omitempty" mapconv:"[]Server,omitempty,recursive"`
+}
+
 // VPCRouterFindResult represents the Result of API
 type VPCRouterFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -1445,7 +1445,7 @@ type SwitchGetServersResult struct {
 	From  int `json:",omitempty"` // Current page number
 	Count int `json:",omitempty"` // Count of current page
 
-	Servers []*Server `json:",omitempty" mapconv:"[]Server,omitempty,recursive"`
+	Servers []*Server `json:",omitempty" mapconv:"[]Servers,omitempty,recursive"`
 }
 
 // VPCRouterFindResult represents the Result of API


### PR DESCRIPTION
(feedback from [sacloud/terraform-provider-sakuracloud](https://github.com/sacloud/terraform-provider-sakuracloud))

- 接続されているサーバ数を示すフィールド`ServerCount`を追加
- 接続されているサーバを取得するAPI`GetServers()`を追加