### PR TITLE
Add OSTypes - distro-ver-latest

### DIFF
--- a/api/archive.go
+++ b/api/archive.go
@@ -31,10 +31,15 @@ type ArchiveAPI struct {
 
 var (
 	archiveLatestStableCentOSTags                          = []string{"current-stable", "distro-centos"}
-	archiveLatestStableCentOS7Tags                         = []string{"distro-centos", "distro-ver-7.7"}
-	archiveLatestStableCentOS6Tags                         = []string{"distro-centos", "distro-ver-6.10"}
+	archiveLatestStableCentOS8Tags                         = []string{"centos-8-latest"}
+	archiveLatestStableCentOS7Tags                         = []string{"centos-7-latest"}
+	archiveLatestStableCentOS6Tags                         = []string{"centos-6-latest"}
 	archiveLatestStableUbuntuTags                          = []string{"current-stable", "distro-ubuntu"}
+	archiveLatestStableUbuntu1804Tags                      = []string{"ubuntu-18.04-latest"}
+	archiveLatestStableUbuntu1604Tags                      = []string{"ubuntu-16.04-latest"}
 	archiveLatestStableDebianTags                          = []string{"current-stable", "distro-debian"}
+	archiveLatestStableDebian10Tags                        = []string{"debian-10-latest"}
+	archiveLatestStableDebian9Tags                         = []string{"debian-9-latest"}
 	archiveLatestStableCoreOSTags                          = []string{"current-stable", "distro-coreos"}
 	archiveLatestStableRancherOSTags                       = []string{"current-stable", "distro-rancheros"}
 	archiveLatestStableK3OSTags                            = []string{"current-stable", "distro-k3os"}
@@ -67,10 +72,15 @@ func NewArchiveAPI(client *Client) *ArchiveAPI {
 
 	api.findFuncMapPerOSType = map[ostype.ArchiveOSTypes]func() (*sacloud.Archive, error){
 		ostype.CentOS:                              api.FindLatestStableCentOS,
+		ostype.CentOS8:                             api.FindLatestStableCentOS8,
 		ostype.CentOS7:                             api.FindLatestStableCentOS7,
 		ostype.CentOS6:                             api.FindLatestStableCentOS6,
 		ostype.Ubuntu:                              api.FindLatestStableUbuntu,
+		ostype.Ubuntu1804:                          api.FindLatestStableUbuntu1804,
+		ostype.Ubuntu1604:                          api.FindLatestStableUbuntu1604,
 		ostype.Debian:                              api.FindLatestStableDebian,
+		ostype.Debian10:                            api.FindLatestStableDebian10,
+		ostype.Debian9:                             api.FindLatestStableDebian9,
 		ostype.CoreOS:                              api.FindLatestStableCoreOS,
 		ostype.RancherOS:                           api.FindLatestStableRancherOS,
 		ostype.K3OS:                                api.FindLatestStableK3OS,
@@ -240,6 +250,11 @@ func (api *ArchiveAPI) FindLatestStableCentOS() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableCentOSTags)
 }
 
+// FindLatestStableCentOS8 安定版最新のCentOS8パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableCentOS8() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableCentOS8Tags)
+}
+
 // FindLatestStableCentOS7 安定版最新のCentOS7パブリックアーカイブを取得
 func (api *ArchiveAPI) FindLatestStableCentOS7() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableCentOS7Tags)
@@ -255,9 +270,29 @@ func (api *ArchiveAPI) FindLatestStableDebian() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableDebianTags)
 }
 
+// FindLatestStableDebian10 安定版最新のDebian10パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableDebian10() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableDebian10Tags)
+}
+
+// FindLatestStableDebian9 安定版最新のDebian9パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableDebian9() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableDebian9Tags)
+}
+
 // FindLatestStableUbuntu 安定版最新のUbuntuパブリックアーカイブを取得
 func (api *ArchiveAPI) FindLatestStableUbuntu() (*sacloud.Archive, error) {
 	return api.findByOSTags(archiveLatestStableUbuntuTags)
+}
+
+// FindLatestStableUbuntu1804 安定版最新のUbuntu1804パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableUbuntu1804() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableUbuntu1804Tags)
+}
+
+// FindLatestStableUbuntu1604 安定版最新のUbuntu1604パブリックアーカイブを取得
+func (api *ArchiveAPI) FindLatestStableUbuntu1604() (*sacloud.Archive, error) {
+	return api.findByOSTags(archiveLatestStableUbuntu1604Tags)
 }
 
 // FindLatestStableCoreOS 安定版最新のCoreOSパブリックアーカイブを取得

