### PR TITLE
VPCルータAPI: premiumプラン

### DIFF
--- a/internal/define/models.go
+++ b/internal/define/models.go
@@ -768,7 +768,7 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Type: m.vpcRouterInterface(),
 				Tags: &dsl.FieldTags{
 					JSON:    ",omitempty",
-					MapConv: "Router.[]Interface,omitempty,recursive",
+					MapConv: "Router.[]Interfaces,omitempty,recursive",
 				},
 			},
 			{
@@ -859,6 +859,13 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 					MapConv: "Router.StaticRoutes.[]Config,omitempty,recursive",
 				},
 			},
+			{
+				Name: "SyslogHost",
+				Type: meta.TypeString,
+				Tags: &dsl.FieldTags{
+					MapConv: "Router.SyslogHost",
+				},
+			},
 		},
 	}
 }
@@ -869,7 +876,6 @@ func (m *modelsDef) vpcRouterInterface() *dsl.Model {
 		NakedType: meta.Static(naked.VPCRouterInterface{}),
 		IsArray:   true,
 		Fields: []*dsl.FieldDesc{
-			fields.stringEnabled(),
 			{
 				Name: "IPAddress",
 				Type: meta.TypeStringSlice,

--- a/sacloud/naked/vpc_router.go
+++ b/sacloud/naked/vpc_router.go
@@ -35,7 +35,7 @@ type VPCRouterSettings struct {
 // VPCRouterSetting VPCルータ 設定
 type VPCRouterSetting struct {
 	InternetConnection *VPCRouterInternetConnection `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Interfaces         []*VPCRouterInterface        `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Interfaces         VPCRouterInterfaces          `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	VRID               int                          `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	StaticNAT          *VPCRouterStaticNAT          `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	Firewall           *VPCRouterFirewall           `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
@@ -46,6 +46,7 @@ type VPCRouterSetting struct {
 	RemoteAccessUsers  *VPCRouterRemoteAccessUsers  `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	SiteToSiteIPsecVPN *VPCRouterSiteToSiteIPsecVPN `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	StaticRoutes       *VPCRouterStaticRoutes       `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	SyslogHost         string                       `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 }
 
 // VPCRouterInternetConnection インターフェース

--- a/sacloud/test/vpc_router_op_test.go
+++ b/sacloud/test/vpc_router_op_test.go
@@ -214,9 +214,9 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 			return nil
 		},
 		Create: &testutil.CRUDTestFunc{
-			Func: testVPCRouterCreate(createVPCRouterParam),
+			Func: testVPCRouterCreate(withRouterCreateVPCRouterParam),
 			CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
-				ExpectValue:  createVPCRouterExpected,
+				ExpectValue:  withRouterCreateVPCRouterExpected,
 				IgnoreFields: ignoreVPCRouterFields,
 			}),
 		},
@@ -224,7 +224,7 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 		Read: &testutil.CRUDTestFunc{
 			Func: testVPCRouterRead,
 			CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
-				ExpectValue:  createVPCRouterExpected,
+				ExpectValue:  withRouterCreateVPCRouterExpected,
 				IgnoreFields: ignoreVPCRouterFields,
 			}),
 		},
