### PR TITLE
Add OSType - CentOS7

### DIFF
--- a/api/archive.go
+++ b/api/archive.go
@@ -31,6 +31,7 @@ type ArchiveAPI struct {
 
 var (
 	archiveLatestStableCentOSTags                          = []string{"current-stable", "distro-centos"}
+	archiveLatestStableCentOS7Tags                         = []string{"distro-centos", "distro-ver-7.7"}
 	archiveLatestStableCentOS6Tags                         = []string{"distro-centos", "distro-ver-6.10"}
 	archiveLatestStableUbuntuTags                          = []string{"current-stable", "distro-ubuntu"}
 	archiveLatestStableDebianTags                          = []string{"current-stable", "distro-debian"}
@@ -66,6 +67,7 @@ func NewArchiveAPI(client *Client) *ArchiveAPI {
 
 	api.findFuncMapPerOSType = map[ostype.ArchiveOSTypes]func() (*sacloud.Archive, error){
 		ostype.CentOS:                              api.FindLatestStableCentOS,
+		ostype.CentOS7:                             api.FindLatestStableCentOS7,
 		ostype.CentOS6:                             api.FindLatestStableCentOS6,
 		ostype.Ubuntu:                              api.FindLatestStableUbuntu,
 		ostype.Debian:                              api.FindLatestStableDebian,
@@ -236,6 +238,11 @@ func (api *ArchiveAPI) GetPublicArchiveIDFromAncestors(id int64) (int64, bool) {
 // FindLatestStableCentOS 安定版最新のCentOSパブリックアーカイブを取得
 func (api *ArchiveAPI) FindLatestStableCentOS() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableCentOSTags)
+}
+
+// FindLatestStableCentOS7 安定版最新のCentOS7パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableCentOS7() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableCentOS7Tags)
 }
 
 // FindLatestStableCentOS6 安定版最新のCentOS6パブリックアーカイブを取得

--- a/api/archive_test.go
+++ b/api/archive_test.go
@@ -289,6 +289,7 @@ func TestArchiveAPI_FindStableOSs(t *testing.T) {
 
 	targets := []target{
 		{label: "CentOS", f: api.FindLatestStableCentOS},
+		{label: "CentOS7", f: api.FindLatestStableCentOS7},
 		{label: "CentOS6", f: api.FindLatestStableCentOS6},
 		{label: "Debian", f: api.FindLatestStableDebian},
 		{label: "Ubuntu", f: api.FindLatestStableUbuntu},
@@ -332,6 +333,7 @@ func TestArchiveAPI_CanDiskEdit(t *testing.T) {
 
 	targets := []target{
 		{label: "CentOS", expect: true, f: api.FindLatestStableCentOS},
+		{label: "CentOS7", expect: true, f: api.FindLatestStableCentOS7},
 		{label: "CentOS6", expect: true, f: api.FindLatestStableCentOS6},
 		{label: "Debian", expect: true, f: api.FindLatestStableDebian},
 		{label: "Ubuntu", expect: true, f: api.FindLatestStableUbuntu},

--- a/sacloud/ostype/archive_ostype.go
+++ b/sacloud/ostype/archive_ostype.go
@@ -23,6 +23,8 @@ type ArchiveOSTypes int
 const (
 	// CentOS OS種別:CentOS
 	CentOS ArchiveOSTypes = iota
+	// CentOS7 OS種別:CentOS7
+	CentOS7
 	// CentOS6 OS種別:CentOS6
 	CentOS6
 	// Ubuntu OS種別:Ubuntu
@@ -69,7 +71,7 @@ const (
 
 // OSTypeShortNames OSTypeとして利用できる文字列のリスト
 var OSTypeShortNames = []string{
-	"centos", "centos6", "ubuntu", "debian", "coreos",
+	"centos", "centos7", "centos6", "ubuntu", "debian", "coreos",
 	"rancheros", "k3os", "kusanagi", "sophos-utm", "freebsd",
 	"netwiser", "opnsense",
 	"windows2016", "windows2016-rds", "windows2016-rds-office",
@@ -94,7 +96,7 @@ func (o ArchiveOSTypes) IsWindows() bool {
 // IsSupportDiskEdit ディスクの修正機能をフルサポートしているか(Windowsは一部サポートのためfalseを返す)
 func (o ArchiveOSTypes) IsSupportDiskEdit() bool {
 	switch o {
-	case CentOS, CentOS6, Ubuntu, Debian, CoreOS, RancherOS, K3OS, Kusanagi, FreeBSD:
+	case CentOS, CentOS7, CentOS6, Ubuntu, Debian, CoreOS, RancherOS, K3OS, Kusanagi, FreeBSD:
 		return true
 	default:
 		return false
@@ -106,6 +108,8 @@ func StrToOSType(osType string) ArchiveOSTypes {
 	switch osType {
 	case "centos":
 		return CentOS
+	case "centos7":
+		return CentOS7
 	case "centos6":
 		return CentOS6
 	case "ubuntu":

--- a/sacloud/ostype/archiveostypes_string.go
+++ b/sacloud/ostype/archiveostypes_string.go
@@ -23,32 +23,33 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[CentOS-0]
-	_ = x[CentOS6-1]
-	_ = x[Ubuntu-2]
-	_ = x[Debian-3]
-	_ = x[CoreOS-4]
-	_ = x[RancherOS-5]
-	_ = x[K3OS-6]
-	_ = x[Kusanagi-7]
-	_ = x[SophosUTM-8]
-	_ = x[FreeBSD-9]
-	_ = x[Netwiser-10]
-	_ = x[OPNsense-11]
-	_ = x[Windows2016-12]
-	_ = x[Windows2016RDS-13]
-	_ = x[Windows2016RDSOffice-14]
-	_ = x[Windows2016SQLServerWeb-15]
-	_ = x[Windows2016SQLServerStandard-16]
-	_ = x[Windows2016SQLServer2017Standard-17]
-	_ = x[Windows2016SQLServerStandardAll-18]
-	_ = x[Windows2016SQLServer2017StandardAll-19]
-	_ = x[Windows2019-20]
-	_ = x[Custom-21]
+	_ = x[CentOS7-1]
+	_ = x[CentOS6-2]
+	_ = x[Ubuntu-3]
+	_ = x[Debian-4]
+	_ = x[CoreOS-5]
+	_ = x[RancherOS-6]
+	_ = x[K3OS-7]
+	_ = x[Kusanagi-8]
+	_ = x[SophosUTM-9]
+	_ = x[FreeBSD-10]
+	_ = x[Netwiser-11]
+	_ = x[OPNsense-12]
+	_ = x[Windows2016-13]
+	_ = x[Windows2016RDS-14]
+	_ = x[Windows2016RDSOffice-15]
+	_ = x[Windows2016SQLServerWeb-16]
+	_ = x[Windows2016SQLServerStandard-17]
+	_ = x[Windows2016SQLServer2017Standard-18]
+	_ = x[Windows2016SQLServerStandardAll-19]
+	_ = x[Windows2016SQLServer2017StandardAll-20]
+	_ = x[Windows2019-21]
+	_ = x[Custom-22]
 }
 
-const _ArchiveOSTypes_name = "CentOSCentOS6UbuntuDebianCoreOSRancherOSK3OSKusanagiSophosUTMFreeBSDNetwiserOPNsenseWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllWindows2019Custom"
+const _ArchiveOSTypes_name = "CentOSCentOS7CentOS6UbuntuDebianCoreOSRancherOSK3OSKusanagiSophosUTMFreeBSDNetwiserOPNsenseWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllWindows2019Custom"
 
-var _ArchiveOSTypes_index = [...]uint16{0, 6, 13, 19, 25, 31, 40, 44, 52, 61, 68, 76, 84, 95, 109, 129, 152, 180, 212, 243, 278, 289, 295}
+var _ArchiveOSTypes_index = [...]uint16{0, 6, 13, 20, 26, 32, 38, 47, 51, 59, 68, 75, 83, 91, 102, 116, 136, 159, 187, 219, 250, 285, 296, 302}
 
 func (i ArchiveOSTypes) String() string {
 	if i < 0 || i >= ArchiveOSTypes(len(_ArchiveOSTypes_index)-1) {


### PR DESCRIPTION
related: #380 

v1に対し`ostype.CentOS7`を追加する。

Note: CentOS6/7はタグ`distro-ver-x.x`で検索しており、マイナーバージョンが上がった場合に対応できない。名称で検索するとCentOS 7.6などもヒットしてしまうため現状この方法がベターと思われる。
マイナーバージョンアップの際はソースの修正を行うようにする。