### PR TITLE
LoadBalancerSetting: MarshalJSON

### DIFF
--- a/sacloud/naked/load_balancer.go
+++ b/sacloud/naked/load_balancer.go
@@ -64,7 +64,18 @@ type LoadBalancerSetting struct {
 	DelayLoop        types.StringNumber               `json:",omitempty" yaml:"delay_loop,omitempty" structs:",omitempty"`
 	SorryServer      string                           `json:",omitempty" yaml:"sorry_server,omitempty" structs:",omitempty"`
 	Description      string                           `yaml:"description"`
-	Servers          []*LoadBalancerDestinationServer `json:",omitempty" yaml:"servers,omitempty" structs:",omitempty"`
+	Servers          []*LoadBalancerDestinationServer `yaml:"servers"`
+}
+
+// MarshalJSON nullの場合に空配列を出力するための実装
+func (s LoadBalancerSetting) MarshalJSON() ([]byte, error) {
+	if s.Servers == nil {
+		s.Servers = make([]*LoadBalancerDestinationServer, 0)
+	}
+
+	type alias LoadBalancerSetting
+	tmp := alias(s)
+	return json.Marshal(&tmp)
 }
 
 // LoadBalancerDestinationServer ロードバランサ配下の実サーバ

--- a/sacloud/test/load_balancer_op_test.go
+++ b/sacloud/test/load_balancer_op_test.go
@@ -273,16 +273,6 @@ var (
 			{
 				VirtualIPAddress: "192.168.0.111",
 				Port:             80,
-				Servers: []*sacloud.LoadBalancerServer{
-					{
-						IPAddress: "192.168.0.211",
-						Enabled:   types.StringTrue,
-						Port:      80,
-						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
-							Protocol: types.LoadBalancerHealthCheckProtocols.Ping,
-						},
-					},
-				},
 			},
 		},
 	}
@@ -300,16 +290,6 @@ var (
 				VirtualIPAddress: "192.168.0.111",
 				Port:             80,
 				DelayLoop:        10, // default value
-				Servers: []*sacloud.LoadBalancerServer{
-					{
-						IPAddress: "192.168.0.211",
-						Enabled:   types.StringTrue,
-						Port:      80,
-						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
-							Protocol: types.LoadBalancerHealthCheckProtocols.Ping,
-						},
-					},
-				},
 			},
 		},
 	}


### PR DESCRIPTION
fixes #394 

#394対応として`LoadBalancerSetting.Servers`の`omitempty`を除去する。
ただし、`LoadBalancerSetting.Servers`はリクエスト時にnullだとエラーとなる。
このためMarshalJSONを実装し空だった場合には`[]`を出力するようにする。