### PR TITLE
Exampleテストの追加

### DIFF
--- a/sacloud/example_test.go
+++ b/sacloud/example_test.go
@@ -1,0 +1,115 @@
+package sacloud_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+func Example_basic() {
+	// APIクライアントの基本的な使い方の例
+
+	// APIキー
+	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+
+	// クライアントの作成
+	client := sacloud.NewClient(token, secret)
+
+	// スイッチの作成
+	swOp := sacloud.NewSwitchOp(client)
+	sw, err := swOp.Create(context.Background(), "is1a", &sacloud.SwitchCreateRequest{
+		Name:        "libsacloud-example",
+		Description: "description",
+		Tags:        types.Tags{"tag1", "tag2"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Name: %s", sw.Name)
+}
+
+func Example_serverCRUD() {
+	// ServerのCRUDを行う例
+
+	// Note: サーバの作成を行いたい場合、通常はgithub.com/libsacloud/v2/utils/serverパッケージを利用してください。
+	// この例はServer APIを直接利用したい場合向けです。
+
+	// APIキー
+	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+
+	// クライアントの作成
+	client := sacloud.NewClient(token, secret)
+
+	// サーバの作成(ディスクレス)
+	ctx := context.Background()
+	serverOp := sacloud.NewServerOp(client)
+	server, err := serverOp.Create(ctx, "is1a", &sacloud.ServerCreateRequest{
+		CPU:                  1,
+		MemoryMB:             1024,
+		ServerPlanCommitment: types.Commitments.Standard,
+		ServerPlanGeneration: types.PlanGenerations.Default,
+		ConnectedSwitches:    []*sacloud.ConnectedSwitch{{Scope: "shared"}},
+		InterfaceDriver:      types.InterfaceDrivers.VirtIO,
+		Name:                 "libsacloud-example",
+		Description:          "description",
+		Tags:                 types.Tags{"tag1", "tag2"},
+		//IconID:               0,
+		WaitDiskMigration: false,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// 更新
+	server, err = serverOp.Update(ctx, "is1a", server.ID, &sacloud.ServerUpdateRequest{
+		Name:        "libsacloud-example-updated",
+		Description: "description-updated",
+		Tags:        types.Tags{"tag1-updated", "tag2-updated"},
+		// IconID:      0,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// 起動
+	if err := serverOp.Boot(ctx, "is1a", server.ID); err != nil {
+		log.Fatal(err)
+	}
+
+	// runningになるまで待機(同期)
+	waiter := sacloud.WaiterForUp(func() (state interface{}, err error) {
+		return serverOp.Read(ctx, "is1a", server.ID)
+	})
+	if _, err := waiter.WaitForState(ctx); err != nil {
+		log.Fatal(err)
+	}
+	// 非同期の場合
+	// completeCh, progressCh, errCh := waiter.AsyncWaitForState(ctx)
+
+	// シャットダウン(force)
+	if err := serverOp.Shutdown(ctx, "is1a", server.ID, &sacloud.ShutdownOption{Force: true}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Downになるまで待機
+	waiter = sacloud.WaiterForDown(func() (state interface{}, err error) {
+		return serverOp.Read(ctx, "is1a", server.ID)
+	})
+	if _, err := waiter.WaitForState(ctx); err != nil {
+		log.Fatal(err)
+	}
+
+	// 削除
+	if err := serverOp.Delete(ctx, "is1a", server.ID); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("hoge")
+}

--- a/utils/server/example_test.go
+++ b/utils/server/example_test.go
@@ -1,0 +1,91 @@
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/server"
+	"github.com/sacloud/libsacloud/v2/utils/server/ostype"
+)
+
+func Example_builder() {
+
+	// APIキー
+	token := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
+	secret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
+
+	// クライアントの作成
+	client := sacloud.NewClient(token, secret)
+
+	// ビルダーの準備
+	builder := &server.Builder{
+		Name:     "libsacloud-example",
+		CPU:      2,
+		MemoryGB: 4,
+		// Commitment:      types.Commitments.Standard,
+		// Generation:      types.PlanGenerations.Default,
+		// InterfaceDriver: types.InterfaceDrivers.VirtIO,
+		Description:     "description",
+		Tags:            types.Tags{"tag1", "tag2"},
+		BootAfterCreate: true,
+		NIC:             &server.SharedNICSetting{
+			// PacketFilterID: types.ID(123456789012),
+		},
+		//AdditionalNICs: []server.AdditionalNICSettingHolder{
+		//	&server.ConnectedNICSetting{
+		//		SwitchID:        types.ID(123456789012),
+		//		DisplayIPAddress: "192.168.0.1",
+		//		PacketFilterID:  types.ID(123456789012),
+		//	},
+		//},
+
+		// IconID:          types.ID(123456789012),
+		// CDROMID:         types.ID(123456789012),
+		// PrivateHostID:   types.ID(123456789012),
+
+		DiskBuilders: []server.DiskBuilder{
+			&server.FromUnixDiskBuilder{
+				OSType:     ostype.CentOS,
+				Name:       "libsacloud-example",
+				SizeGB:     20,
+				PlanID:     types.DiskPlans.SSD,
+				Connection: types.DiskConnections.VirtIO,
+				//DistantFrom:     []types.ID{types.ID(123456789012)},
+				Description: "description",
+				Tags:        types.Tags{"tag1", "tag2"},
+				EditParameter: &server.UnixDiskEditRequest{
+					HostName:            "libsacloud-example", // ホスト名
+					Password:            "P@ssW0rd",           // パスワード
+					DisablePWAuth:       false,                // パスワード認証の無効化
+					ChangePartitionUUID: true,                 // UUIDの変更
+					EnableDHCP:          false,                // DHCPの有効化
+
+					//IPAddress:                 "192.168.11.11",                    // IPアドレス(スイッチ or スイッチ+ルータに接続する場合)
+					//NetworkMaskLen:            24,                                 // ネットワークマスク長(スイッチ or スイッチ+ルータに接続する場合)
+					//DefaultRoute:              "192.168.11.1",                     // デフォルトルート(スイッチ or スイッチ+ルータに接続する場合)
+					//SSHKeys:                   []string{sshKey1, sshKey2},         // 公開鍵(文字列で指定)
+					//SSHKeyIDs:                 []types.ID{types.ID(123456789012)}, // 公開鍵(IDで指定)
+					//IsSSHKeysEphemeral:        false,                              // 公開鍵をさくらのクラウド側で生成した場合にサーバ作成後に該当鍵の削除を行うか
+					//GenerateSSHKeyName:        "",                                 // 生成する公開鍵の名称
+					//GenerateSSHKeyPassPhrase:  "",                                 // 生成する公開鍵のパスフレーズ
+					//GenerateSSHKeyDescription: "",                                 // 生成する公開鍵の説明
+					//IsNotesEphemeral:          false,                              // Notesで指定したスタートアップスクリプトをサーバ作成後に削除するか
+					//Notes:                     []string{note1, note2},             // スタートアップスクリプト(文字列で指定)
+					//NoteIDs:                   []types.ID{types.ID(123456789012)}, // スタートアップスクリプト(IDで指定)
+				},
+				// IconID:          0,
+			},
+		},
+	}
+
+	result, err := builder.Build(context.Background(), server.NewBuildersAPIClient(client), "is1a")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("ServerID: %s", result.ServerID)
+}


### PR DESCRIPTION
(related: #304)

Exampleテストを追加する。

- sacloudパッケージ
  - 基本的なクライアントの利用方法
  - ServerのCRUD
- utils/serverパッケージ
  - builderの利用方法