### PR TITLE
Fix response envelope - Internet API

### DIFF
--- a/internal/define/names/resource_name.go
+++ b/internal/define/names/resource_name.go
@@ -17,6 +17,7 @@ func ResourceFieldName(resourceName string, form dsl.PayloadForm) string {
 		case
 			resourceName == "NFS",
 			resourceName == "DNS",
+			resourceName == "Internet",
 			resourceName == "IPAddress",
 			strings.HasSuffix(resourceName, "Info"):
 			return resourceName

--- a/sacloud/fake/ops_internet.go
+++ b/sacloud/fake/ops_internet.go
@@ -21,10 +21,10 @@ func (o *InternetOp) Find(ctx context.Context, zone string, conditions *sacloud.
 		values = append(values, dest)
 	}
 	return &sacloud.InternetFindResult{
-		Total:     len(results),
-		Count:     len(results),
-		From:      0,
-		Internets: values,
+		Total:    len(results),
+		Count:    len(results),
+		From:     0,
+		Internet: values,
 	}, nil
 }
 

--- a/sacloud/testutil/util.go
+++ b/sacloud/testutil/util.go
@@ -276,8 +276,8 @@ func findInternet(ctx context.Context, caller sacloud.APICaller) ([]*cleanupTarg
 		if err != nil {
 			return nil, err
 		}
-		for j := range searched.Internets {
-			v := searched.Internets[j]
+		for j := range searched.Internet {
+			v := searched.Internet[j]
 			res = append(res, &cleanupTarget{
 				resource: v,
 				deleteFunc: func(ctx context.Context) error {

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -966,7 +966,7 @@ type internetFindResponseEnvelope struct {
 	From  int `json:",omitempty"` // ページング開始ページ
 	Count int `json:",omitempty"` // 件数
 
-	Internets []*naked.Internet `json:",omitempty"`
+	Internet []*naked.Internet `json:",omitempty"`
 }
 
 // internetCreateRequestEnvelope is envelop of API request

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -548,7 +548,7 @@ type InternetFindResult struct {
 	From  int `json:",omitempty"` // Current page number
 	Count int `json:",omitempty"` // Count of current page
 
-	Internets []*Internet `json:",omitempty" mapconv:"[]Internets,omitempty,recursive"`
+	Internet []*Internet `json:",omitempty" mapconv:"[]Internet,omitempty,recursive"`
 }
 
 // internetCreateResult represents the Result of API


### PR DESCRIPTION
ルータ検索でのレスポンスエンベロープのフィールド名を`Internets`から`Internet`に修正