### PR TITLE
Aliasレコード

### DIFF
--- a/sacloud/dns.go
+++ b/sacloud/dns.go
@@ -59,7 +59,7 @@ func CreateNewDNS(zoneName string) *DNS {
 
 // AllowDNSTypes DNSレコード種別リスト
 func AllowDNSTypes() []string {
-	return []string{"A", "AAAA", "CNAME", "NS", "MX", "TXT", "SRV", "CAA"}
+	return []string{"A", "AAAA", "ALIAS", "CNAME", "NS", "MX", "TXT", "SRV", "CAA"}
 }
 
 // SetZone DNSゾーン名 設定


### PR DESCRIPTION
ALIASレコードを登録可能にする。

libsacloudレベルではこれまでも登録できていたが、他プロジェクトでのレコードタイプのバリデーションで利用する値にAliasレコードが存在しなかった。このPRではAliasレコードを許可リストに追加するのみの対応となっている。