### PR TITLE
Backgroundパラメータの追加

### DIFF
--- a/api/disk.go
+++ b/api/disk.go
@@ -194,6 +194,18 @@ func (api *DiskAPI) ResizePartition(diskID int64) (bool, error) {
 	return api.modify(method, uri, nil)
 }
 
+// ResizePartitionBackground パーティションのリサイズ(非同期)
+func (api *DiskAPI) ResizePartitionBackground(diskID int64) (bool, error) {
+	var (
+		method = "PUT"
+		uri    = fmt.Sprintf("%s/%d/resize-partition", api.getResourceURL(), diskID)
+		body   = map[string]interface{}{
+			"Background": true,
+		}
+	)
+	return api.modify(method, uri, body)
+}
+
 // DisconnectFromServer サーバーとの接続解除
 func (api *DiskAPI) DisconnectFromServer(diskID int64) (bool, error) {
 	var (

--- a/api/disk_test.go
+++ b/api/disk_test.go
@@ -119,6 +119,7 @@ func TestCreateDiskWithConfig(t *testing.T) {
 	disk.SetSourceArchive(archiveID) //ソースアーカイブはIDだけ指定する
 
 	config := diskAPI.NewCondig()
+	config.SetBackground(true)
 	config.SetPassword("p@ssw0rd")
 	config.SetHostName(testDiskName)
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/sacloud/libsacloud
 
+go 1.12
+
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect

--- a/sacloud/disk.go
+++ b/sacloud/disk.go
@@ -94,6 +94,7 @@ func (d *Disk) SetDiskPlanToSSD() {
 //
 // 設定を行う項目のみ値をセットする。値のセットにはセッターを利用すること。
 type DiskEditValue struct {
+	Background    bool        `json:",omitempty"` // バックグラウンド実行
 	Password      *string     `json:",omitempty"` // パスワード
 	SSHKey        *SSHKey     `json:",omitempty"` // 公開鍵(単体)
 	SSHKeys       []*SSHKey   `json:",omitempty"` // 公開鍵(複数)
@@ -105,6 +106,11 @@ type DiskEditValue struct {
 		DefaultRoute   string `json:",omitempty"` // デフォルトルート
 		NetworkMaskLen string `json:",omitempty"` // ネットワークマスク長
 	} `json:",omitempty"`
+}
+
+// SetBackground バックグラウンド実行 設定
+func (d *DiskEditValue) SetBackground(value bool) {
+	d.Background = value
 }
 
 // SetHostName ホスト名 設定


### PR DESCRIPTION
( a part of #353 )

ディスクの修正APIにBackgroundパラメータを追加する。

Note: ResizePartitionに対しては別funcを追加して対応している。  
この方法の場合、今後さらに引数が増えた場合のメンテナンスコストが上がるが、現状でパラメータ用に新しい型を作るのが面倒だった、かつこのfuncに対して引数が増えることはあまりなさそうに思えることから採用した。