### PR TITLE
シンプル監視での再通知間隔の指定

### DIFF
--- a/api/simple_monitor_test.go
+++ b/api/simple_monitor_test.go
@@ -21,6 +21,7 @@ func TestSimpleMonitorCRUD(t *testing.T) {
 	newItem := api.New(testSimpleMonitorName)
 	newItem.Description = "before"
 	newItem.SetDelayLoop(60)
+	newItem.SetNotifyInterval(60 * 60 * 1) // 1時間
 	newItem.EnableNotifyEmail(true)
 	newItem.SetHealthCheckHTTP("80", "/index.html", "200", "www.libsacloud.com", "", "")
 

--- a/sacloud/simple_monitor.go
+++ b/sacloud/simple_monitor.go
@@ -16,7 +16,6 @@ type SimpleMonitor struct {
 	Settings *SimpleMonitorSettings `json:",omitempty"` // 設定
 	Status   *SimpleMonitorStatus   `json:",omitempty"` // ステータス
 	Provider *SimpleMonitorProvider `json:",omitempty"` // プロバイダ
-
 }
 
 // SimpleMonitorSettings シンプル監視設定 リスト
@@ -26,11 +25,12 @@ type SimpleMonitorSettings struct {
 
 // SimpleMonitorSetting シンプル監視設定
 type SimpleMonitorSetting struct {
-	DelayLoop   int                       `json:",omitempty"` // 監視間隔
-	HealthCheck *SimpleMonitorHealthCheck `json:",omitempty"` // ヘルスチェック
-	Enabled     string                    `json:",omitempty"` // 有効/無効
-	NotifyEmail *SimpleMonitorNotify      `json:",omitempty"` // Email通知
-	NotifySlack *SimpleMonitorNotify      `json:",omitempty"` // Slack通知
+	DelayLoop      int                       `json:",omitempty"` // 監視間隔
+	NotifyInterval int                       `json:",omitempty"` // 再通知間隔(秒数)
+	HealthCheck    *SimpleMonitorHealthCheck `json:",omitempty"` // ヘルスチェック
+	Enabled        string                    `json:",omitempty"` // 有効/無効
+	NotifyEmail    *SimpleMonitorNotify      `json:",omitempty"` // Email通知
+	NotifySlack    *SimpleMonitorNotify      `json:",omitempty"` // Slack通知
 }
 
 // SimpleMonitorStatus シンプル監視ステータス
@@ -286,4 +286,9 @@ func (s *SimpleMonitor) DisableNotifySlack() {
 // SetDelayLoop 監視間隔の設定
 func (s *SimpleMonitor) SetDelayLoop(loop int) {
 	s.Settings.SimpleMonitor.DelayLoop = loop
+}
+
+// SetNotifyInterval 再通知間隔の設定
+func (s *SimpleMonitor) SetNotifyInterval(loop int) {
+	s.Settings.SimpleMonitor.NotifyInterval = loop
 }


### PR DESCRIPTION
( a part of #345 )

シンプル監視での再通知間隔を指定可能にする。