@@ -233,8 +233,8 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 			{
 				Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					if isAccTest() {
-						// 起動直後だとシャットダウンできない場合があるため10秒ほど待つ
-						time.Sleep(10 * time.Second)
+						// 起動直後だとシャットダウンできない場合があるため20秒ほど待つ
+						time.Sleep(20 * time.Second)
 					}
 
 					vpcOp := sacloud.NewVPCRouterOp(caller)
@@ -266,12 +266,14 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 					// setup update param
 					p := withRouterUpdateVPCRouterParam
 					p.Settings = &sacloud.VPCRouterSetting{
+						VRID:                      10,
+						SyslogHost:                "192.168.2.199",
 						InternetConnectionEnabled: true,
 						Interfaces: []*sacloud.VPCRouterInterfaceSetting{
 							withRouterCreateVPCRouterParam.Settings.Interfaces[0],
 							{
-								VirtualIPAddress: "192.0.2.1",
-								IPAddress:        []string{"192.0.2.11", "192.0.2.12"},
+								VirtualIPAddress: "192.168.2.1",
+								IPAddress:        []string{"192.168.2.11", "192.168.2.12"},
 								NetworkMaskLen:   24,
 								Index:            2,
 							},
@@ -279,30 +281,30 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 						StaticNAT: []*sacloud.VPCRouterStaticNAT{
 							{
 								GlobalAddress:  withRouterCreateVPCRouterParam.Settings.Interfaces[0].IPAliases[0],
-								PrivateAddress: "192.0.2.1",
+								PrivateAddress: "192.168.2.1",
 							},
 						},
 						DHCPServer: []*sacloud.VPCRouterDHCPServer{
 							{
 								Interface:  "eth2",
-								RangeStart: "192.0.2.51",
-								RangeStop:  "192.0.2.60",
+								RangeStart: "192.168.2.51",
+								RangeStop:  "192.168.2.60",
 							},
 						},
 						DHCPStaticMapping: []*sacloud.VPCRouterDHCPStaticMapping{
 							{
 								MACAddress: "aa:bb:cc:dd:ee:ff",
-								IPAddress:  "192.0.2.21",
+								IPAddress:  "192.168.2.21",
 							},
 						},
 						PPTPServer: &sacloud.VPCRouterPPTPServer{
-							RangeStart: "192.0.2.61",
-							RangeStop:  "192.0.2.70",
+							RangeStart: "192.168.2.61",
+							RangeStop:  "192.168.2.70",
 						},
 						PPTPServerEnabled: true,
 						L2TPIPsecServer: &sacloud.VPCRouterL2TPIPsecServer{
-							RangeStart:      "192.0.2.71",
-							RangeStop:       "192.0.2.80",
+							RangeStart:      "192.168.2.71",
+							RangeStop:       "192.168.2.80",
 							PreSharedSecret: "presharedsecret",
 						},
 						L2TPIPsecServerEnabled: true,
@@ -314,26 +316,26 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 						},
 						SiteToSiteIPsecVPN: []*sacloud.VPCRouterSiteToSiteIPsecVPN{
 							{
-								Peer:            "10.0.0.1",
+								Peer:            "1.2.3.4",
 								PreSharedSecret: "presharedsecret",
-								RemoteID:        "10.0.0.1",
-								Routes:          []string{"192.0.2.248/28"},
-								LocalPrefix:     []string{"192.0.2.0/24"},
+								RemoteID:        "1.2.3.4",
+								Routes:          []string{"10.0.0.0/24"},
+								LocalPrefix:     []string{"192.168.2.0/24"},
 							},
 						},
 						StaticRoute: []*sacloud.VPCRouterStaticRoute{
 							{
 								Prefix:  "172.16.0.0/16",
-								NextHop: "192.0.2.11",
+								NextHop: "192.168.2.11",
 							},
 						},
 					}
 
 					withRouterUpdateVPCRouterExpected.Settings = p.Settings
-					return testVPCRouterUpdate(updateVPCRouterParam)(ctx, caller)
+					return testVPCRouterUpdate(withRouterUpdateVPCRouterParam)(ctx, caller)
 				},
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
-					ExpectValue:  updateVPCRouterExpected,
+					ExpectValue:  withRouterUpdateVPCRouterExpected,
 					IgnoreFields: ignoreVPCRouterFields,
 				}),
 			},
@@ -342,6 +344,7 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 					// setup update param
 					p := withRouterUpdateVPCRouterToMinParam
 					p.Settings = &sacloud.VPCRouterSetting{
+						VRID:                      10,
 						InternetConnectionEnabled: false,
 						Interfaces: []*sacloud.VPCRouterInterfaceSetting{
 							withRouterCreateVPCRouterParam.Settings.Interfaces[0],
@@ -349,10 +352,10 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 					}
 
 					withRouterUpdateVPCRouterToMinExpected.Settings = p.Settings
-					return testVPCRouterUpdate(updateVPCRouterParam)(ctx, caller)
+					return testVPCRouterUpdate(withRouterUpdateVPCRouterToMinParam)(ctx, caller)
 				},
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
-					ExpectValue:  updateVPCRouterExpected,
+					ExpectValue:  withRouterUpdateVPCRouterToMinExpected,
 					IgnoreFields: ignoreVPCRouterFields,
 				}),
 			},
