### PR TITLE
Add Background parameter

### DIFF
--- a/internal/define/disk.go
+++ b/internal/define/disk.go
@@ -143,7 +143,28 @@ var diskAPI = &dsl.Resource{
 		ops.WithIDAction(diskAPIName, "ToBlank", http.MethodPut, "to/blank"),
 
 		// resize partition
-		ops.WithIDAction(diskAPIName, "ResizePartition", http.MethodPut, "resize-partition"),
+		{
+			ResourceName: diskAPIName,
+			Name:         "ResizePartition",
+			PathFormat:   dsl.IDAndSuffixPathFormat("resize-partition"),
+			Method:       http.MethodPut,
+			RequestEnvelope: dsl.RequestEnvelope(
+				&dsl.EnvelopePayloadDesc{
+					Type: meta.TypeFlag,
+					Name: "Background",
+				},
+			),
+			Arguments: dsl.Arguments{
+				dsl.ArgumentID,
+				dsl.PassthroughModelArgument("param", &dsl.Model{
+					Name: "DiskResizePartitionRequest",
+					Fields: []*dsl.FieldDesc{
+						fields.Def("Background", meta.TypeFlag),
+					},
+					NakedType: meta.Static(naked.ResizePartitionRequest{}),
+				}),
+			},
+		},
 
 		// connect to server
 		ops.WithIDAction(diskAPIName, "ConnectToServer", http.MethodPut, "to/server/{{.serverID}}",
@@ -233,6 +254,7 @@ var (
 			fields.DiskConnection(),
 			fields.DiskConnectionOrder(),
 			fields.DiskReinstallCount(),
+			fields.Def("JobStatus", models.migrationJobStatus()),
 			fields.SizeMB(),
 			fields.MigratedMB(),
 			fields.DiskPlanID(),

--- a/internal/define/models.go
+++ b/internal/define/models.go
@@ -112,6 +112,14 @@ func (m *modelsDef) diskEdit() *dsl.Model {
 		NakedType: meta.Static(naked.DiskEdit{}),
 		Fields: []*dsl.FieldDesc{
 			{
+				Name: "Background",
+				Type: meta.TypeFlag,
+				Tags: &dsl.FieldTags{
+					MapConv: ",omitempty",
+					JSON:    ",omitempty",
+				},
+			},
+			{
 				Name: "Password",
 				Type: meta.TypeString,
 				Tags: &dsl.FieldTags{

--- a/internal/define/models.go
+++ b/internal/define/models.go
@@ -1362,3 +1362,22 @@ func (m *modelsDef) simInfoFields() []*dsl.FieldDesc {
 		fields.Def("ConnectedIMEI", meta.TypeString),
 	}
 }
+
+func (m *modelsDef) migrationJobStatus() *dsl.Model {
+	return &dsl.Model{
+		Name:      "JobStatus",
+		NakedType: meta.Static(naked.MigrationJobStatus{}),
+		Fields: []*dsl.FieldDesc{
+			fields.Def("Status", meta.TypeString),
+			fields.Def("ConfigError", &dsl.Model{
+				Name:      "JobConfigError",
+				NakedType: meta.Static(naked.JobConfigError{}),
+				Fields: []*dsl.FieldDesc{
+					fields.Def("ErrorCode", meta.TypeString),
+					fields.Def("ErrorMsg", meta.TypeString),
+					fields.Def("Status", meta.TypeString),
+				},
+			}),
+		},
+	}
+}

--- a/sacloud/fake/ops_disk.go
+++ b/sacloud/fake/ops_disk.go
@@ -128,7 +128,7 @@ func (o *DiskOp) ToBlank(ctx context.Context, zone string, id types.ID) error {
 }
 
 // ResizePartition is fake implementation
-func (o *DiskOp) ResizePartition(ctx context.Context, zone string, id types.ID) error {
+func (o *DiskOp) ResizePartition(ctx context.Context, zone string, id types.ID, param *sacloud.DiskResizePartitionRequest) error {
 	_, err := o.Read(ctx, zone, id)
 	if err != nil {
 		return err

--- a/sacloud/naked/disk.go
+++ b/sacloud/naked/disk.go
@@ -1,6 +1,7 @@
 package naked
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -33,8 +34,9 @@ type Disk struct {
 
 // MigrationJobStatus マイグレーションジョブステータス
 type MigrationJobStatus struct {
-	Status string    `json:",omitempty" yaml:"status,omitempty" structs:",omitempty"` // ステータス
-	Delays *struct { // Delays
+	Status      string          `json:",omitempty" yaml:"status,omitempty" structs:",omitempty"` // ステータス
+	ConfigError *JobConfigError `json:",omitempty" yaml:"config_error,omitempty" structs:",omitempty"`
+	Delays      *struct {       // Delays
 		Start *struct { // 開始
 			Max int `json:",omitempty" yaml:"max,omitempty" structs:",omitempty"` // 最大
 			Min int `json:",omitempty" yaml:"min,omitempty" structs:",omitempty"` // 最小
@@ -45,4 +47,21 @@ type MigrationJobStatus struct {
 			Min int `json:",omitempty" yaml:"min,omitempty" structs:",omitempty"` // 最小
 		} `json:",omitempty" yaml:"finish,omitempty" structs:",omitempty"`
 	}
+}
+
+// JobConfigError マイグレーションジョブのエラー
+type JobConfigError struct {
+	ErrorCode string `json:",omitempty" yaml:"error_code,omitempty" structs:",omitempty"`
+	ErrorMsg  string `json:",omitempty" yaml:"error_msg,omitempty" structs:",omitempty"`
+	Status    string `json:",omitempty" yaml:"status,omitempty" structs:",omitempty"`
+}
+
+// String マイグレーションジョブエラーの文字列表現
+func (e *JobConfigError) String() string {
+	return fmt.Sprintf("%s: %s", e.ErrorCode, e.ErrorMsg)
+}
+
+// ResizePartitionRequest リサイズ時のオプション
+type ResizePartitionRequest struct {
+	Background bool `json:",omitempty" yaml:"background,omitempty" structs:",omitempty"`
 }

--- a/sacloud/naked/disk_edit.go
+++ b/sacloud/naked/disk_edit.go
@@ -14,6 +14,7 @@ type DiskEdit struct {
 	Notes               []DiskEditNote    `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // スタートアップスクリプト
 	UserIPAddress       string            `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // IPアドレス
 	UserSubnet          *UserSubnet       `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // デフォルトルート/サブネットマスク長
+	Background          bool              `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // バックグラウンド実行
 }
 
 // DiskEditSSHKey ディスク修正時のSSHキー

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -1031,7 +1031,7 @@ func (s *DiskStub) ToBlank(ctx context.Context, zone string, id types.ID) error 
 }
 
 // ResizePartition is API call with trace log
-func (s *DiskStub) ResizePartition(ctx context.Context, zone string, id types.ID) error {
+func (s *DiskStub) ResizePartition(ctx context.Context, zone string, id types.ID, param *sacloud.DiskResizePartitionRequest) error {
 	if s.ResizePartitionStubResult == nil {
 		log.Fatal("DiskStub.ResizePartitionStubResult is not set")
 	}

--- a/sacloud/test/disk_op_test.go
+++ b/sacloud/test/disk_op_test.go
@@ -194,7 +194,8 @@ func TestDiskOp_Config(t *testing.T) {
 					// edit disk
 					client := sacloud.NewDiskOp(singletonAPICaller())
 					err := client.Config(ctx, testZone, ctx.ID, &sacloud.DiskEditRequest{
-						Password: "password",
+						Background: true,
+						Password:   "password",
 						SSHKeys: []*sacloud.DiskEditSSHKey{
 							{
 								PublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC4LDQuDiKecOJDPY9InS7EswZ2fPnoRZXc48T1EqyRLyJhgEYGSDWaBiMDs2R/lWgA81Hp37qhrNqZPjFHUkBr93FOXxt9W0m1TNlkNepK0Uyi+14B2n0pdoeqsKEkb3sTevWF0ztxxWrwUd7Mems2hf+wFODITHYye9RlDAKLKPCFRvlQ9xQj4bBWOogQwoaXMSK1znMPjudcm1tRry4KIifLdXmwVKU4qDPGxoXfqs44Dgsikk43UVBStQ7IFoqPgAqcJFSGHLoMS7tPKdTvY9+GME5QidWK84gl69piAkgIdwd+JTMUOc/J+9DXAt220HqZ6l3yhWG5nIgi0x8n",
@@ -209,6 +210,13 @@ func TestDiskOp_Config(t *testing.T) {
 							NetworkMaskLen: 24,
 						},
 					})
+					if err != nil {
+						return nil, err
+					}
+					// wait
+					_, err = sacloud.WaiterForReady(func() (interface{}, error) {
+						return client.Read(ctx, testZone, ctx.ID)
+					}).WaitForState(ctx)
 					return nil, err
 				},
 			},

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -2177,14 +2177,16 @@ func (t *DiskTracer) ToBlank(ctx context.Context, zone string, id types.ID) erro
 }
 
 // ResizePartition is API call with trace log
-func (t *DiskTracer) ResizePartition(ctx context.Context, zone string, id types.ID) error {
+func (t *DiskTracer) ResizePartition(ctx context.Context, zone string, id types.ID, param *sacloud.DiskResizePartitionRequest) error {
 	log.Println("[TRACE] DiskAPI.ResizePartition start")
 	targetArguments := struct {
-		Argzone string
-		Argid   types.ID `json:"id"`
+		Argzone  string
+		Argid    types.ID                            `json:"id"`
+		Argparam *sacloud.DiskResizePartitionRequest `json:"param"`
 	}{
-		Argzone: zone,
-		Argid:   id,
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
 	}
 	if d, err := json.Marshal(targetArguments); err == nil {
 		log.Printf("[TRACE] \targs: %s\n", string(d))
@@ -2194,7 +2196,7 @@ func (t *DiskTracer) ResizePartition(ctx context.Context, zone string, id types.
 		log.Println("[TRACE] DiskAPI.ResizePartition end")
 	}()
 
-	err := t.Internal.ResizePartition(ctx, zone, id)
+	err := t.Internal.ResizePartition(ctx, zone, id, param)
 	targetResults := struct {
 		Error error
 	}{

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -2556,7 +2556,7 @@ func (o *DiskOp) ToBlank(ctx context.Context, zone string, id types.ID) error {
 }
 
 // ResizePartition is API call
-func (o *DiskOp) ResizePartition(ctx context.Context, zone string, id types.ID) error {
+func (o *DiskOp) ResizePartition(ctx context.Context, zone string, id types.ID, param *DiskResizePartitionRequest) error {
 	// build request URL
 	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/resize-partition", map[string]interface{}{
 		"rootURL":    SakuraCloudAPIRoot,
@@ -2564,6 +2564,7 @@ func (o *DiskOp) ResizePartition(ctx context.Context, zone string, id types.ID) 
 		"pathName":   o.PathName,
 		"zone":       zone,
 		"id":         id,
+		"param":      param,
 	})
 	if err != nil {
 		return err
@@ -2571,6 +2572,11 @@ func (o *DiskOp) ResizePartition(ctx context.Context, zone string, id types.ID) 
 
 	// build request body
 	var body interface{}
+	v, err := o.transformResizePartitionArgs(id, param)
+	if err != nil {
+		return err
+	}
+	body = v
 
 	// do request
 	_, err = o.Client.Do(ctx, "PUT", url, body)

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -1451,6 +1451,36 @@ func (o *DiskOp) transformCreateWithConfigResults(data []byte) (*diskCreateWithC
 	return results, nil
 }
 
+func (o *DiskOp) transformResizePartitionArgs(id types.ID, param *DiskResizePartitionRequest) (*diskResizePartitionRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &DiskResizePartitionRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &diskResizePartitionRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
 func (o *DiskOp) transformInstallArgs(id types.ID, installParam *DiskInstallRequest, distantFrom []types.ID) (*diskInstallRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -135,7 +135,7 @@ type DiskAPI interface {
 	Config(ctx context.Context, zone string, id types.ID, edit *DiskEditRequest) error
 	CreateWithConfig(ctx context.Context, zone string, createParam *DiskCreateRequest, editParam *DiskEditRequest, bootAtAvailable bool, distantFrom []types.ID) (*Disk, error)
 	ToBlank(ctx context.Context, zone string, id types.ID) error
-	ResizePartition(ctx context.Context, zone string, id types.ID) error
+	ResizePartition(ctx context.Context, zone string, id types.ID, param *DiskResizePartitionRequest) error
 	ConnectToServer(ctx context.Context, zone string, id types.ID, serverID types.ID) error
 	DisconnectFromServer(ctx context.Context, zone string, id types.ID) error
 	Install(ctx context.Context, zone string, id types.ID, installParam *DiskInstallRequest, distantFrom []types.ID) (*Disk, error)

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -584,6 +584,11 @@ type diskCreateWithConfigResponseEnvelope struct {
 	Disk *naked.Disk `json:",omitempty"`
 }
 
+// diskResizePartitionRequestEnvelope is envelop of API request
+type diskResizePartitionRequestEnvelope struct {
+	Background bool `json:",omitempty"`
+}
+
 // diskInstallRequestEnvelope is envelop of API request
 type diskInstallRequestEnvelope struct {
 	Disk        *naked.Disk `json:",omitempty"`

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -555,6 +555,7 @@ type diskCreateResponseEnvelope struct {
 
 // diskConfigRequestEnvelope is envelop of API request
 type diskConfigRequestEnvelope struct {
+	Background          bool                `json:",omitempty"`
 	Password            string              `json:",omitempty"`
 	SSHKey              *DiskEditSSHKey     `json:",omitempty"`
 	SSHKeys             []*DiskEditSSHKey   `json:",omitempty"`

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -6907,6 +6907,7 @@ func (o *DiskCreateRequest) SetIconID(v types.ID) {
 
 // DiskEditRequest represents API parameter/response structure
 type DiskEditRequest struct {
+	Background          bool                `json:",omitempty" mapconv:",omitempty"`
 	Password            string              `json:",omitempty" mapconv:",omitempty"`
 	SSHKey              *DiskEditSSHKey     `json:",omitempty" mapconv:",omitempty,recursive"`
 	SSHKeys             []*DiskEditSSHKey   `json:",omitempty" mapconv:"[]SSHKeys,omitempty,recursive"`
@@ -6927,6 +6928,7 @@ func (o *DiskEditRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *DiskEditRequest) setDefaults() interface{} {
 	return &struct {
+		Background          bool                `json:",omitempty" mapconv:",omitempty"`
 		Password            string              `json:",omitempty" mapconv:",omitempty"`
 		SSHKey              *DiskEditSSHKey     `json:",omitempty" mapconv:",omitempty,recursive"`
 		SSHKeys             []*DiskEditSSHKey   `json:",omitempty" mapconv:"[]SSHKeys,omitempty,recursive"`
@@ -6938,6 +6940,7 @@ func (o *DiskEditRequest) setDefaults() interface{} {
 		UserIPAddress       string              `json:",omitempty" mapconv:",omitempty"`
 		UserSubnet          *DiskEditUserSubnet `json:",omitempty" mapconv:",omitempty"`
 	}{
+		Background:          o.GetBackground(),
 		Password:            o.GetPassword(),
 		SSHKey:              o.GetSSHKey(),
 		SSHKeys:             o.GetSSHKeys(),
@@ -6949,6 +6952,16 @@ func (o *DiskEditRequest) setDefaults() interface{} {
 		UserIPAddress:       o.GetUserIPAddress(),
 		UserSubnet:          o.GetUserSubnet(),
 	}
+}
+
+// GetBackground returns value of Background
+func (o *DiskEditRequest) GetBackground() bool {
+	return o.Background
+}
+
+// SetBackground sets value to Background
+func (o *DiskEditRequest) SetBackground(v bool) {
+	o.Background = v
 }
 
 // GetPassword returns value of Password

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -6361,6 +6361,7 @@ type Disk struct {
 	Connection                types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
 	ConnectionOrder           int
 	ReinstallCount            int
+	JobStatus                 *JobStatus
 	SizeMB                    int
 	MigratedMB                int
 	DiskPlanID                types.ID            `mapconv:"Plan.ID"`
@@ -6394,6 +6395,7 @@ func (o *Disk) setDefaults() interface{} {
 		Connection                types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
 		ConnectionOrder           int
 		ReinstallCount            int
+		JobStatus                 *JobStatus
 		SizeMB                    int
 		MigratedMB                int
 		DiskPlanID                types.ID            `mapconv:"Plan.ID"`
@@ -6418,6 +6420,7 @@ func (o *Disk) setDefaults() interface{} {
 		Connection:                o.GetConnection(),
 		ConnectionOrder:           o.GetConnectionOrder(),
 		ReinstallCount:            o.GetReinstallCount(),
+		JobStatus:                 o.GetJobStatus(),
 		SizeMB:                    o.GetSizeMB(),
 		MigratedMB:                o.GetMigratedMB(),
 		DiskPlanID:                o.GetDiskPlanID(),
@@ -6554,6 +6557,16 @@ func (o *Disk) GetReinstallCount() int {
 // SetReinstallCount sets value to ReinstallCount
 func (o *Disk) SetReinstallCount(v int) {
 	o.ReinstallCount = v
+}
+
+// GetJobStatus returns value of JobStatus
+func (o *Disk) GetJobStatus() *JobStatus {
+	return o.JobStatus
+}
+
+// SetJobStatus sets value to JobStatus
+func (o *Disk) SetJobStatus(v *JobStatus) {
+	o.JobStatus = v
 }
 
 // GetSizeMB returns value of SizeMB
@@ -6719,6 +6732,111 @@ func (o *Disk) GetModifiedAt() time.Time {
 // SetModifiedAt sets value to ModifiedAt
 func (o *Disk) SetModifiedAt(v time.Time) {
 	o.ModifiedAt = v
+}
+
+/*************************************************
+* JobStatus
+*************************************************/
+
+// JobStatus represents API parameter/response structure
+type JobStatus struct {
+	Status      string
+	ConfigError *JobConfigError
+}
+
+// Validate validates by field tags
+func (o *JobStatus) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *JobStatus) setDefaults() interface{} {
+	return &struct {
+		Status      string
+		ConfigError *JobConfigError
+	}{
+		Status:      o.GetStatus(),
+		ConfigError: o.GetConfigError(),
+	}
+}
+
+// GetStatus returns value of Status
+func (o *JobStatus) GetStatus() string {
+	return o.Status
+}
+
+// SetStatus sets value to Status
+func (o *JobStatus) SetStatus(v string) {
+	o.Status = v
+}
+
+// GetConfigError returns value of ConfigError
+func (o *JobStatus) GetConfigError() *JobConfigError {
+	return o.ConfigError
+}
+
+// SetConfigError sets value to ConfigError
+func (o *JobStatus) SetConfigError(v *JobConfigError) {
+	o.ConfigError = v
+}
+
+/*************************************************
+* JobConfigError
+*************************************************/
+
+// JobConfigError represents API parameter/response structure
+type JobConfigError struct {
+	ErrorCode string
+	ErrorMsg  string
+	Status    string
+}
+
+// Validate validates by field tags
+func (o *JobConfigError) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *JobConfigError) setDefaults() interface{} {
+	return &struct {
+		ErrorCode string
+		ErrorMsg  string
+		Status    string
+	}{
+		ErrorCode: o.GetErrorCode(),
+		ErrorMsg:  o.GetErrorMsg(),
+		Status:    o.GetStatus(),
+	}
+}
+
+// GetErrorCode returns value of ErrorCode
+func (o *JobConfigError) GetErrorCode() string {
+	return o.ErrorCode
+}
+
+// SetErrorCode sets value to ErrorCode
+func (o *JobConfigError) SetErrorCode(v string) {
+	o.ErrorCode = v
+}
+
+// GetErrorMsg returns value of ErrorMsg
+func (o *JobConfigError) GetErrorMsg() string {
+	return o.ErrorMsg
+}
+
+// SetErrorMsg sets value to ErrorMsg
+func (o *JobConfigError) SetErrorMsg(v string) {
+	o.ErrorMsg = v
+}
+
+// GetStatus returns value of Status
+func (o *JobConfigError) GetStatus() string {
+	return o.Status
+}
+
+// SetStatus sets value to Status
+func (o *JobConfigError) SetStatus(v string) {
+	o.Status = v
 }
 
 /*************************************************
@@ -7200,6 +7318,39 @@ func (o *DiskEditUserSubnet) GetNetworkMaskLen() int {
 // SetNetworkMaskLen sets value to NetworkMaskLen
 func (o *DiskEditUserSubnet) SetNetworkMaskLen(v int) {
 	o.NetworkMaskLen = v
+}
+
+/*************************************************
+* DiskResizePartitionRequest
+*************************************************/
+
+// DiskResizePartitionRequest represents API parameter/response structure
+type DiskResizePartitionRequest struct {
+	Background bool
+}
+
+// Validate validates by field tags
+func (o *DiskResizePartitionRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *DiskResizePartitionRequest) setDefaults() interface{} {
+	return &struct {
+		Background bool
+	}{
+		Background: o.GetBackground(),
+	}
+}
+
+// GetBackground returns value of Background
+func (o *DiskResizePartitionRequest) GetBackground() bool {
+	return o.Background
+}
+
+// SetBackground sets value to Background
+func (o *DiskResizePartitionRequest) SetBackground(v bool) {
+	o.Background = v
 }
 
 /*************************************************


### PR DESCRIPTION
( a part of #353 )

ディスクの修正/パーティションリサイズAPIでBackgroundパラメータを指定可能にする。

Note: `Background=true`の場合のエラーを`Disk.JobStatus.ConfigError`から参照可能にする。