--- a/api/archive_test.go
+++ b/api/archive_test.go
@@ -289,10 +289,15 @@ func TestArchiveAPI_FindStableOSs(t *testing.T) {
 
 	targets := []target{
 		{label: "CentOS", f: api.FindLatestStableCentOS},
+		{label: "CentOS8", f: api.FindLatestStableCentOS8},
 		{label: "CentOS7", f: api.FindLatestStableCentOS7},
 		{label: "CentOS6", f: api.FindLatestStableCentOS6},
 		{label: "Debian", f: api.FindLatestStableDebian},
+		{label: "Debian10", f: api.FindLatestStableDebian10},
+		{label: "Debian9", f: api.FindLatestStableDebian9},
 		{label: "Ubuntu", f: api.FindLatestStableUbuntu},
+		{label: "Ubuntu1804", f: api.FindLatestStableUbuntu1804},
+		{label: "Ubuntu1604", f: api.FindLatestStableUbuntu1604},
 		{label: "CoreOS", f: api.FindLatestStableCoreOS},
 		{label: "RancherOS", f: api.FindLatestStableRancherOS},
 		{label: "k3OS", f: api.FindLatestStableK3OS},
@@ -333,10 +338,15 @@ func TestArchiveAPI_CanDiskEdit(t *testing.T) {
 
 	targets := []target{
 		{label: "CentOS", expect: true, f: api.FindLatestStableCentOS},
+		{label: "CentOS8", expect: true, f: api.FindLatestStableCentOS8},
 		{label: "CentOS7", expect: true, f: api.FindLatestStableCentOS7},
 		{label: "CentOS6", expect: true, f: api.FindLatestStableCentOS6},
 		{label: "Debian", expect: true, f: api.FindLatestStableDebian},
+		{label: "Debian10", expect: true, f: api.FindLatestStableDebian10},
+		{label: "Debian9", expect: true, f: api.FindLatestStableDebian9},
 		{label: "Ubuntu", expect: true, f: api.FindLatestStableUbuntu},
+		{label: "Ubuntu1804", expect: true, f: api.FindLatestStableUbuntu1804},
+		{label: "Ubuntu1604", expect: true, f: api.FindLatestStableUbuntu1604},
 		{label: "CoreOS", expect: true, f: api.FindLatestStableCoreOS},
 		{label: "RancherOS", expect: true, f: api.FindLatestStableRancherOS},
 		{label: "k3OS", expect: true, f: api.FindLatestStableK3OS},

--- a/sacloud/ostype/archive_ostype.go
+++ b/sacloud/ostype/archive_ostype.go
@@ -23,14 +23,24 @@ type ArchiveOSTypes int
 const (
 	// CentOS OS種別:CentOS
 	CentOS ArchiveOSTypes = iota
+	// CentOS8 OS種別:CentOS8
+	CentOS8
 	// CentOS7 OS種別:CentOS7
 	CentOS7
 	// CentOS6 OS種別:CentOS6
 	CentOS6
 	// Ubuntu OS種別:Ubuntu
 	Ubuntu
+	// Ubuntu1804 OS種別:Ubuntu(Bionic)
+	Ubuntu1804
+	// Ubuntu1604 OS種別:Ubuntu(Xenial)
+	Ubuntu1604
 	// Debian OS種別:Debian
 	Debian
+	// Debian10 OS種別:Debian10
+	Debian10
+	// Debian9 OS種別:Debian9
+	Debian9
 	// CoreOS OS種別:CoreOS
 	CoreOS
 	// RancherOS OS種別:RancherOS
@@ -71,8 +81,10 @@ const (
 
 // OSTypeShortNames OSTypeとして利用できる文字列のリスト
 var OSTypeShortNames = []string{
-	"centos", "centos7", "centos6", "ubuntu", "debian", "coreos",
-	"rancheros", "k3os", "kusanagi", "sophos-utm", "freebsd",
+	"centos", "centos8", "centos7", "centos6",
+	"ubuntu", "ubuntu1804", "ubuntu1604",
+	"debian", "debian10", "debian9",
+	"coreos", "rancheros", "k3os", "kusanagi", "sophos-utm", "freebsd",
 	"netwiser", "opnsense",
 	"windows2016", "windows2016-rds", "windows2016-rds-office",
 	"windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all",
@@ -96,7 +108,10 @@ func (o ArchiveOSTypes) IsWindows() bool {
 // IsSupportDiskEdit ディスクの修正機能をフルサポートしているか(Windowsは一部サポートのためfalseを返す)
 func (o ArchiveOSTypes) IsSupportDiskEdit() bool {
 	switch o {
-	case CentOS, CentOS7, CentOS6, Ubuntu, Debian, CoreOS, RancherOS, K3OS, Kusanagi, FreeBSD:
+	case CentOS, CentOS8, CentOS7, CentOS6,
+		Ubuntu, Ubuntu1804, Ubuntu1604,
+		Debian, Debian10, Debian9,
+		CoreOS, RancherOS, K3OS, Kusanagi, FreeBSD:
 		return true
 	default:
 		return false
@@ -108,14 +123,24 @@ func StrToOSType(osType string) ArchiveOSTypes {
 	switch osType {
 	case "centos":
 		return CentOS
+	case "centos8":
+		return CentOS8
 	case "centos7":
 		return CentOS7
 	case "centos6":
 		return CentOS6
 	case "ubuntu":
 		return Ubuntu
+	case "ubuntu1804":
+		return Ubuntu1804
+	case "ubuntu1604":
+		return Ubuntu1604
 	case "debian":
 		return Debian
+	case "debian10":
+		return Debian10
+	case "debian9":
+		return Debian9
 	case "coreos":
 		return CoreOS
 	case "rancheros":

--- a/sacloud/ostype/archiveostypes_string.go
+++ b/sacloud/ostype/archiveostypes_string.go
@@ -23,33 +23,38 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[CentOS-0]
-	_ = x[CentOS7-1]
-	_ = x[CentOS6-2]
-	_ = x[Ubuntu-3]
-	_ = x[Debian-4]
-	_ = x[CoreOS-5]
-	_ = x[RancherOS-6]
-	_ = x[K3OS-7]
-	_ = x[Kusanagi-8]
-	_ = x[SophosUTM-9]
-	_ = x[FreeBSD-10]
-	_ = x[Netwiser-11]
-	_ = x[OPNsense-12]
-	_ = x[Windows2016-13]
-	_ = x[Windows2016RDS-14]
-	_ = x[Windows2016RDSOffice-15]
-	_ = x[Windows2016SQLServerWeb-16]
-	_ = x[Windows2016SQLServerStandard-17]
-	_ = x[Windows2016SQLServer2017Standard-18]
-	_ = x[Windows2016SQLServerStandardAll-19]
-	_ = x[Windows2016SQLServer2017StandardAll-20]
-	_ = x[Windows2019-21]
-	_ = x[Custom-22]
+	_ = x[CentOS8-1]
+	_ = x[CentOS7-2]
+	_ = x[CentOS6-3]
+	_ = x[Ubuntu-4]
+	_ = x[Ubuntu1804-5]
+	_ = x[Ubuntu1604-6]
+	_ = x[Debian-7]
+	_ = x[Debian10-8]
+	_ = x[Debian9-9]
+	_ = x[CoreOS-10]
+	_ = x[RancherOS-11]
+	_ = x[K3OS-12]
+	_ = x[Kusanagi-13]
+	_ = x[SophosUTM-14]
+	_ = x[FreeBSD-15]
+	_ = x[Netwiser-16]
+	_ = x[OPNsense-17]
+	_ = x[Windows2016-18]
+	_ = x[Windows2016RDS-19]
+	_ = x[Windows2016RDSOffice-20]
+	_ = x[Windows2016SQLServerWeb-21]
+	_ = x[Windows2016SQLServerStandard-22]
+	_ = x[Windows2016SQLServer2017Standard-23]
+	_ = x[Windows2016SQLServerStandardAll-24]
+	_ = x[Windows2016SQLServer2017StandardAll-25]
+	_ = x[Windows2019-26]
+	_ = x[Custom-27]
 }
 
-const _ArchiveOSTypes_name = "CentOSCentOS7CentOS6UbuntuDebianCoreOSRancherOSK3OSKusanagiSophosUTMFreeBSDNetwiserOPNsenseWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllWindows2019Custom"
+const _ArchiveOSTypes_name = "CentOSCentOS8CentOS7CentOS6UbuntuUbuntu1804Ubuntu1604DebianDebian10Debian9CoreOSRancherOSK3OSKusanagiSophosUTMFreeBSDNetwiserOPNsenseWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllWindows2019Custom"
 
-var _ArchiveOSTypes_index = [...]uint16{0, 6, 13, 20, 26, 32, 38, 47, 51, 59, 68, 75, 83, 91, 102, 116, 136, 159, 187, 219, 250, 285, 296, 302}
+var _ArchiveOSTypes_index = [...]uint16{0, 6, 13, 20, 27, 33, 43, 53, 59, 67, 74, 80, 89, 93, 101, 110, 117, 125, 133, 144, 158, 178, 201, 229, 261, 292, 327, 338, 344}
 
 func (i ArchiveOSTypes) String() string {
 	if i < 0 || i >= ArchiveOSTypes(len(_ArchiveOSTypes_index)-1) {


### PR DESCRIPTION
related: #380 

OSTypeに以下を加える。

- `centos8`
- `ubuntu1804`
- `ubuntu1604`
- `debian10`
- `debian9`

## 背景

https://github.com/sacloud/libsacloud/issues/380#issuecomment-554844408

## 実装

パブリックアーカイブに`<dist>-<version>-latest`タグが追加された。
例: `centos-7-latest`

これを利用して以下のように全バージョンを通じた最新版と各メジャーバージョンごとの最新版でOSTypeを使い分ける。

- `centos` : 全メジャーバージョンを通じた最新版
- `centos8`/`centos7`/`centos6`: 各メジャーバージョン内での最新版