@@ -390,20 +393,20 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 
 var (
 	withRouterCreateVPCRouterParam = &sacloud.VPCRouterCreateRequest{
-		PlanID:      types.VPCRouterPlans.Standard,
+		PlanID:      types.VPCRouterPlans.Premium,
 		Name:        testutil.ResourceName("vpc-router"),
 		Description: "desc",
 		Tags:        []string{"tag1", "tag2"},
 	}
 	withRouterCreateVPCRouterExpected = &sacloud.VPCRouter{
 		Class:          "vpcrouter",
-		Name:           createVPCRouterParam.Name,
-		Description:    createVPCRouterParam.Description,
-		Tags:           createVPCRouterParam.Tags,
+		Name:           withRouterCreateVPCRouterParam.Name,
+		Description:    withRouterCreateVPCRouterParam.Description,
+		Tags:           withRouterCreateVPCRouterParam.Tags,
 		Availability:   types.Availabilities.Available,
 		InstanceStatus: types.ServerInstanceStatuses.Up,
-		PlanID:         createVPCRouterParam.PlanID,
-		Settings:       createVPCRouterParam.Settings,
+		PlanID:         withRouterCreateVPCRouterParam.PlanID,
+		Settings:       withRouterCreateVPCRouterParam.Settings,
 	}
 	withRouterUpdateVPCRouterParam = &sacloud.VPCRouterUpdateRequest{
 		Name:        testutil.ResourceName("vpc-router-upd"),
@@ -413,12 +416,12 @@ var (
 	}
 	withRouterUpdateVPCRouterExpected = &sacloud.VPCRouter{
 		Class:          "vpcrouter",
-		Name:           updateVPCRouterParam.Name,
-		Description:    updateVPCRouterParam.Description,
-		Tags:           updateVPCRouterParam.Tags,
+		Name:           withRouterUpdateVPCRouterParam.Name,
+		Description:    withRouterUpdateVPCRouterParam.Description,
+		Tags:           withRouterUpdateVPCRouterParam.Tags,
 		Availability:   types.Availabilities.Available,
 		InstanceStatus: types.ServerInstanceStatuses.Up,
-		PlanID:         createVPCRouterParam.PlanID,
+		PlanID:         withRouterCreateVPCRouterParam.PlanID,
 		Settings:       withRouterUpdateVPCRouterParam.Settings,
 		IconID:         testIconID,
 	}
@@ -427,10 +430,10 @@ var (
 	}
 	withRouterUpdateVPCRouterToMinExpected = &sacloud.VPCRouter{
 		Class:          "vpcrouter",
-		Name:           updateVPCRouterParam.Name,
+		Name:           withRouterUpdateVPCRouterToMinParam.Name,
 		Availability:   types.Availabilities.Available,
 		InstanceStatus: types.ServerInstanceStatuses.Up,
-		PlanID:         createVPCRouterParam.PlanID,
+		PlanID:         withRouterCreateVPCRouterParam.PlanID,
 		Settings:       withRouterUpdateVPCRouterToMinParam.Settings,
 	}
 )

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -25694,7 +25694,7 @@ func (o *VPCRouter) SetZoneID(v types.ID) {
 type VPCRouterSetting struct {
 	VRID                      int                            `json:",omitempty" mapconv:"Router.VRID"`
 	InternetConnectionEnabled types.StringFlag               `json:",omitempty" mapconv:"Router.InternetConnection.Enabled,omitempty"`
-	Interfaces                []*VPCRouterInterfaceSetting   `json:",omitempty" mapconv:"Router.[]Interface,omitempty,recursive"`
+	Interfaces                []*VPCRouterInterfaceSetting   `json:",omitempty" mapconv:"Router.[]Interfaces,omitempty,recursive"`
 	StaticNAT                 []*VPCRouterStaticNAT          `json:",omitempty" mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
 	Firewall                  []*VPCRouterFirewall           `json:",omitempty" mapconv:"Router.Firewall.[]Config,omitempty,recursive"`
 	DHCPServer                []*VPCRouterDHCPServer         `json:",omitempty" mapconv:"Router.DHCPServer.[]Config,omitempty,recursive"`
@@ -25706,6 +25706,7 @@ type VPCRouterSetting struct {
 	RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `json:",omitempty" mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
 	SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `json:",omitempty" mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
 	StaticRoute               []*VPCRouterStaticRoute        `json:",omitempty" mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
+	SyslogHost                string                         `mapconv:"Router.SyslogHost"`
 }
 
 // Validate validates by field tags
@@ -25718,7 +25719,7 @@ func (o *VPCRouterSetting) setDefaults() interface{} {
 	return &struct {
 		VRID                      int                            `json:",omitempty" mapconv:"Router.VRID"`
 		InternetConnectionEnabled types.StringFlag               `json:",omitempty" mapconv:"Router.InternetConnection.Enabled,omitempty"`
-		Interfaces                []*VPCRouterInterfaceSetting   `json:",omitempty" mapconv:"Router.[]Interface,omitempty,recursive"`
+		Interfaces                []*VPCRouterInterfaceSetting   `json:",omitempty" mapconv:"Router.[]Interfaces,omitempty,recursive"`
 		StaticNAT                 []*VPCRouterStaticNAT          `json:",omitempty" mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
 		Firewall                  []*VPCRouterFirewall           `json:",omitempty" mapconv:"Router.Firewall.[]Config,omitempty,recursive"`
 		DHCPServer                []*VPCRouterDHCPServer         `json:",omitempty" mapconv:"Router.DHCPServer.[]Config,omitempty,recursive"`
@@ -25730,6 +25731,7 @@ func (o *VPCRouterSetting) setDefaults() interface{} {
 		RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `json:",omitempty" mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
 		SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `json:",omitempty" mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
 		StaticRoute               []*VPCRouterStaticRoute        `json:",omitempty" mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
+		SyslogHost                string                         `mapconv:"Router.SyslogHost"`
 	}{
 		VRID:                      o.GetVRID(),
 		InternetConnectionEnabled: o.GetInternetConnectionEnabled(),
@@ -25745,6 +25747,7 @@ func (o *VPCRouterSetting) setDefaults() interface{} {
 		RemoteAccessUsers:         o.GetRemoteAccessUsers(),
 		SiteToSiteIPsecVPN:        o.GetSiteToSiteIPsecVPN(),
 		StaticRoute:               o.GetStaticRoute(),
+		SyslogHost:                o.GetSyslogHost(),
 	}
 }
 
@@ -25888,13 +25891,22 @@ func (o *VPCRouterSetting) SetStaticRoute(v []*VPCRouterStaticRoute) {
 	o.StaticRoute = v
 }
 
+// GetSyslogHost returns value of SyslogHost
+func (o *VPCRouterSetting) GetSyslogHost() string {
+	return o.SyslogHost
+}
+
+// SetSyslogHost sets value to SyslogHost
+func (o *VPCRouterSetting) SetSyslogHost(v string) {
+	o.SyslogHost = v
+}
+
 /*************************************************
 * VPCRouterInterfaceSetting
 *************************************************/
 
 // VPCRouterInterfaceSetting represents API parameter/response structure
 type VPCRouterInterfaceSetting struct {
-	Enabled          types.StringFlag `mapconv:",omitempty"`
 	IPAddress        []string
 	VirtualIPAddress string
 	IPAliases        []string
@@ -25910,30 +25922,18 @@ func (o *VPCRouterInterfaceSetting) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *VPCRouterInterfaceSetting) setDefaults() interface{} {
 	return &struct {
-		Enabled          types.StringFlag `mapconv:",omitempty"`
 		IPAddress        []string
 		VirtualIPAddress string
 		IPAliases        []string
 		NetworkMaskLen   int
 		Index            int
 	}{
-		Enabled:          o.GetEnabled(),
 		IPAddress:        o.GetIPAddress(),
 		VirtualIPAddress: o.GetVirtualIPAddress(),
 		IPAliases:        o.GetIPAliases(),
 		NetworkMaskLen:   o.GetNetworkMaskLen(),
 		Index:            o.GetIndex(),
 	}
-}
-
-// GetEnabled returns value of Enabled
-func (o *VPCRouterInterfaceSetting) GetEnabled() types.StringFlag {
-	return o.Enabled
-}
-
-// SetEnabled sets value to Enabled
-func (o *VPCRouterInterfaceSetting) SetEnabled(v types.StringFlag) {
-	o.Enabled = v
 }
 
 // GetIPAddress returns value of IPAddress


### PR DESCRIPTION
- SyslogHostフィールドの追加
- Settings.Interfacesのmapconvタグ誤り修正
- InterfacesでのJSONマーシャル/アンマーシャルの誤り修正
- テストケースがpremiumプランを利用していなかった問題の修正