### PR TITLE
v2: UpdateSettings API

### DIFF
--- a/internal/define/auto_backup.go
+++ b/internal/define/auto_backup.go
@@ -47,13 +47,20 @@ var autoBackupAPI = &dsl.Resource{
 		// patch
 		ops.PatchCommonServiceItem(autoBackupAPIName, autoBackupNakedType, patchModel(autoBackupUpdateParam), autoBackupView),
 
+		// updateSettings
+		ops.UpdateCommonServiceItemSettings(autoBackupAPIName, autoBackupSettingsUpdateNakedType, autoBackupUpdateSettingsParam, autoBackupView),
+
+		// patchSettings
+		ops.PatchCommonServiceItemSettings(autoBackupAPIName, autoBackupSettingsUpdateNakedType, patchModel(autoBackupUpdateSettingsParam), autoBackupView),
+
 		// delete
 		ops.Delete(autoBackupAPIName),
 	},
 }
 
 var (
-	autoBackupNakedType = meta.Static(naked.AutoBackup{})
+	autoBackupNakedType               = meta.Static(naked.AutoBackup{})
+	autoBackupSettingsUpdateNakedType = meta.Static(naked.AutoBackupSettingsUpdate{})
 
 	autoBackupView = &dsl.Model{
 		Name:      autoBackupAPIName,
@@ -139,6 +146,28 @@ var (
 			fields.Tags(),
 			fields.IconID(),
 
+			// backup setting
+			fields.AutoBackupBackupSpanWeekDays(),
+			fields.AutoBackupMaximumNumberOfArchives(),
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+
+	autoBackupUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(autoBackupAPIName),
+		NakedType: autoBackupNakedType,
+		ConstFields: []*dsl.ConstFieldDesc{
+			{
+				Name: "BackupSpanType",
+				Type: meta.TypeBackupSpanType,
+				Tags: &dsl.FieldTags{
+					MapConv: "Settings.Autobackup.BackupSpanType",
+				},
+				Value: `types.BackupSpanTypes.Weekdays`,
+			},
+		},
+		Fields: []*dsl.FieldDesc{
 			// backup setting
 			fields.AutoBackupBackupSpanWeekDays(),
 			fields.AutoBackupMaximumNumberOfArchives(),

--- a/internal/define/database.go
+++ b/internal/define/database.go
@@ -46,8 +46,14 @@ var databaseAPI = &dsl.Resource{
 		// update
 		ops.UpdateAppliance(databaseAPIName, databaseNakedType, databaseUpdateParam, databaseView),
 
+		// updateSettings
+		ops.UpdateApplianceSettings(databaseAPIName, databaseUpdateSettingsNakedType, databaseUpdateSettingsParam, databaseView),
+
 		// patch
 		ops.PatchAppliance(databaseAPIName, databaseNakedType, patchModel(databaseUpdateParam), databaseView),
+
+		// patchSettings
+		ops.PatchApplianceSettings(databaseAPIName, databaseUpdateSettingsNakedType, patchModel(databaseUpdateSettingsParam), databaseView),
 
 		// delete
 		ops.Delete(databaseAPIName),
@@ -98,8 +104,9 @@ var databaseAPI = &dsl.Resource{
 }
 
 var (
-	databaseNakedType       = meta.Static(naked.Database{})
-	databaseStatusNakedType = meta.Static(naked.DatabaseStatus{})
+	databaseNakedType               = meta.Static(naked.Database{})
+	databaseUpdateSettingsNakedType = meta.Static(naked.DatabaseSettingsUpdate{})
+	databaseStatusNakedType         = meta.Static(naked.DatabaseStatus{})
 
 	databaseView = &dsl.Model{
 		Name:      databaseAPIName,
@@ -180,6 +187,19 @@ var (
 			fields.Tags(),
 			fields.IconID(),
 
+			// settings
+			fields.DatabaseSettingsCommon(),
+			fields.DatabaseSettingsBackup(),
+			fields.DatabaseSettingsReplication(),
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+
+	databaseUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(databaseAPIName),
+		NakedType: databaseNakedType,
+		Fields: []*dsl.FieldDesc{
 			// settings
 			fields.DatabaseSettingsCommon(),
 			fields.DatabaseSettingsBackup(),

--- a/internal/define/dns.go
+++ b/internal/define/dns.go
@@ -45,8 +45,14 @@ var dnsAPI = &dsl.Resource{
 		// update
 		ops.UpdateCommonServiceItem(dnsAPIName, dnsNakedType, dnsUpdateParam, dnsView),
 
+		// updateSettings
+		ops.UpdateCommonServiceItemSettings(dnsAPIName, dnsUpdateSettingsNakedType, dnsUpdateSettingsParam, dnsView),
+
 		// patch
 		ops.PatchCommonServiceItem(dnsAPIName, dnsNakedType, patchModel(dnsUpdateParam), dnsView),
+
+		// patchSettings
+		ops.PatchCommonServiceItemSettings(dnsAPIName, dnsUpdateSettingsNakedType, patchModel(dnsUpdateSettingsParam), dnsView),
 
 		// delete
 		ops.Delete(dnsAPIName),
@@ -54,7 +60,8 @@ var dnsAPI = &dsl.Resource{
 }
 
 var (
-	dnsNakedType = meta.Static(naked.DNS{})
+	dnsNakedType               = meta.Static(naked.DNS{})
+	dnsUpdateSettingsNakedType = meta.Static(naked.DNSSettingsUpdate{})
 
 	dnsView = &dsl.Model{
 		Name:      dnsAPIName,
@@ -122,6 +129,17 @@ var (
 			fields.Tags(),
 			fields.IconID(),
 
+			// setting
+			fields.DNSRecords(),
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+
+	dnsUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(dnsAPIName),
+		NakedType: dnsNakedType,
+		Fields: []*dsl.FieldDesc{
 			// setting
 			fields.DNSRecords(),
 			// settings hash

--- a/internal/define/gslb.go
+++ b/internal/define/gslb.go
@@ -45,8 +45,14 @@ var gslbAPI = &dsl.Resource{
 		// update
 		ops.UpdateCommonServiceItem(gslbAPIName, gslbNakedType, gslbUpdateParam, gslbView),
 
+		// updateSettings
+		ops.UpdateCommonServiceItemSettings(gslbAPIName, gslbUpdateSettingsNakedType, gslbUpdateSettingsParam, gslbView),
+
 		// patch
 		ops.PatchCommonServiceItem(gslbAPIName, gslbNakedType, patchModel(gslbUpdateParam), gslbView),
+
+		// patchSettings
+		ops.PatchCommonServiceItemSettings(gslbAPIName, gslbUpdateSettingsNakedType, patchModel(gslbUpdateSettingsParam), gslbView),
 
 		// delete
 		ops.Delete(gslbAPIName),
@@ -54,7 +60,8 @@ var gslbAPI = &dsl.Resource{
 }
 
 var (
-	gslbNakedType = meta.Static(naked.GSLB{})
+	gslbNakedType               = meta.Static(naked.GSLB{})
+	gslbUpdateSettingsNakedType = meta.Static(naked.GSLBSettingsUpdate{})
 
 	gslbView = &dsl.Model{
 		Name:      gslbAPIName,
@@ -115,6 +122,21 @@ var (
 			fields.Tags(),
 			fields.IconID(),
 
+			// settings
+			fields.GSLBHealthCheck(),
+			fields.GSLBDelayLoop(),
+			fields.GSLBWeighted(),
+			fields.GSLBSorryServer(),
+			fields.GSLBDestinationServers(),
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+
+	gslbUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(gslbAPIName),
+		NakedType: gslbNakedType,
+		Fields: []*dsl.FieldDesc{
 			// settings
 			fields.GSLBHealthCheck(),
 			fields.GSLBDelayLoop(),

--- a/internal/define/load_balancer.go
+++ b/internal/define/load_balancer.go
@@ -43,9 +43,13 @@ var loadBalancerAPI = &dsl.Resource{
 
 		// update
 		ops.UpdateAppliance(loadBalancerAPIName, loadBalancerNakedType, loadBalancerUpdateParam, loadBalancerView),
+		// updateSettings
+		ops.UpdateApplianceSettings(loadBalancerAPIName, loadBalancerUpdateSettingsNakedType, loadBalancerUpdateSettingsParam, loadBalancerView),
 
 		// patch
 		ops.PatchAppliance(loadBalancerAPIName, loadBalancerNakedType, patchModel(loadBalancerUpdateParam), loadBalancerView),
+		// patchSettings
+		ops.PatchApplianceSettings(loadBalancerAPIName, loadBalancerUpdateSettingsNakedType, patchModel(loadBalancerUpdateSettingsParam), loadBalancerView),
 
 		// delete
 		ops.Delete(loadBalancerAPIName),
@@ -68,7 +72,8 @@ var loadBalancerAPI = &dsl.Resource{
 }
 
 var (
-	loadBalancerNakedType = meta.Static(naked.LoadBalancer{})
+	loadBalancerNakedType               = meta.Static(naked.LoadBalancer{})
+	loadBalancerUpdateSettingsNakedType = meta.Static(naked.LoadBalancerSettingsUpdate{})
 
 	loadBalancerView = &dsl.Model{
 		Name:      loadBalancerAPIName,
@@ -143,6 +148,17 @@ var (
 			fields.Tags(),
 			fields.IconID(),
 
+			// settings
+			fields.LoadBalancerVIP(),
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+
+	loadBalancerUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(loadBalancerAPIName),
+		NakedType: loadBalancerNakedType,
+		Fields: []*dsl.FieldDesc{
 			// settings
 			fields.LoadBalancerVIP(),
 			// settings hash

--- a/internal/define/mobile_gateway.go
+++ b/internal/define/mobile_gateway.go
@@ -45,9 +45,13 @@ var mobileGatewayAPI = &dsl.Resource{
 
 		// update
 		ops.UpdateAppliance(mobileGatewayAPIName, mobileGatewayNakedType, mobileGatewayUpdateParam, mobileGatewayView),
+		// updateSettings
+		ops.UpdateApplianceSettings(mobileGatewayAPIName, mobileGatewayUpdateSettingsNakedType, mobileGatewayUpdateSettingsParam, mobileGatewayView),
 
 		// patch
 		ops.PatchAppliance(mobileGatewayAPIName, mobileGatewayNakedType, patchModel(mobileGatewayUpdateParam), mobileGatewayView),
+		// patchSettings
+		ops.PatchApplianceSettings(mobileGatewayAPIName, mobileGatewayUpdateSettingsNakedType, patchModel(mobileGatewayUpdateSettingsParam), mobileGatewayView),
 
 		// delete
 		ops.Delete(mobileGatewayAPIName),
@@ -331,7 +335,8 @@ var mobileGatewayAPI = &dsl.Resource{
 }
 
 var (
-	mobileGatewayNakedType = meta.Static(naked.MobileGateway{})
+	mobileGatewayNakedType               = meta.Static(naked.MobileGateway{})
+	mobileGatewayUpdateSettingsNakedType = meta.Static(naked.MobileGatewaySettingsUpdate{})
 
 	mobileGatewayView = &dsl.Model{
 		Name:      mobileGatewayAPIName,
@@ -410,6 +415,22 @@ var (
 			fields.Description(),
 			fields.Tags(),
 			fields.IconID(),
+			{
+				Name: "Settings",
+				Type: models.mobileGatewaySetting(),
+				Tags: &dsl.FieldTags{
+					JSON:    ",omitempty",
+					MapConv: ",omitempty,recursive",
+				},
+			},
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+	mobileGatewayUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(mobileGatewayAPIName),
+		NakedType: mobileGatewayNakedType,
+		Fields: []*dsl.FieldDesc{
 			{
 				Name: "Settings",
 				Type: models.mobileGatewaySetting(),

--- a/internal/define/names/resource_name.go
+++ b/internal/define/names/resource_name.go
@@ -57,6 +57,11 @@ func UpdateParameterName(resourceName string) string {
 	return RequestParameterName(resourceName, "Update")
 }
 
+// UpdateSettingsParameterName UpdateSettings操作に渡すパラメータの名称
+func UpdateSettingsParameterName(resourceName string) string {
+	return RequestParameterName(resourceName, "UpdateSettings")
+}
+
 // RequestParameterName 任意の操作に渡すパラメータの名称
 func RequestParameterName(resourceName, funcName string) string {
 	return fmt.Sprintf("%s%sRequest", resourceName, funcName)

--- a/internal/define/ops/operations.go
+++ b/internal/define/ops/operations.go
@@ -182,13 +182,21 @@ func ReadCommonServiceItem(resourceName string, nakedType meta.Type, result *dsl
 }
 
 func update(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model, payloadName string) *dsl.Operation {
+	return updateInternal(resourceName, nakedType, updateParam, result, payloadName, "Update")
+}
+
+func updateSettings(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model, payloadName string) *dsl.Operation {
+	return updateInternal(resourceName, nakedType, updateParam, result, payloadName, "UpdateSettings")
+}
+
+func updateInternal(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model, payloadName, opName string) *dsl.Operation {
 	if payloadName == "" {
 		payloadName = names.ResourceFieldName(resourceName, dsl.PayloadForms.Singular)
 	}
 
 	return &dsl.Operation{
 		ResourceName: resourceName,
-		Name:         "Update",
+		Name:         opName,
 		PathFormat:   dsl.DefaultPathFormatWithID,
 		Method:       http.MethodPut,
 		RequestEnvelope: dsl.RequestEnvelope(&dsl.EnvelopePayloadDesc{
@@ -229,9 +237,27 @@ func UpdateCommonServiceItem(resourceName string, nakedType meta.Type, updatePar
 	return update(resourceName, nakedType, updateParam, result, "CommonServiceItem")
 }
 
+// UpdateApplianceSettings UpdateSettings操作を定義
+func UpdateApplianceSettings(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model) *dsl.Operation {
+	return updateSettings(resourceName, nakedType, updateParam, result, "Appliance")
+}
+
+// UpdateCommonServiceItemSettings UpdateSettings操作を定義
+func UpdateCommonServiceItemSettings(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model) *dsl.Operation {
+	return updateSettings(resourceName, nakedType, updateParam, result, "CommonServiceItem")
+}
+
 func patch(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model, payloadName string) *dsl.Operation {
+	return patchInternal(resourceName, nakedType, updateParam, result, payloadName, "Patch")
+}
+
+func patchSettings(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model, payloadName string) *dsl.Operation {
+	return patchInternal(resourceName, nakedType, updateParam, result, payloadName, "PatchSettings")
+}
+
+func patchInternal(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model, payloadName, opName string) *dsl.Operation {
 	op := update(resourceName, nakedType, updateParam, result, payloadName)
-	op.Name = "Patch"
+	op.Name = opName
 	op.IsPatch = true
 	return op
 }
@@ -249,6 +275,16 @@ func PatchAppliance(resourceName string, nakedType meta.Type, updateParam, resul
 // PatchCommonServiceItem Patch操作を定義
 func PatchCommonServiceItem(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model) *dsl.Operation {
 	return patch(resourceName, nakedType, updateParam, result, "CommonServiceItem")
+}
+
+// PatchApplianceSettings PatchSettings操作を定義
+func PatchApplianceSettings(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model) *dsl.Operation {
+	return patchSettings(resourceName, nakedType, updateParam, result, "Appliance")
+}
+
+// PatchCommonServiceItemSettings PatchSettings操作を定義
+func PatchCommonServiceItemSettings(resourceName string, nakedType meta.Type, updateParam, result *dsl.Model) *dsl.Operation {
+	return patchSettings(resourceName, nakedType, updateParam, result, "CommonServiceItem")
 }
 
 // Delete Delete操作を定義

--- a/internal/define/ops/operations.go
+++ b/internal/define/ops/operations.go
@@ -109,7 +109,7 @@ func create(resourceName string, nakedType meta.Type, createParam, result *dsl.M
 			dsl.MappableArgument("param", createParam, payloadName),
 		},
 		ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
-			Type: nakedType,
+			Type: result.NakedType,
 			Name: payloadName,
 		}),
 		Results: dsl.Results{
@@ -208,7 +208,7 @@ func updateInternal(resourceName string, nakedType meta.Type, updateParam, resul
 			dsl.MappableArgument("param", updateParam, payloadName),
 		},
 		ResponseEnvelope: dsl.ResponseEnvelope(&dsl.EnvelopePayloadDesc{
-			Type: nakedType,
+			Type: result.NakedType,
 			Name: payloadName,
 		}),
 		Results: dsl.Results{

--- a/internal/define/proxylb.go
+++ b/internal/define/proxylb.go
@@ -46,9 +46,13 @@ var proxyLBAPI = &dsl.Resource{
 
 		// update
 		ops.UpdateCommonServiceItem(proxyLBAPIName, proxyLBNakedType, proxyLBUpdateParam, proxyLBView),
+		// updateSettings
+		ops.UpdateCommonServiceItemSettings(proxyLBAPIName, proxyLBUpdateSettingsNakedType, proxyLBUpdateSettingsParam, proxyLBView),
 
 		// patch
 		ops.PatchCommonServiceItem(proxyLBAPIName, proxyLBNakedType, patchModel(proxyLBUpdateParam), proxyLBView),
+		// updateSettings
+		ops.PatchCommonServiceItemSettings(proxyLBAPIName, proxyLBUpdateSettingsNakedType, patchModel(proxyLBUpdateSettingsParam), proxyLBView),
 
 		// delete
 		ops.Delete(proxyLBAPIName),
@@ -156,8 +160,9 @@ var proxyLBAPI = &dsl.Resource{
 }
 
 var (
-	proxyLBNakedType             = meta.Static(naked.ProxyLB{})
-	proxyLBCertificatesNakedType = meta.Static(naked.ProxyLBCertificates{})
+	proxyLBNakedType               = meta.Static(naked.ProxyLB{})
+	proxyLBUpdateSettingsNakedType = meta.Static(naked.ProxyLBSettingsUpdate{})
+	proxyLBCertificatesNakedType   = meta.Static(naked.ProxyLBCertificates{})
 
 	proxyLBView = &dsl.Model{
 		Name:      proxyLBAPIName,
@@ -252,6 +257,23 @@ var (
 			fields.Description(),
 			fields.Tags(),
 			fields.IconID(),
+		},
+	}
+
+	proxyLBUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(proxyLBAPIName),
+		NakedType: proxyLBNakedType,
+		Fields: []*dsl.FieldDesc{
+			// settings
+			fields.ProxyLBHealthCheck(),
+			fields.ProxyLBSorryServer(),
+			fields.ProxyLBBindPorts(),
+			fields.ProxyLBServers(),
+			fields.ProxyLBLetsEncrypt(),
+			fields.ProxyLBStickySession(),
+			fields.ProxyLBTimeout(),
+			// settings hash
+			fields.SettingsHash(),
 		},
 	}
 

--- a/internal/define/simple_monitor.go
+++ b/internal/define/simple_monitor.go
@@ -45,9 +45,13 @@ var simpleMonitorAPI = &dsl.Resource{
 
 		// update
 		ops.UpdateCommonServiceItem(simpleMonitorAPIName, simpleMonitorNakedType, simpleMonitorUpdateParam, simpleMonitorView),
+		// updateSettings
+		ops.UpdateCommonServiceItemSettings(simpleMonitorAPIName, simpleMonitorUpdateSettingsNakedType, simpleMonitorUpdateSettingsParam, simpleMonitorView),
 
 		// patch
 		ops.PatchCommonServiceItem(simpleMonitorAPIName, simpleMonitorNakedType, patchModel(simpleMonitorUpdateParam), simpleMonitorView),
+		// patchSettings
+		ops.PatchCommonServiceItemSettings(simpleMonitorAPIName, simpleMonitorUpdateSettingsNakedType, patchModel(simpleMonitorUpdateSettingsParam), simpleMonitorView),
 
 		// delete
 		ops.Delete(simpleMonitorAPIName),
@@ -62,8 +66,9 @@ var simpleMonitorAPI = &dsl.Resource{
 }
 
 var (
-	simpleMonitorNakedType             = meta.Static(naked.SimpleMonitor{})
-	simpleMonitorHealthStatusNakedType = meta.Static(naked.SimpleMonitorHealthCheckStatus{})
+	simpleMonitorNakedType               = meta.Static(naked.SimpleMonitor{})
+	simpleMonitorUpdateSettingsNakedType = meta.Static(naked.SimpleMonitorSettingsUpdate{})
+	simpleMonitorHealthStatusNakedType   = meta.Static(naked.SimpleMonitorHealthCheckStatus{})
 
 	simpleMonitorView = &dsl.Model{
 		Name:      simpleMonitorAPIName,
@@ -142,6 +147,28 @@ var (
 			fields.Description(),
 			fields.Tags(),
 			fields.IconID(),
+		},
+	}
+
+	simpleMonitorUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(simpleMonitorAPIName),
+		NakedType: simpleMonitorNakedType,
+		Fields: []*dsl.FieldDesc{
+			// settings
+			fields.SimpleMonitorDelayLoop(),
+			fields.SimpleMonitorEnabled(),
+			// settings - health check
+			fields.SimpleMonitorHealthCheck(),
+			// settings - email
+			fields.SimpleMonitorNotifyEmailEnabled(),
+			fields.SimpleMonitorNotifyEmailHTML(),
+			// settings - slack
+			fields.SimpleMonitorNotifySlackEnabled(),
+			fields.SimpleMonitorSlackWebhooksURL(),
+
+			fields.SimpleMonitorNotifyInterval(),
+			// settings hash
+			fields.SettingsHash(),
 		},
 	}
 

--- a/internal/define/vpc_router.go
+++ b/internal/define/vpc_router.go
@@ -45,9 +45,13 @@ var vpcRouterAPI = &dsl.Resource{
 
 		// update
 		ops.UpdateAppliance(vpcRouterAPIName, vpcRouterNakedType, vpcRouterUpdateParam, vpcRouterView),
+		// updateSettings
+		ops.UpdateApplianceSettings(vpcRouterAPIName, vpcRouterUpdateSettingsNakedType, vpcRouterUpdateSettingsParam, vpcRouterView),
 
 		// patch
 		ops.PatchAppliance(vpcRouterAPIName, vpcRouterNakedType, patchModel(vpcRouterUpdateParam), vpcRouterView),
+		// patchSettings
+		ops.PatchApplianceSettings(vpcRouterAPIName, vpcRouterUpdateSettingsNakedType, patchModel(vpcRouterUpdateSettingsParam), vpcRouterView),
 
 		// delete
 		ops.Delete(vpcRouterAPIName),
@@ -111,7 +115,8 @@ var vpcRouterAPI = &dsl.Resource{
 }
 
 var (
-	vpcRouterNakedType = meta.Static(naked.VPCRouter{})
+	vpcRouterNakedType               = meta.Static(naked.VPCRouter{})
+	vpcRouterUpdateSettingsNakedType = meta.Static(naked.VPCRouterSettingsUpdate{})
 
 	vpcRouterView = &dsl.Model{
 		Name:      vpcRouterAPIName,
@@ -203,6 +208,22 @@ var (
 			fields.Description(),
 			fields.Tags(),
 			fields.IconID(),
+			{
+				Name: "Settings",
+				Type: models.vpcRouterSetting(),
+				Tags: &dsl.FieldTags{
+					MapConv: ",omitempty,recursive",
+				},
+			},
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+
+	vpcRouterUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(vpcRouterAPIName),
+		NakedType: vpcRouterNakedType,
+		Fields: []*dsl.FieldDesc{
 			{
 				Name: "Settings",
 				Type: models.vpcRouterSetting(),

--- a/sacloud/fake/ops_auto_backup.go
+++ b/sacloud/fake/ops_auto_backup.go
@@ -119,6 +119,26 @@ func (o *AutoBackupOp) Patch(ctx context.Context, zone string, id types.ID, para
 	return value, nil
 }
 
+// UpdateSettings is fake implementation
+func (o *AutoBackupOp) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.AutoBackupUpdateSettingsRequest) (*sacloud.AutoBackup, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	putAutoBackup(zone, value)
+	return value, nil
+}
+
+// PatchSettings is fake implementation
+func (o *AutoBackupOp) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.AutoBackupPatchSettingsRequest) (*sacloud.AutoBackup, error) {
+	patchParam := &sacloud.AutoBackupPatchRequest{}
+	copySameNameField(param, patchParam)
+	return o.Patch(ctx, zone, id, patchParam)
+}
+
 // Delete is fake implementation
 func (o *AutoBackupOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	_, err := o.Read(ctx, zone, id)

--- a/sacloud/fake/ops_database.go
+++ b/sacloud/fake/ops_database.go
@@ -125,6 +125,26 @@ func (o *DatabaseOp) Patch(ctx context.Context, zone string, id types.ID, param 
 	return value, nil
 }
 
+// UpdateSettings is fake implementation
+func (o *DatabaseOp) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.DatabaseUpdateSettingsRequest) (*sacloud.Database, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	putDatabase(zone, value)
+	return value, nil
+}
+
+// PatchSettings is fake implementation
+func (o *DatabaseOp) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.DatabasePatchSettingsRequest) (*sacloud.Database, error) {
+	patchParam := &sacloud.DatabasePatchRequest{}
+	copySameNameField(param, patchParam)
+	return o.Patch(ctx, zone, id, patchParam)
+}
+
 // Delete is fake implementation
 func (o *DatabaseOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	_, err := o.Read(ctx, zone, id)

--- a/sacloud/fake/ops_dns.go
+++ b/sacloud/fake/ops_dns.go
@@ -114,6 +114,26 @@ func (o *DNSOp) Patch(ctx context.Context, id types.ID, param *sacloud.DNSPatchR
 	return value, nil
 }
 
+// UpdateSettings is fake implementation
+func (o *DNSOp) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.DNSUpdateSettingsRequest) (*sacloud.DNS, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	putDNS(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// PatchSettings is fake implementation
+func (o *DNSOp) PatchSettings(ctx context.Context, id types.ID, param *sacloud.DNSPatchSettingsRequest) (*sacloud.DNS, error) {
+	patchParam := &sacloud.DNSPatchRequest{}
+	copySameNameField(param, patchParam)
+	return o.Patch(ctx, id, patchParam)
+}
+
 // Delete is fake implementation
 func (o *DNSOp) Delete(ctx context.Context, id types.ID) error {
 	_, err := o.Read(ctx, id)

--- a/sacloud/fake/ops_gslb.go
+++ b/sacloud/fake/ops_gslb.go
@@ -129,6 +129,26 @@ func (o *GSLBOp) Patch(ctx context.Context, id types.ID, param *sacloud.GSLBPatc
 	return value, nil
 }
 
+// UpdateSettings is fake implementation
+func (o *GSLBOp) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.GSLBUpdateSettingsRequest) (*sacloud.GSLB, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	putGSLB(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// PatchSettings is fake implementation
+func (o *GSLBOp) PatchSettings(ctx context.Context, id types.ID, param *sacloud.GSLBPatchSettingsRequest) (*sacloud.GSLB, error) {
+	patchParam := &sacloud.GSLBPatchRequest{}
+	copySameNameField(param, patchParam)
+	return o.Patch(ctx, id, patchParam)
+}
+
 // Delete is fake implementation
 func (o *GSLBOp) Delete(ctx context.Context, id types.ID) error {
 	_, err := o.Read(ctx, id)

--- a/sacloud/fake/ops_load_balancer.go
+++ b/sacloud/fake/ops_load_balancer.go
@@ -132,6 +132,31 @@ func (o *LoadBalancerOp) Patch(ctx context.Context, zone string, id types.ID, pa
 	return value, nil
 }
 
+// UpdateSettings is fake implementation
+func (o *LoadBalancerOp) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerUpdateSettingsRequest) (*sacloud.LoadBalancer, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+	for _, vip := range value.VirtualIPAddresses {
+		if vip.DelayLoop == 0 {
+			vip.DelayLoop = 10 // default value
+		}
+	}
+	putLoadBalancer(zone, value)
+	return value, nil
+}
+
+// PatchSettings is fake implementation
+func (o *LoadBalancerOp) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerPatchSettingsRequest) (*sacloud.LoadBalancer, error) {
+	patchParam := &sacloud.LoadBalancerPatchRequest{}
+	copySameNameField(param, patchParam)
+	return o.Patch(ctx, zone, id, patchParam)
+}
+
 // Delete is fake implementation
 func (o *LoadBalancerOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	_, err := o.Read(ctx, zone, id)

--- a/sacloud/fake/ops_mobile_gateway.go
+++ b/sacloud/fake/ops_mobile_gateway.go
@@ -133,6 +133,26 @@ func (o *MobileGatewayOp) Patch(ctx context.Context, zone string, id types.ID, p
 	return value, nil
 }
 
+// UpdateSettings is fake implementation
+func (o *MobileGatewayOp) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayUpdateSettingsRequest) (*sacloud.MobileGateway, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	putMobileGateway(zone, value)
+	return value, nil
+}
+
+// PatchSettings is fake implementation
+func (o *MobileGatewayOp) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayPatchSettingsRequest) (*sacloud.MobileGateway, error) {
+	patchParam := &sacloud.MobileGatewayPatchRequest{}
+	copySameNameField(param, patchParam)
+	return o.Patch(ctx, zone, id, patchParam)
+}
+
 // Delete is fake implementation
 func (o *MobileGatewayOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	_, err := o.Read(ctx, zone, id)

--- a/sacloud/fake/ops_simple_monitor.go
+++ b/sacloud/fake/ops_simple_monitor.go
@@ -148,6 +148,31 @@ func (o *SimpleMonitorOp) Patch(ctx context.Context, id types.ID, param *sacloud
 	return value, nil
 }
 
+// UpdateSettings is fake implementation
+func (o *SimpleMonitorOp) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorUpdateSettingsRequest) (*sacloud.SimpleMonitor, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+	if value.DelayLoop == 0 {
+		value.DelayLoop = 60
+	}
+	if value.NotifyInterval == 0 {
+		value.NotifyInterval = 7200
+	}
+	putSimpleMonitor(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// PatchSettings is fake implementation
+func (o *SimpleMonitorOp) PatchSettings(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorPatchSettingsRequest) (*sacloud.SimpleMonitor, error) {
+	patchParam := &sacloud.SimpleMonitorPatchRequest{}
+	copySameNameField(param, patchParam)
+	return o.Patch(ctx, id, patchParam)
+}
+
 // Delete is fake implementation
 func (o *SimpleMonitorOp) Delete(ctx context.Context, id types.ID) error {
 	_, err := o.Read(ctx, id)

--- a/sacloud/fake/ops_vpc_router.go
+++ b/sacloud/fake/ops_vpc_router.go
@@ -158,6 +158,26 @@ func (o *VPCRouterOp) Patch(ctx context.Context, zone string, id types.ID, param
 	return value, nil
 }
 
+// UpdateSettings is fake implementation
+func (o *VPCRouterOp) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterUpdateSettingsRequest) (*sacloud.VPCRouter, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	putVPCRouter(zone, value)
+	return value, nil
+}
+
+// PatchSettings is fake implementation
+func (o *VPCRouterOp) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterPatchSettingsRequest) (*sacloud.VPCRouter, error) {
+	patchParam := &sacloud.VPCRouterPatchRequest{}
+	copySameNameField(param, patchParam)
+	return o.Patch(ctx, zone, id, patchParam)
+}
+
 // Delete is fake implementation
 func (o *VPCRouterOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	_, err := o.Read(ctx, zone, id)

--- a/sacloud/naked/auto_backup.go
+++ b/sacloud/naked/auto_backup.go
@@ -37,6 +37,12 @@ type AutoBackup struct {
 	Status       *AutoBackupStatus   `json:",omitempty" yaml:"status,omitempty" structs:",omitempty"`
 }
 
+// AutoBackupSettingsUpdate 自動バックアップ
+type AutoBackupSettingsUpdate struct {
+	Settings     *AutoBackupSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string              `json:",omitempty" yaml:"setting_hash,omitempty" structs:",omitempty"`
+}
+
 // AutoBackupSettings 自動バックアップ設定
 type AutoBackupSettings struct {
 	Autobackup *AutoBackupSetting `json:",omitempty" yaml:"autobackup,omitempty" structs:",omitempty"` // HACK: 注: API側がキャメルケースになっていない

--- a/sacloud/naked/database.go
+++ b/sacloud/naked/database.go
@@ -46,6 +46,12 @@ type Database struct {
 	Generation interface{}
 }
 
+// DatabaseSettingsUpdate データベース
+type DatabaseSettingsUpdate struct {
+	Settings     *DatabaseSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string            `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
 // DatabaseSettings データベース設定
 type DatabaseSettings struct {
 	DBConf *DatabaseSetting `json:",omitempty" yaml:"db_conf,omitempty" structs:",omitempty"`

--- a/sacloud/naked/dns.go
+++ b/sacloud/naked/dns.go
@@ -38,6 +38,12 @@ type DNS struct {
 	Status       *DNSStatus          `json:",omitempty" yaml:"status,omitempty" structs:",omitempty"`
 }
 
+// DNSSettingsUpdate DNSゾーン
+type DNSSettingsUpdate struct {
+	Settings     *DNSSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string       `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
 // DNSStatus DNSステータス
 type DNSStatus struct {
 	Zone string   `json:",omitempty" yaml:"zone,omitempty" structs:",omitempty"`

--- a/sacloud/naked/gslb.go
+++ b/sacloud/naked/gslb.go
@@ -37,6 +37,12 @@ type GSLB struct {
 	Status       *GSLBStatus         `json:",omitempty" yaml:"status,omitempty" structs:",omitempty"`
 }
 
+// GSLBSettingsUpdate GSLB
+type GSLBSettingsUpdate struct {
+	Settings     *GSLBSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string        `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
 // GSLBSettings GSLBの設定
 type GSLBSettings struct {
 	GSLB *GSLBSetting `json:",omitempty" yaml:"gslb,omitempty" structs:",omitempty"`

--- a/sacloud/naked/load_balancer.go
+++ b/sacloud/naked/load_balancer.go
@@ -42,6 +42,12 @@ type LoadBalancer struct {
 	Remark       *ApplianceRemark      `json:",omitempty" yaml:"remark,omitempty" structs:",omitempty"`
 }
 
+// LoadBalancerSettingsUpdate ロードバランサ
+type LoadBalancerSettingsUpdate struct {
+	Settings     *LoadBalancerSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string                `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
 // LoadBalancerSettings ロードバランサの設定
 type LoadBalancerSettings struct {
 	LoadBalancer []*LoadBalancerSetting `yaml:"load_balancer"`

--- a/sacloud/naked/mobile_gateway.go
+++ b/sacloud/naked/mobile_gateway.go
@@ -42,6 +42,12 @@ type MobileGateway struct {
 	Interfaces   MobileGatewayInterfaces `json:",omitempty" yaml:"interfaces,omitempty" structs:",omitempty"`
 }
 
+// MobileGatewaySettingsUpdate モバイルゲートウェイ
+type MobileGatewaySettingsUpdate struct {
+	Settings     *MobileGatewaySettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string                 `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
 // MobileGatewayInterfaces 要素がnullにことがある場合に対応するためのtype
 //
 // 例: モバイルゲートウェイ 作成時、eth0/eth1の2要素が返ってくるがeth1の分はnullとなっている。

--- a/sacloud/naked/proxylb.go
+++ b/sacloud/naked/proxylb.go
@@ -41,6 +41,12 @@ type ProxyLB struct {
 	ServiceClass types.EProxyLBPlan `json:",omitempty" yaml:"service_class,omitempty" structs:",omitempty"`
 }
 
+// ProxyLBSettingsUpdate エンハンスドロードバランサ
+type ProxyLBSettingsUpdate struct {
+	Settings     *ProxyLBSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string           `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
 // ProxyLBSettings エンハンスドロードバランサ設定
 type ProxyLBSettings struct {
 	ProxyLB *ProxyLBSetting `json:",omitempty" yaml:"proxy_lb,omitempty" structs:",omitempty"`

--- a/sacloud/naked/simple_monitor.go
+++ b/sacloud/naked/simple_monitor.go
@@ -37,6 +37,12 @@ type SimpleMonitor struct {
 	Status       *SimpleMonitorStatus   `json:",omitempty" yaml:"status,omitempty" structs:",omitempty"`
 }
 
+// SimpleMonitorSettingsUpdate シンプル監視
+type SimpleMonitorSettingsUpdate struct {
+	Settings     *SimpleMonitorSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string                 `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
 // SimpleMonitorSettings シンプル監視セッティング
 type SimpleMonitorSettings struct {
 	SimpleMonitor *SimpleMonitorSetting `json:",omitempty" yaml:"simple_monitor,omitempty" structs:",omitempty"`

--- a/sacloud/naked/vpc_router.go
+++ b/sacloud/naked/vpc_router.go
@@ -41,6 +41,12 @@ type VPCRouter struct {
 	Tags         types.Tags          `yaml:"tags"`
 }
 
+// VPCRouterSettingsUpdate VPCルータ
+type VPCRouterSettingsUpdate struct {
+	Settings     *VPCRouterSettings `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	SettingsHash string             `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+}
+
 // VPCRouterSettings VPCルータ 設定
 type VPCRouterSettings struct {
 	Router *VPCRouterSetting `json:",omitempty" yaml:",omitempty" structs:",omitempty"`

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -3527,8 +3527,20 @@ type ProxyLBUpdateStubResult struct {
 	Err     error
 }
 
+// ProxyLBUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type ProxyLBUpdateSettingsStubResult struct {
+	ProxyLB *sacloud.ProxyLB
+	Err     error
+}
+
 // ProxyLBPatchStubResult is expected values of the Patch operation
 type ProxyLBPatchStubResult struct {
+	ProxyLB *sacloud.ProxyLB
+	Err     error
+}
+
+// ProxyLBPatchSettingsStubResult is expected values of the PatchSettings operation
+type ProxyLBPatchSettingsStubResult struct {
 	ProxyLB *sacloud.ProxyLB
 	Err     error
 }
@@ -3584,7 +3596,9 @@ type ProxyLBStub struct {
 	CreateStubResult               *ProxyLBCreateStubResult
 	ReadStubResult                 *ProxyLBReadStubResult
 	UpdateStubResult               *ProxyLBUpdateStubResult
+	UpdateSettingsStubResult       *ProxyLBUpdateSettingsStubResult
 	PatchStubResult                *ProxyLBPatchStubResult
+	PatchSettingsStubResult        *ProxyLBPatchSettingsStubResult
 	DeleteStubResult               *ProxyLBDeleteStubResult
 	ChangePlanStubResult           *ProxyLBChangePlanStubResult
 	GetCertificatesStubResult      *ProxyLBGetCertificatesStubResult
@@ -3632,12 +3646,28 @@ func (s *ProxyLBStub) Update(ctx context.Context, id types.ID, param *sacloud.Pr
 	return s.UpdateStubResult.ProxyLB, s.UpdateStubResult.Err
 }
 
+// UpdateSettings is API call with trace log
+func (s *ProxyLBStub) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.ProxyLBUpdateSettingsRequest) (*sacloud.ProxyLB, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("ProxyLBStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.ProxyLB, s.UpdateSettingsStubResult.Err
+}
+
 // Patch is API call with trace log
 func (s *ProxyLBStub) Patch(ctx context.Context, id types.ID, param *sacloud.ProxyLBPatchRequest) (*sacloud.ProxyLB, error) {
 	if s.PatchStubResult == nil {
 		log.Fatal("ProxyLBStub.PatchStubResult is not set")
 	}
 	return s.PatchStubResult.ProxyLB, s.PatchStubResult.Err
+}
+
+// PatchSettings is API call with trace log
+func (s *ProxyLBStub) PatchSettings(ctx context.Context, id types.ID, param *sacloud.ProxyLBPatchSettingsRequest) (*sacloud.ProxyLB, error) {
+	if s.PatchSettingsStubResult == nil {
+		log.Fatal("ProxyLBStub.PatchSettingsStubResult is not set")
+	}
+	return s.PatchSettingsStubResult.ProxyLB, s.PatchSettingsStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -2599,8 +2599,20 @@ type MobileGatewayUpdateStubResult struct {
 	Err           error
 }
 
+// MobileGatewayUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type MobileGatewayUpdateSettingsStubResult struct {
+	MobileGateway *sacloud.MobileGateway
+	Err           error
+}
+
 // MobileGatewayPatchStubResult is expected values of the Patch operation
 type MobileGatewayPatchStubResult struct {
+	MobileGateway *sacloud.MobileGateway
+	Err           error
+}
+
+// MobileGatewayPatchSettingsStubResult is expected values of the PatchSettings operation
+type MobileGatewayPatchSettingsStubResult struct {
 	MobileGateway *sacloud.MobileGateway
 	Err           error
 }
@@ -2718,7 +2730,9 @@ type MobileGatewayStub struct {
 	CreateStubResult               *MobileGatewayCreateStubResult
 	ReadStubResult                 *MobileGatewayReadStubResult
 	UpdateStubResult               *MobileGatewayUpdateStubResult
+	UpdateSettingsStubResult       *MobileGatewayUpdateSettingsStubResult
 	PatchStubResult                *MobileGatewayPatchStubResult
+	PatchSettingsStubResult        *MobileGatewayPatchSettingsStubResult
 	DeleteStubResult               *MobileGatewayDeleteStubResult
 	ConfigStubResult               *MobileGatewayConfigStubResult
 	BootStubResult                 *MobileGatewayBootStubResult
@@ -2778,12 +2792,28 @@ func (s *MobileGatewayStub) Update(ctx context.Context, zone string, id types.ID
 	return s.UpdateStubResult.MobileGateway, s.UpdateStubResult.Err
 }
 
+// UpdateSettings is API call with trace log
+func (s *MobileGatewayStub) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayUpdateSettingsRequest) (*sacloud.MobileGateway, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("MobileGatewayStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.MobileGateway, s.UpdateSettingsStubResult.Err
+}
+
 // Patch is API call with trace log
 func (s *MobileGatewayStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayPatchRequest) (*sacloud.MobileGateway, error) {
 	if s.PatchStubResult == nil {
 		log.Fatal("MobileGatewayStub.PatchStubResult is not set")
 	}
 	return s.PatchStubResult.MobileGateway, s.PatchStubResult.Err
+}
+
+// PatchSettings is API call with trace log
+func (s *MobileGatewayStub) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayPatchSettingsRequest) (*sacloud.MobileGateway, error) {
+	if s.PatchSettingsStubResult == nil {
+		log.Fatal("MobileGatewayStub.PatchSettingsStubResult is not set")
+	}
+	return s.PatchSettingsStubResult.MobileGateway, s.PatchSettingsStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -2381,8 +2381,20 @@ type LoadBalancerUpdateStubResult struct {
 	Err          error
 }
 
+// LoadBalancerUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type LoadBalancerUpdateSettingsStubResult struct {
+	LoadBalancer *sacloud.LoadBalancer
+	Err          error
+}
+
 // LoadBalancerPatchStubResult is expected values of the Patch operation
 type LoadBalancerPatchStubResult struct {
+	LoadBalancer *sacloud.LoadBalancer
+	Err          error
+}
+
+// LoadBalancerPatchSettingsStubResult is expected values of the PatchSettings operation
+type LoadBalancerPatchSettingsStubResult struct {
 	LoadBalancer *sacloud.LoadBalancer
 	Err          error
 }
@@ -2430,7 +2442,9 @@ type LoadBalancerStub struct {
 	CreateStubResult           *LoadBalancerCreateStubResult
 	ReadStubResult             *LoadBalancerReadStubResult
 	UpdateStubResult           *LoadBalancerUpdateStubResult
+	UpdateSettingsStubResult   *LoadBalancerUpdateSettingsStubResult
 	PatchStubResult            *LoadBalancerPatchStubResult
+	PatchSettingsStubResult    *LoadBalancerPatchSettingsStubResult
 	DeleteStubResult           *LoadBalancerDeleteStubResult
 	ConfigStubResult           *LoadBalancerConfigStubResult
 	BootStubResult             *LoadBalancerBootStubResult
@@ -2477,12 +2491,28 @@ func (s *LoadBalancerStub) Update(ctx context.Context, zone string, id types.ID,
 	return s.UpdateStubResult.LoadBalancer, s.UpdateStubResult.Err
 }
 
+// UpdateSettings is API call with trace log
+func (s *LoadBalancerStub) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerUpdateSettingsRequest) (*sacloud.LoadBalancer, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("LoadBalancerStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.LoadBalancer, s.UpdateSettingsStubResult.Err
+}
+
 // Patch is API call with trace log
 func (s *LoadBalancerStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerPatchRequest) (*sacloud.LoadBalancer, error) {
 	if s.PatchStubResult == nil {
 		log.Fatal("LoadBalancerStub.PatchStubResult is not set")
 	}
 	return s.PatchStubResult.LoadBalancer, s.PatchStubResult.Err
+}
+
+// PatchSettings is API call with trace log
+func (s *LoadBalancerStub) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerPatchSettingsRequest) (*sacloud.LoadBalancer, error) {
+	if s.PatchSettingsStubResult == nil {
+		log.Fatal("LoadBalancerStub.PatchSettingsStubResult is not set")
+	}
+	return s.PatchSettingsStubResult.LoadBalancer, s.PatchSettingsStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -1247,8 +1247,20 @@ type DNSUpdateStubResult struct {
 	Err error
 }
 
+// DNSUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type DNSUpdateSettingsStubResult struct {
+	DNS *sacloud.DNS
+	Err error
+}
+
 // DNSPatchStubResult is expected values of the Patch operation
 type DNSPatchStubResult struct {
+	DNS *sacloud.DNS
+	Err error
+}
+
+// DNSPatchSettingsStubResult is expected values of the PatchSettings operation
+type DNSPatchSettingsStubResult struct {
 	DNS *sacloud.DNS
 	Err error
 }
@@ -1260,12 +1272,14 @@ type DNSDeleteStubResult struct {
 
 // DNSStub is for trace DNSOp operations
 type DNSStub struct {
-	FindStubResult   *DNSFindStubResult
-	CreateStubResult *DNSCreateStubResult
-	ReadStubResult   *DNSReadStubResult
-	UpdateStubResult *DNSUpdateStubResult
-	PatchStubResult  *DNSPatchStubResult
-	DeleteStubResult *DNSDeleteStubResult
+	FindStubResult           *DNSFindStubResult
+	CreateStubResult         *DNSCreateStubResult
+	ReadStubResult           *DNSReadStubResult
+	UpdateStubResult         *DNSUpdateStubResult
+	UpdateSettingsStubResult *DNSUpdateSettingsStubResult
+	PatchStubResult          *DNSPatchStubResult
+	PatchSettingsStubResult  *DNSPatchSettingsStubResult
+	DeleteStubResult         *DNSDeleteStubResult
 }
 
 // NewDNSStub creates new DNSStub instance
@@ -1305,12 +1319,28 @@ func (s *DNSStub) Update(ctx context.Context, id types.ID, param *sacloud.DNSUpd
 	return s.UpdateStubResult.DNS, s.UpdateStubResult.Err
 }
 
+// UpdateSettings is API call with trace log
+func (s *DNSStub) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.DNSUpdateSettingsRequest) (*sacloud.DNS, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("DNSStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.DNS, s.UpdateSettingsStubResult.Err
+}
+
 // Patch is API call with trace log
 func (s *DNSStub) Patch(ctx context.Context, id types.ID, param *sacloud.DNSPatchRequest) (*sacloud.DNS, error) {
 	if s.PatchStubResult == nil {
 		log.Fatal("DNSStub.PatchStubResult is not set")
 	}
 	return s.PatchStubResult.DNS, s.PatchStubResult.Err
+}
+
+// PatchSettings is API call with trace log
+func (s *DNSStub) PatchSettings(ctx context.Context, id types.ID, param *sacloud.DNSPatchSettingsRequest) (*sacloud.DNS, error) {
+	if s.PatchSettingsStubResult == nil {
+		log.Fatal("DNSStub.PatchSettingsStubResult is not set")
+	}
+	return s.PatchSettingsStubResult.DNS, s.PatchSettingsStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -233,6 +233,18 @@ type AutoBackupPatchStubResult struct {
 	Err        error
 }
 
+// AutoBackupUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type AutoBackupUpdateSettingsStubResult struct {
+	AutoBackup *sacloud.AutoBackup
+	Err        error
+}
+
+// AutoBackupPatchSettingsStubResult is expected values of the PatchSettings operation
+type AutoBackupPatchSettingsStubResult struct {
+	AutoBackup *sacloud.AutoBackup
+	Err        error
+}
+
 // AutoBackupDeleteStubResult is expected values of the Delete operation
 type AutoBackupDeleteStubResult struct {
 	Err error
@@ -240,12 +252,14 @@ type AutoBackupDeleteStubResult struct {
 
 // AutoBackupStub is for trace AutoBackupOp operations
 type AutoBackupStub struct {
-	FindStubResult   *AutoBackupFindStubResult
-	CreateStubResult *AutoBackupCreateStubResult
-	ReadStubResult   *AutoBackupReadStubResult
-	UpdateStubResult *AutoBackupUpdateStubResult
-	PatchStubResult  *AutoBackupPatchStubResult
-	DeleteStubResult *AutoBackupDeleteStubResult
+	FindStubResult           *AutoBackupFindStubResult
+	CreateStubResult         *AutoBackupCreateStubResult
+	ReadStubResult           *AutoBackupReadStubResult
+	UpdateStubResult         *AutoBackupUpdateStubResult
+	PatchStubResult          *AutoBackupPatchStubResult
+	UpdateSettingsStubResult *AutoBackupUpdateSettingsStubResult
+	PatchSettingsStubResult  *AutoBackupPatchSettingsStubResult
+	DeleteStubResult         *AutoBackupDeleteStubResult
 }
 
 // NewAutoBackupStub creates new AutoBackupStub instance
@@ -291,6 +305,22 @@ func (s *AutoBackupStub) Patch(ctx context.Context, zone string, id types.ID, pa
 		log.Fatal("AutoBackupStub.PatchStubResult is not set")
 	}
 	return s.PatchStubResult.AutoBackup, s.PatchStubResult.Err
+}
+
+// UpdateSettings is API call with trace log
+func (s *AutoBackupStub) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.AutoBackupUpdateSettingsRequest) (*sacloud.AutoBackup, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("AutoBackupStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.AutoBackup, s.UpdateSettingsStubResult.Err
+}
+
+// PatchSettings is API call with trace log
+func (s *AutoBackupStub) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.AutoBackupPatchSettingsRequest) (*sacloud.AutoBackup, error) {
+	if s.PatchSettingsStubResult == nil {
+		log.Fatal("AutoBackupStub.PatchSettingsStubResult is not set")
+	}
+	return s.PatchSettingsStubResult.AutoBackup, s.PatchSettingsStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -724,8 +724,20 @@ type DatabaseUpdateStubResult struct {
 	Err      error
 }
 
+// DatabaseUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type DatabaseUpdateSettingsStubResult struct {
+	Database *sacloud.Database
+	Err      error
+}
+
 // DatabasePatchStubResult is expected values of the Patch operation
 type DatabasePatchStubResult struct {
+	Database *sacloud.Database
+	Err      error
+}
+
+// DatabasePatchSettingsStubResult is expected values of the PatchSettings operation
+type DatabasePatchSettingsStubResult struct {
 	Database *sacloud.Database
 	Err      error
 }
@@ -791,7 +803,9 @@ type DatabaseStub struct {
 	CreateStubResult           *DatabaseCreateStubResult
 	ReadStubResult             *DatabaseReadStubResult
 	UpdateStubResult           *DatabaseUpdateStubResult
+	UpdateSettingsStubResult   *DatabaseUpdateSettingsStubResult
 	PatchStubResult            *DatabasePatchStubResult
+	PatchSettingsStubResult    *DatabasePatchSettingsStubResult
 	DeleteStubResult           *DatabaseDeleteStubResult
 	ConfigStubResult           *DatabaseConfigStubResult
 	BootStubResult             *DatabaseBootStubResult
@@ -841,12 +855,28 @@ func (s *DatabaseStub) Update(ctx context.Context, zone string, id types.ID, par
 	return s.UpdateStubResult.Database, s.UpdateStubResult.Err
 }
 
+// UpdateSettings is API call with trace log
+func (s *DatabaseStub) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.DatabaseUpdateSettingsRequest) (*sacloud.Database, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("DatabaseStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.Database, s.UpdateSettingsStubResult.Err
+}
+
 // Patch is API call with trace log
 func (s *DatabaseStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.DatabasePatchRequest) (*sacloud.Database, error) {
 	if s.PatchStubResult == nil {
 		log.Fatal("DatabaseStub.PatchStubResult is not set")
 	}
 	return s.PatchStubResult.Database, s.PatchStubResult.Err
+}
+
+// PatchSettings is API call with trace log
+func (s *DatabaseStub) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.DatabasePatchSettingsRequest) (*sacloud.Database, error) {
+	if s.PatchSettingsStubResult == nil {
+		log.Fatal("DatabaseStub.PatchSettingsStubResult is not set")
+	}
+	return s.PatchSettingsStubResult.Database, s.PatchSettingsStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -1379,8 +1379,20 @@ type GSLBUpdateStubResult struct {
 	Err  error
 }
 
+// GSLBUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type GSLBUpdateSettingsStubResult struct {
+	GSLB *sacloud.GSLB
+	Err  error
+}
+
 // GSLBPatchStubResult is expected values of the Patch operation
 type GSLBPatchStubResult struct {
+	GSLB *sacloud.GSLB
+	Err  error
+}
+
+// GSLBPatchSettingsStubResult is expected values of the PatchSettings operation
+type GSLBPatchSettingsStubResult struct {
 	GSLB *sacloud.GSLB
 	Err  error
 }
@@ -1392,12 +1404,14 @@ type GSLBDeleteStubResult struct {
 
 // GSLBStub is for trace GSLBOp operations
 type GSLBStub struct {
-	FindStubResult   *GSLBFindStubResult
-	CreateStubResult *GSLBCreateStubResult
-	ReadStubResult   *GSLBReadStubResult
-	UpdateStubResult *GSLBUpdateStubResult
-	PatchStubResult  *GSLBPatchStubResult
-	DeleteStubResult *GSLBDeleteStubResult
+	FindStubResult           *GSLBFindStubResult
+	CreateStubResult         *GSLBCreateStubResult
+	ReadStubResult           *GSLBReadStubResult
+	UpdateStubResult         *GSLBUpdateStubResult
+	UpdateSettingsStubResult *GSLBUpdateSettingsStubResult
+	PatchStubResult          *GSLBPatchStubResult
+	PatchSettingsStubResult  *GSLBPatchSettingsStubResult
+	DeleteStubResult         *GSLBDeleteStubResult
 }
 
 // NewGSLBStub creates new GSLBStub instance
@@ -1437,12 +1451,28 @@ func (s *GSLBStub) Update(ctx context.Context, id types.ID, param *sacloud.GSLBU
 	return s.UpdateStubResult.GSLB, s.UpdateStubResult.Err
 }
 
+// UpdateSettings is API call with trace log
+func (s *GSLBStub) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.GSLBUpdateSettingsRequest) (*sacloud.GSLB, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("GSLBStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.GSLB, s.UpdateSettingsStubResult.Err
+}
+
 // Patch is API call with trace log
 func (s *GSLBStub) Patch(ctx context.Context, id types.ID, param *sacloud.GSLBPatchRequest) (*sacloud.GSLB, error) {
 	if s.PatchStubResult == nil {
 		log.Fatal("GSLBStub.PatchStubResult is not set")
 	}
 	return s.PatchStubResult.GSLB, s.PatchStubResult.Err
+}
+
+// PatchSettings is API call with trace log
+func (s *GSLBStub) PatchSettings(ctx context.Context, id types.ID, param *sacloud.GSLBPatchSettingsRequest) (*sacloud.GSLB, error) {
+	if s.PatchSettingsStubResult == nil {
+		log.Fatal("GSLBStub.PatchSettingsStubResult is not set")
+	}
+	return s.PatchSettingsStubResult.GSLB, s.PatchSettingsStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -4848,8 +4848,20 @@ type VPCRouterUpdateStubResult struct {
 	Err       error
 }
 
+// VPCRouterUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type VPCRouterUpdateSettingsStubResult struct {
+	VPCRouter *sacloud.VPCRouter
+	Err       error
+}
+
 // VPCRouterPatchStubResult is expected values of the Patch operation
 type VPCRouterPatchStubResult struct {
+	VPCRouter *sacloud.VPCRouter
+	Err       error
+}
+
+// VPCRouterPatchSettingsStubResult is expected values of the PatchSettings operation
+type VPCRouterPatchSettingsStubResult struct {
 	VPCRouter *sacloud.VPCRouter
 	Err       error
 }
@@ -4907,7 +4919,9 @@ type VPCRouterStub struct {
 	CreateStubResult               *VPCRouterCreateStubResult
 	ReadStubResult                 *VPCRouterReadStubResult
 	UpdateStubResult               *VPCRouterUpdateStubResult
+	UpdateSettingsStubResult       *VPCRouterUpdateSettingsStubResult
 	PatchStubResult                *VPCRouterPatchStubResult
+	PatchSettingsStubResult        *VPCRouterPatchSettingsStubResult
 	DeleteStubResult               *VPCRouterDeleteStubResult
 	ConfigStubResult               *VPCRouterConfigStubResult
 	BootStubResult                 *VPCRouterBootStubResult
@@ -4956,12 +4970,28 @@ func (s *VPCRouterStub) Update(ctx context.Context, zone string, id types.ID, pa
 	return s.UpdateStubResult.VPCRouter, s.UpdateStubResult.Err
 }
 
+// UpdateSettings is API call with trace log
+func (s *VPCRouterStub) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterUpdateSettingsRequest) (*sacloud.VPCRouter, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("VPCRouterStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.VPCRouter, s.UpdateSettingsStubResult.Err
+}
+
 // Patch is API call with trace log
 func (s *VPCRouterStub) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterPatchRequest) (*sacloud.VPCRouter, error) {
 	if s.PatchStubResult == nil {
 		log.Fatal("VPCRouterStub.PatchStubResult is not set")
 	}
 	return s.PatchStubResult.VPCRouter, s.PatchStubResult.Err
+}
+
+// PatchSettings is API call with trace log
+func (s *VPCRouterStub) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterPatchSettingsRequest) (*sacloud.VPCRouter, error) {
+	if s.PatchSettingsStubResult == nil {
+		log.Fatal("VPCRouterStub.PatchSettingsStubResult is not set")
+	}
+	return s.PatchSettingsStubResult.VPCRouter, s.PatchSettingsStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -4381,8 +4381,20 @@ type SimpleMonitorUpdateStubResult struct {
 	Err           error
 }
 
+// SimpleMonitorUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type SimpleMonitorUpdateSettingsStubResult struct {
+	SimpleMonitor *sacloud.SimpleMonitor
+	Err           error
+}
+
 // SimpleMonitorPatchStubResult is expected values of the Patch operation
 type SimpleMonitorPatchStubResult struct {
+	SimpleMonitor *sacloud.SimpleMonitor
+	Err           error
+}
+
+// SimpleMonitorPatchSettingsStubResult is expected values of the PatchSettings operation
+type SimpleMonitorPatchSettingsStubResult struct {
 	SimpleMonitor *sacloud.SimpleMonitor
 	Err           error
 }
@@ -4410,7 +4422,9 @@ type SimpleMonitorStub struct {
 	CreateStubResult              *SimpleMonitorCreateStubResult
 	ReadStubResult                *SimpleMonitorReadStubResult
 	UpdateStubResult              *SimpleMonitorUpdateStubResult
+	UpdateSettingsStubResult      *SimpleMonitorUpdateSettingsStubResult
 	PatchStubResult               *SimpleMonitorPatchStubResult
+	PatchSettingsStubResult       *SimpleMonitorPatchSettingsStubResult
 	DeleteStubResult              *SimpleMonitorDeleteStubResult
 	MonitorResponseTimeStubResult *SimpleMonitorMonitorResponseTimeStubResult
 	HealthStatusStubResult        *SimpleMonitorHealthStatusStubResult
@@ -4453,12 +4467,28 @@ func (s *SimpleMonitorStub) Update(ctx context.Context, id types.ID, param *sacl
 	return s.UpdateStubResult.SimpleMonitor, s.UpdateStubResult.Err
 }
 
+// UpdateSettings is API call with trace log
+func (s *SimpleMonitorStub) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorUpdateSettingsRequest) (*sacloud.SimpleMonitor, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("SimpleMonitorStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.SimpleMonitor, s.UpdateSettingsStubResult.Err
+}
+
 // Patch is API call with trace log
 func (s *SimpleMonitorStub) Patch(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorPatchRequest) (*sacloud.SimpleMonitor, error) {
 	if s.PatchStubResult == nil {
 		log.Fatal("SimpleMonitorStub.PatchStubResult is not set")
 	}
 	return s.PatchStubResult.SimpleMonitor, s.PatchStubResult.Err
+}
+
+// PatchSettings is API call with trace log
+func (s *SimpleMonitorStub) PatchSettings(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorPatchSettingsRequest) (*sacloud.SimpleMonitor, error) {
+	if s.PatchSettingsStubResult == nil {
+		log.Fatal("SimpleMonitorStub.PatchSettingsStubResult is not set")
+	}
+	return s.PatchSettingsStubResult.SimpleMonitor, s.PatchSettingsStubResult.Err
 }
 
 // Delete is API call with trace log

--- a/sacloud/test/auto_backup_op_test.go
+++ b/sacloud/test/auto_backup_op_test.go
@@ -80,9 +80,23 @@ func TestAutoBackupOpCRUD(t *testing.T) {
 				}),
 			},
 			{
+				Func: testAutoBackupUpdateSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateAutoBackupSettingsExpected,
+					IgnoreFields: ignoreAutoBackupFields,
+				}),
+			},
+			{
 				Func: testAutoBackupPatch,
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
 					ExpectValue:  patchAutoBackupExpected,
+					IgnoreFields: ignoreAutoBackupFields,
+				}),
+			},
+			{
+				Func: testAutoBackupPatchSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchAutoBackupSettingsExpected,
 					IgnoreFields: ignoreAutoBackupFields,
 				}),
 			},
@@ -163,6 +177,25 @@ var (
 		MaximumNumberOfArchives: updateAutoBackupParam.MaximumNumberOfArchives,
 		IconID:                  testIconID,
 	}
+
+	updateAutoBackupSettingsParam = &sacloud.AutoBackupUpdateSettingsRequest{
+		BackupSpanWeekdays: []types.EBackupSpanWeekday{
+			types.BackupSpanWeekdays.Monday,
+			types.BackupSpanWeekdays.Tuesday,
+			types.BackupSpanWeekdays.Wednesday,
+		},
+		MaximumNumberOfArchives: 4,
+	}
+	updateAutoBackupSettingsExpected = &sacloud.AutoBackup{
+		Name:                    updateAutoBackupParam.Name,
+		Description:             updateAutoBackupParam.Description,
+		Tags:                    updateAutoBackupParam.Tags,
+		Availability:            types.Availabilities.Available,
+		BackupSpanWeekdays:      updateAutoBackupSettingsParam.BackupSpanWeekdays,
+		MaximumNumberOfArchives: updateAutoBackupSettingsParam.MaximumNumberOfArchives,
+		IconID:                  testIconID,
+	}
+
 	patchAutoBackupParam = &sacloud.AutoBackupPatchRequest{
 		Description:      "desc-pached",
 		PatchEmptyToTags: true,
@@ -172,8 +205,23 @@ var (
 		Description: patchAutoBackupParam.Description,
 		//Tags:                    updateAutoBackupParam.Tags,
 		Availability:            types.Availabilities.Available,
-		BackupSpanWeekdays:      updateAutoBackupParam.BackupSpanWeekdays,
-		MaximumNumberOfArchives: updateAutoBackupParam.MaximumNumberOfArchives,
+		BackupSpanWeekdays:      updateAutoBackupSettingsParam.BackupSpanWeekdays,
+		MaximumNumberOfArchives: updateAutoBackupSettingsParam.MaximumNumberOfArchives,
+		IconID:                  testIconID,
+	}
+	patchAutoBackupSettingsParam = &sacloud.AutoBackupPatchSettingsRequest{
+		BackupSpanWeekdays: []types.EBackupSpanWeekday{
+			types.BackupSpanWeekdays.Monday,
+			types.BackupSpanWeekdays.Tuesday,
+		},
+	}
+	patchAutoBackupSettingsExpected = &sacloud.AutoBackup{
+		Name:        updateAutoBackupParam.Name,
+		Description: patchAutoBackupParam.Description,
+		//Tags:                    updateAutoBackupParam.Tags,
+		Availability:            types.Availabilities.Available,
+		BackupSpanWeekdays:      patchAutoBackupSettingsParam.BackupSpanWeekdays,
+		MaximumNumberOfArchives: updateAutoBackupSettingsParam.MaximumNumberOfArchives,
 		IconID:                  testIconID,
 	}
 	updateAutoBackupToMinParam = &sacloud.AutoBackupUpdateRequest{
@@ -206,9 +254,19 @@ func testAutoBackupUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICalle
 	return client.Update(ctx, testZone, ctx.ID, updateAutoBackupParam)
 }
 
+func testAutoBackupUpdateSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewAutoBackupOp(caller)
+	return client.UpdateSettings(ctx, testZone, ctx.ID, updateAutoBackupSettingsParam)
+}
+
 func testAutoBackupPatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewAutoBackupOp(caller)
 	return client.Patch(ctx, testZone, ctx.ID, patchAutoBackupParam)
+}
+
+func testAutoBackupPatchSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewAutoBackupOp(caller)
+	return client.PatchSettings(ctx, testZone, ctx.ID, patchAutoBackupSettingsParam)
 }
 
 func testAutoBackupUpdateToMin(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/sacloud/test/database_op_test.go
+++ b/sacloud/test/database_op_test.go
@@ -31,6 +31,8 @@ func TestDatabaseOpCRUD(t *testing.T) {
 			createDatabaseParam,
 			createDatabaseExpected,
 			patchDatabaseExpected,
+			patchDatabaseSettingsExpected,
+			updateDatabaseSettingsExpected,
 			updateDatabaseExpected,
 			updateDatabaseToFullExpected,
 			updateDatabaseToMinExpected,
@@ -54,6 +56,27 @@ func TestDatabaseOpCRUD(t *testing.T) {
 				Func: testDatabasePatch,
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
 					ExpectValue:  patchDatabaseExpected,
+					IgnoreFields: ignoreDatabaseFields,
+				}),
+			},
+			{
+				Func: testDatabaseUpdateSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateDatabaseSettingsExpected,
+					IgnoreFields: ignoreDatabaseFields,
+				}),
+			},
+			{
+				Func: testDatabasePatchSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchDatabaseSettingsExpected,
+					IgnoreFields: ignoreDatabaseFields,
+				}),
+			},
+			{
+				Func: testDatabaseUpdate,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateDatabaseExpected,
 					IgnoreFields: ignoreDatabaseFields,
 				}),
 			},
@@ -170,6 +193,64 @@ var (
 			UserPassword:    "LibsacloudExamplePassword01",
 			ReplicaUser:     "replica",
 			ReplicaPassword: "replica-user-password",
+		},
+		ReplicationSetting: createDatabaseParam.ReplicationSetting,
+	}
+	updateDatabaseSettingsParam = &sacloud.DatabaseUpdateSettingsRequest{
+		CommonSetting: &sacloud.DatabaseSettingCommon{
+			ServicePort:     54322,
+			DefaultUser:     "exa.mple.upd",
+			UserPassword:    "LibsacloudExamplePassword01up1",
+			ReplicaUser:     "replica-upd",
+			ReplicaPassword: "replica-user-password-upd",
+		},
+		ReplicationSetting: createDatabaseParam.ReplicationSetting,
+	}
+	updateDatabaseSettingsExpected = &sacloud.Database{
+		Name:           createDatabaseParam.Name,
+		Description:    "",
+		Availability:   types.Availabilities.Available,
+		PlanID:         createDatabaseParam.PlanID,
+		InstanceStatus: types.ServerInstanceStatuses.Up,
+		DefaultRoute:   createDatabaseParam.DefaultRoute,
+		NetworkMaskLen: createDatabaseParam.NetworkMaskLen,
+		IPAddresses:    createDatabaseParam.IPAddresses,
+		Conf:           createDatabaseParam.Conf,
+		CommonSetting: &sacloud.DatabaseSettingCommon{
+			ServicePort:     54322,
+			DefaultUser:     "exa.mple.upd",
+			UserPassword:    "LibsacloudExamplePassword01up1",
+			ReplicaUser:     "replica-upd",
+			ReplicaPassword: "replica-user-password-upd",
+		},
+		ReplicationSetting: createDatabaseParam.ReplicationSetting,
+	}
+	patchDatabaseSettingsParam = &sacloud.DatabasePatchSettingsRequest{
+		CommonSetting: &sacloud.DatabaseSettingCommon{
+			ServicePort:     54323,
+			DefaultUser:     "exa.mple.upd2",
+			UserPassword:    "LibsacloudExamplePassword01up2",
+			ReplicaUser:     "replica-upd2",
+			ReplicaPassword: "replica-user-password-upd2",
+		},
+		ReplicationSetting: createDatabaseParam.ReplicationSetting,
+	}
+	patchDatabaseSettingsExpected = &sacloud.Database{
+		Name:           createDatabaseParam.Name,
+		Description:    "",
+		Availability:   types.Availabilities.Available,
+		PlanID:         createDatabaseParam.PlanID,
+		InstanceStatus: types.ServerInstanceStatuses.Up,
+		DefaultRoute:   createDatabaseParam.DefaultRoute,
+		NetworkMaskLen: createDatabaseParam.NetworkMaskLen,
+		IPAddresses:    createDatabaseParam.IPAddresses,
+		Conf:           createDatabaseParam.Conf,
+		CommonSetting: &sacloud.DatabaseSettingCommon{
+			ServicePort:     54323,
+			DefaultUser:     "exa.mple.upd2",
+			UserPassword:    "LibsacloudExamplePassword01up2",
+			ReplicaUser:     "replica-upd2",
+			ReplicaPassword: "replica-user-password-upd2",
 		},
 		ReplicationSetting: createDatabaseParam.ReplicationSetting,
 	}
@@ -298,6 +379,16 @@ func testDatabaseRead(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (
 func testDatabasePatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewDatabaseOp(caller)
 	return client.Patch(ctx, testZone, ctx.ID, patchDatabaseParam)
+}
+
+func testDatabasePatchSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewDatabaseOp(caller)
+	return client.PatchSettings(ctx, testZone, ctx.ID, patchDatabaseSettingsParam)
+}
+
+func testDatabaseUpdateSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewDatabaseOp(caller)
+	return client.UpdateSettings(ctx, testZone, ctx.ID, updateDatabaseSettingsParam)
 }
 
 func testDatabaseUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/sacloud/test/dns_op_test.go
+++ b/sacloud/test/dns_op_test.go
@@ -53,6 +53,20 @@ func TestDNSOp_CRUD(t *testing.T) {
 				}),
 			},
 			{
+				Func: testDNSUpdateSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateDNSSettingsExpected,
+					IgnoreFields: ignoreDNSFields,
+				}),
+			},
+			{
+				Func: testDNSPatchSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchDNSSettingsExpected,
+					IgnoreFields: ignoreDNSFields,
+				}),
+			},
+			{
 				Func: testDNSUpdate,
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
 					ExpectValue:  updateDNSExpected,
@@ -136,6 +150,75 @@ var (
 		DNSZone:      createDNSParam.Name,
 		Records:      patchDNSParam.Records,
 	}
+	updateDNSSettingsParam = &sacloud.DNSUpdateSettingsRequest{
+		Records: []*sacloud.DNSRecord{
+			{
+				Name:  "host1",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.11",
+			},
+			{
+				Name:  "host2",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.12",
+			},
+			{
+				Name:  "host3",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.13",
+			},
+			{
+				Name:  "host4",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.14",
+			},
+		},
+	}
+	updateDNSSettingsExpected = &sacloud.DNS{
+		Name:         createDNSParam.Name,
+		Description:  createDNSParam.Description,
+		Tags:         createDNSParam.Tags,
+		Availability: types.Availabilities.Available,
+		DNSZone:      createDNSParam.Name,
+		Records:      updateDNSSettingsParam.Records,
+	}
+	patchDNSSettingsParam = &sacloud.DNSPatchSettingsRequest{
+		Records: []*sacloud.DNSRecord{
+			{
+				Name:  "host1",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.11",
+			},
+			{
+				Name:  "host2",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.12",
+			},
+			{
+				Name:  "host3",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.13",
+			},
+			{
+				Name:  "host4",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.14",
+			},
+			{
+				Name:  "host5",
+				Type:  types.DNSRecordTypes.A,
+				RData: "192.0.2.15",
+			},
+		},
+	}
+	patchDNSSettingsExpected = &sacloud.DNS{
+		Name:         createDNSParam.Name,
+		Description:  createDNSParam.Description,
+		Tags:         createDNSParam.Tags,
+		Availability: types.Availabilities.Available,
+		DNSZone:      createDNSParam.Name,
+		Records:      patchDNSSettingsParam.Records,
+	}
 	updateDNSParam = &sacloud.DNSUpdateRequest{
 		Description: "desc-upd",
 		Tags:        []string{"tag1-upd", "tag2-upd"},
@@ -190,9 +273,19 @@ func testDNSPatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (inte
 	return client.Patch(ctx, ctx.ID, patchDNSParam)
 }
 
+func testDNSPatchSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewDNSOp(caller)
+	return client.PatchSettings(ctx, ctx.ID, patchDNSSettingsParam)
+}
+
 func testDNSUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewDNSOp(caller)
 	return client.Update(ctx, ctx.ID, updateDNSParam)
+}
+
+func testDNSUpdateSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewDNSOp(caller)
+	return client.UpdateSettings(ctx, ctx.ID, updateDNSSettingsParam)
 }
 
 func testDNSUpdateToMin(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/sacloud/test/gslb_op_test.go
+++ b/sacloud/test/gslb_op_test.go
@@ -53,6 +53,27 @@ func TestGSLBOp_CRUD(t *testing.T) {
 				}),
 			},
 			{
+				Func: testGSLBUpdateSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateGSLBSettingsExpected,
+					IgnoreFields: ignoreGSLBFields,
+				}),
+			},
+			{
+				Func: testGSLBPatch,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchGSLBExpected,
+					IgnoreFields: ignoreGSLBFields,
+				}),
+			},
+			{
+				Func: testGSLBPatchSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchGSLBSettingsExpected,
+					IgnoreFields: ignoreGSLBFields,
+				}),
+			},
+			{
 				Func: testGSLBUpdateToMin,
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
 					ExpectValue:  updateGSLBToMinExpected,
@@ -159,6 +180,98 @@ var (
 		DestinationServers: updateGSLBParam.DestinationServers,
 		IconID:             testIconID,
 	}
+	updateGSLBSettingsParam = &sacloud.GSLBUpdateSettingsRequest{
+		HealthCheck: &sacloud.GSLBHealthCheck{
+			Protocol:     types.GSLBHealthCheckProtocols.HTTP,
+			HostHeader:   "upd2.usacloud.jp",
+			Path:         "/index-upd2.html",
+			ResponseCode: types.StringNumber(202),
+		},
+		DelayLoop:   22,
+		Weighted:    types.StringFalse,
+		SorryServer: "1.1.1.1",
+		DestinationServers: []*sacloud.GSLBServer{
+			{
+				IPAddress: "192.2.0.12",
+				Enabled:   types.StringFalse,
+				Weight:    types.StringNumber(100),
+			},
+			{
+				IPAddress: "192.2.0.22",
+				Enabled:   types.StringFalse,
+				Weight:    types.StringNumber(200),
+			},
+		},
+	}
+	updateGSLBSettingsExpected = &sacloud.GSLB{
+		Name:               updateGSLBParam.Name,
+		Description:        updateGSLBParam.Description,
+		Tags:               updateGSLBParam.Tags,
+		Availability:       types.Availabilities.Available,
+		DelayLoop:          updateGSLBSettingsParam.DelayLoop,
+		Weighted:           updateGSLBSettingsParam.Weighted,
+		HealthCheck:        updateGSLBSettingsParam.HealthCheck,
+		SorryServer:        updateGSLBSettingsParam.SorryServer,
+		DestinationServers: updateGSLBSettingsParam.DestinationServers,
+		IconID:             testIconID,
+	}
+	patchGSLBParam = &sacloud.GSLBPatchRequest{
+		Name:      testutil.ResourceName("gslb-patch"),
+		DelayLoop: 23,
+		Weighted:  types.StringTrue,
+		DestinationServers: []*sacloud.GSLBServer{
+			{
+				IPAddress: "192.2.0.13",
+				Enabled:   types.StringFalse,
+				Weight:    types.StringNumber(100),
+			},
+			{
+				IPAddress: "192.2.0.23",
+				Enabled:   types.StringFalse,
+				Weight:    types.StringNumber(200),
+			},
+		},
+	}
+	patchGSLBExpected = &sacloud.GSLB{
+		Name:               patchGSLBParam.Name,
+		Description:        updateGSLBParam.Description,
+		Tags:               updateGSLBParam.Tags,
+		Availability:       types.Availabilities.Available,
+		DelayLoop:          patchGSLBParam.DelayLoop,
+		Weighted:           patchGSLBParam.Weighted,
+		HealthCheck:        updateGSLBSettingsParam.HealthCheck,
+		SorryServer:        updateGSLBSettingsParam.SorryServer,
+		DestinationServers: patchGSLBParam.DestinationServers,
+		IconID:             testIconID,
+	}
+	patchGSLBSettingsParam = &sacloud.GSLBPatchSettingsRequest{
+		DelayLoop: 24,
+		Weighted:  types.StringTrue,
+		DestinationServers: []*sacloud.GSLBServer{
+			{
+				IPAddress: "192.2.0.14",
+				Enabled:   types.StringFalse,
+				Weight:    types.StringNumber(100),
+			},
+			{
+				IPAddress: "192.2.0.24",
+				Enabled:   types.StringFalse,
+				Weight:    types.StringNumber(200),
+			},
+		},
+	}
+	patchGSLBSettingsExpected = &sacloud.GSLB{
+		Name:               patchGSLBParam.Name,
+		Description:        updateGSLBParam.Description,
+		Tags:               updateGSLBParam.Tags,
+		Availability:       types.Availabilities.Available,
+		DelayLoop:          patchGSLBSettingsParam.DelayLoop,
+		Weighted:           patchGSLBSettingsParam.Weighted,
+		HealthCheck:        updateGSLBSettingsParam.HealthCheck,
+		SorryServer:        updateGSLBSettingsParam.SorryServer,
+		DestinationServers: patchGSLBSettingsParam.DestinationServers,
+		IconID:             testIconID,
+	}
 	updateGSLBToMinParam = &sacloud.GSLBUpdateRequest{
 		Name: testutil.ResourceName("gslb-to-min"),
 		HealthCheck: &sacloud.GSLBHealthCheck{
@@ -186,6 +299,21 @@ func testGSLBRead(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (inte
 func testGSLBUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewGSLBOp(caller)
 	return client.Update(ctx, ctx.ID, updateGSLBParam)
+}
+
+func testGSLBUpdateSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewGSLBOp(caller)
+	return client.UpdateSettings(ctx, ctx.ID, updateGSLBSettingsParam)
+}
+
+func testGSLBPatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewGSLBOp(caller)
+	return client.Patch(ctx, ctx.ID, patchGSLBParam)
+}
+
+func testGSLBPatchSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewGSLBOp(caller)
+	return client.PatchSettings(ctx, ctx.ID, patchGSLBSettingsParam)
 }
 
 func testGSLBUpdateToMin(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/sacloud/test/load_balancer_op_test.go
+++ b/sacloud/test/load_balancer_op_test.go
@@ -31,6 +31,9 @@ func TestLoadBalancerOp_CRUD(t *testing.T) {
 			createLoadBalancerParam,
 			createLoadBalancerExpected,
 			updateLoadBalancerExpected,
+			updateLoadBalancerSettingsExpected,
+			patchLoadBalancerExpected,
+			patchLoadBalancerSettingsExpected,
 			updateLoadBalancerToMin1Expected,
 			updateLoadBalancerToMin2Expected,
 		),
@@ -55,6 +58,27 @@ func TestLoadBalancerOp_CRUD(t *testing.T) {
 				Func: testLoadBalancerUpdate,
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
 					ExpectValue:  updateLoadBalancerExpected,
+					IgnoreFields: ignoreLoadBalancerFields,
+				}),
+			},
+			{
+				Func: testLoadBalancerUpdateSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateLoadBalancerSettingsExpected,
+					IgnoreFields: ignoreLoadBalancerFields,
+				}),
+			},
+			{
+				Func: testLoadBalancerPatch,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchLoadBalancerExpected,
+					IgnoreFields: ignoreLoadBalancerFields,
+				}),
+			},
+			{
+				Func: testLoadBalancerPatchSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchLoadBalancerSettingsExpected,
 					IgnoreFields: ignoreLoadBalancerFields,
 				}),
 			},
@@ -267,6 +291,175 @@ var (
 		VRID:               createLoadBalancerParam.VRID,
 		VirtualIPAddresses: updateLoadBalancerParam.VirtualIPAddresses,
 	}
+	updateLoadBalancerSettingsParam = &sacloud.LoadBalancerUpdateSettingsRequest{
+		VirtualIPAddresses: []*sacloud.LoadBalancerVirtualIPAddress{
+			{
+				VirtualIPAddress: "192.168.0.121",
+				Port:             82,
+				DelayLoop:        11,
+				SorryServer:      "192.168.0.4",
+				Description:      "vip1 desc-upd",
+				Servers: []*sacloud.LoadBalancerServer{
+					{
+						IPAddress: "192.168.0.221",
+						Port:      82,
+						Enabled:   false,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTPS,
+							Path:         "/index-upd.html",
+							ResponseCode: 201,
+						},
+					},
+					{
+						IPAddress: "192.168.0.222",
+						Port:      82,
+						Enabled:   false,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTPS,
+							Path:         "/index-upd.html",
+							ResponseCode: 201,
+						},
+					},
+				},
+			},
+			{
+				VirtualIPAddress: "192.168.0.122",
+				Port:             82,
+				DelayLoop:        11,
+				SorryServer:      "192.168.0.4",
+				Description:      "vip2 desc-upd",
+				Servers: []*sacloud.LoadBalancerServer{
+					{
+						IPAddress: "192.168.0.223",
+						Port:      82,
+						Enabled:   false,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTPS,
+							Path:         "/index-upd.html",
+							ResponseCode: 201,
+						},
+					},
+					{
+						IPAddress: "192.168.0.224",
+						Port:      82,
+						Enabled:   false,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTPS,
+							Path:         "/index-upd.html",
+							ResponseCode: 201,
+						},
+					},
+				},
+			},
+		},
+	}
+	updateLoadBalancerSettingsExpected = &sacloud.LoadBalancer{
+		Name:               updateLoadBalancerParam.Name,
+		Description:        updateLoadBalancerParam.Description,
+		Tags:               updateLoadBalancerParam.Tags,
+		IconID:             testIconID,
+		Availability:       types.Availabilities.Available,
+		PlanID:             createLoadBalancerParam.PlanID,
+		InstanceStatus:     types.ServerInstanceStatuses.Up,
+		DefaultRoute:       createLoadBalancerParam.DefaultRoute,
+		NetworkMaskLen:     createLoadBalancerParam.NetworkMaskLen,
+		IPAddresses:        createLoadBalancerParam.IPAddresses,
+		VRID:               createLoadBalancerParam.VRID,
+		VirtualIPAddresses: updateLoadBalancerSettingsParam.VirtualIPAddresses,
+	}
+	patchLoadBalancerParam = &sacloud.LoadBalancerPatchRequest{
+		Name: testutil.ResourceName("lb-patch"),
+	}
+	patchLoadBalancerExpected = &sacloud.LoadBalancer{
+		Name:               patchLoadBalancerParam.Name,
+		Description:        updateLoadBalancerParam.Description,
+		Tags:               updateLoadBalancerParam.Tags,
+		IconID:             testIconID,
+		Availability:       types.Availabilities.Available,
+		PlanID:             createLoadBalancerParam.PlanID,
+		InstanceStatus:     types.ServerInstanceStatuses.Up,
+		DefaultRoute:       createLoadBalancerParam.DefaultRoute,
+		NetworkMaskLen:     createLoadBalancerParam.NetworkMaskLen,
+		IPAddresses:        createLoadBalancerParam.IPAddresses,
+		VRID:               createLoadBalancerParam.VRID,
+		VirtualIPAddresses: updateLoadBalancerSettingsParam.VirtualIPAddresses,
+	}
+	patchLoadBalancerSettingsParam = &sacloud.LoadBalancerPatchSettingsRequest{
+		VirtualIPAddresses: []*sacloud.LoadBalancerVirtualIPAddress{
+			{
+				VirtualIPAddress: "192.168.0.131",
+				Port:             83,
+				DelayLoop:        11,
+				SorryServer:      "192.168.0.4",
+				Description:      "vip1 desc-upd",
+				Servers: []*sacloud.LoadBalancerServer{
+					{
+						IPAddress: "192.168.0.231",
+						Port:      83,
+						Enabled:   false,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTPS,
+							Path:         "/index-upd.html",
+							ResponseCode: 201,
+						},
+					},
+					{
+						IPAddress: "192.168.0.232",
+						Port:      83,
+						Enabled:   false,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTPS,
+							Path:         "/index-upd.html",
+							ResponseCode: 201,
+						},
+					},
+				},
+			},
+			{
+				VirtualIPAddress: "192.168.0.132",
+				Port:             83,
+				DelayLoop:        11,
+				SorryServer:      "192.168.0.4",
+				Description:      "vip2 desc-upd",
+				Servers: []*sacloud.LoadBalancerServer{
+					{
+						IPAddress: "192.168.0.233",
+						Port:      83,
+						Enabled:   false,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTPS,
+							Path:         "/index-upd.html",
+							ResponseCode: 201,
+						},
+					},
+					{
+						IPAddress: "192.168.0.234",
+						Port:      83,
+						Enabled:   false,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTPS,
+							Path:         "/index-upd.html",
+							ResponseCode: 201,
+						},
+					},
+				},
+			},
+		},
+	}
+	patchLoadBalancerSettingsExpected = &sacloud.LoadBalancer{
+		Name:               patchLoadBalancerParam.Name,
+		Description:        updateLoadBalancerParam.Description,
+		Tags:               updateLoadBalancerParam.Tags,
+		IconID:             testIconID,
+		Availability:       types.Availabilities.Available,
+		PlanID:             createLoadBalancerParam.PlanID,
+		InstanceStatus:     types.ServerInstanceStatuses.Up,
+		DefaultRoute:       createLoadBalancerParam.DefaultRoute,
+		NetworkMaskLen:     createLoadBalancerParam.NetworkMaskLen,
+		IPAddresses:        createLoadBalancerParam.IPAddresses,
+		VRID:               createLoadBalancerParam.VRID,
+		VirtualIPAddresses: patchLoadBalancerSettingsParam.VirtualIPAddresses,
+	}
 	updateLoadBalancerToMin1Param = &sacloud.LoadBalancerUpdateRequest{
 		Name: testutil.ResourceName("lb-to-min1"),
 		VirtualIPAddresses: []*sacloud.LoadBalancerVirtualIPAddress{
@@ -321,6 +514,21 @@ func testLoadBalancerRead(ctx *testutil.CRUDTestContext, caller sacloud.APICalle
 func testLoadBalancerUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewLoadBalancerOp(caller)
 	return client.Update(ctx, testZone, ctx.ID, updateLoadBalancerParam)
+}
+
+func testLoadBalancerUpdateSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewLoadBalancerOp(caller)
+	return client.UpdateSettings(ctx, testZone, ctx.ID, updateLoadBalancerSettingsParam)
+}
+
+func testLoadBalancerPatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewLoadBalancerOp(caller)
+	return client.Patch(ctx, testZone, ctx.ID, patchLoadBalancerParam)
+}
+
+func testLoadBalancerPatchSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewLoadBalancerOp(caller)
+	return client.PatchSettings(ctx, testZone, ctx.ID, patchLoadBalancerSettingsParam)
 }
 
 func testLoadBalancerUpdateToMin1(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/sacloud/test/mobile_gateway_op_test.go
+++ b/sacloud/test/mobile_gateway_op_test.go
@@ -58,6 +58,20 @@ func TestMobileGatewayOpCRUD(t *testing.T) {
 					IgnoreFields: ignoreMobileGatewayFields,
 				}),
 			},
+			{
+				Func: testMobileGatewayPatch,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchMobileGatewayExpected,
+					IgnoreFields: ignoreMobileGatewayFields,
+				}),
+			},
+			{
+				Func: testMobileGatewayUpdateSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateMobileGatewaySettingsExpected,
+					IgnoreFields: ignoreMobileGatewayFields,
+				}),
+			},
 			// shutdown(no check)
 			{
 				Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
@@ -425,6 +439,41 @@ func initMobileGatewayVariables() {
 			InterDeviceCommunicationEnabled: false,
 		},
 	}
+	patchMobileGatewayParam = &sacloud.MobileGatewayPatchRequest{
+		Name:        testutil.ResourceName("mobile-gateway-patch"),
+		Description: "desc-upd",
+		Tags:        []string{"tag1-upd", "tag2-upd"},
+		Settings: &sacloud.MobileGatewaySetting{
+			InternetConnectionEnabled:       true,
+			InterDeviceCommunicationEnabled: true,
+		},
+	}
+	patchMobileGatewayExpected = &sacloud.MobileGateway{
+		Name:         patchMobileGatewayParam.Name,
+		Description:  updateMobileGatewayParam.Description,
+		Tags:         updateMobileGatewayParam.Tags,
+		Availability: types.Availabilities.Available,
+		Settings: &sacloud.MobileGatewaySetting{
+			InternetConnectionEnabled:       true,
+			InterDeviceCommunicationEnabled: true,
+		},
+	}
+	updateMobileGatewaySettingsParam = &sacloud.MobileGatewayUpdateSettingsRequest{
+		Settings: &sacloud.MobileGatewaySetting{
+			InternetConnectionEnabled:       true,
+			InterDeviceCommunicationEnabled: true,
+		},
+	}
+	updateMobileGatewaySettingsExpected = &sacloud.MobileGateway{
+		Name:         patchMobileGatewayParam.Name,
+		Description:  updateMobileGatewayParam.Description,
+		Tags:         updateMobileGatewayParam.Tags,
+		Availability: types.Availabilities.Available,
+		Settings: &sacloud.MobileGatewaySetting{
+			InternetConnectionEnabled:       true,
+			InterDeviceCommunicationEnabled: true,
+		},
+	}
 }
 
 var (
@@ -442,12 +491,16 @@ var (
 		"ZoneID",
 		"SettingsHash",
 	}
-	iccid                       string
-	passcode                    string
-	createMobileGatewayParam    *sacloud.MobileGatewayCreateRequest
-	createMobileGatewayExpected *sacloud.MobileGateway
-	updateMobileGatewayParam    *sacloud.MobileGatewayUpdateRequest
-	updateMobileGatewayExpected *sacloud.MobileGateway
+	iccid                               string
+	passcode                            string
+	createMobileGatewayParam            *sacloud.MobileGatewayCreateRequest
+	createMobileGatewayExpected         *sacloud.MobileGateway
+	updateMobileGatewayParam            *sacloud.MobileGatewayUpdateRequest
+	updateMobileGatewayExpected         *sacloud.MobileGateway
+	patchMobileGatewayParam             *sacloud.MobileGatewayPatchRequest
+	patchMobileGatewayExpected          *sacloud.MobileGateway
+	updateMobileGatewaySettingsParam    *sacloud.MobileGatewayUpdateSettingsRequest
+	updateMobileGatewaySettingsExpected *sacloud.MobileGateway
 )
 
 func testMobileGatewayCreate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
@@ -476,6 +529,16 @@ func testMobileGatewayRead(ctx *testutil.CRUDTestContext, caller sacloud.APICall
 func testMobileGatewayUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewMobileGatewayOp(caller)
 	return client.Update(ctx, testZone, ctx.ID, updateMobileGatewayParam)
+}
+
+func testMobileGatewayUpdateSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewMobileGatewayOp(caller)
+	return client.UpdateSettings(ctx, testZone, ctx.ID, updateMobileGatewaySettingsParam)
+}
+
+func testMobileGatewayPatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewMobileGatewayOp(caller)
+	return client.Patch(ctx, testZone, ctx.ID, patchMobileGatewayParam)
 }
 
 func testMobileGatewayDelete(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {

--- a/sacloud/test/simple_monitor_op_test.go
+++ b/sacloud/test/simple_monitor_op_test.go
@@ -56,6 +56,20 @@ func TestSimpleMonitorOp_CRUD(t *testing.T) {
 				}),
 			},
 			{
+				Func: testSimpleMonitorPatch,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  patchSimpleMonitorExpected,
+					IgnoreFields: ignoreSimpleMonitorFields,
+				}),
+			},
+			{
+				Func: testSimpleMonitorUpdateSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateSimpleMonitorSettingsExpected,
+					IgnoreFields: ignoreSimpleMonitorFields,
+				}),
+			},
+			{
 				Func: testSimpleMonitorUpdateToMin,
 				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
 					ExpectValue:  updateSimpleMonitorToMinExpected,
@@ -152,6 +166,59 @@ var (
 		Availability:       types.Availabilities.Available,
 		IconID:             testIconID,
 	}
+	patchSimpleMonitorParam = &sacloud.SimpleMonitorPatchRequest{
+		DelayLoop: 180,
+	}
+	patchSimpleMonitorExpected = &sacloud.SimpleMonitor{
+		Name:               createSimpleMonitorParam.Target,
+		Description:        updateSimpleMonitorParam.Description,
+		Tags:               updateSimpleMonitorParam.Tags,
+		Target:             createSimpleMonitorParam.Target,
+		DelayLoop:          patchSimpleMonitorParam.DelayLoop,
+		Enabled:            updateSimpleMonitorParam.Enabled,
+		HealthCheck:        updateSimpleMonitorParam.HealthCheck,
+		NotifyEmailEnabled: updateSimpleMonitorParam.NotifyEmailEnabled,
+		NotifyEmailHTML:    updateSimpleMonitorParam.NotifyEmailHTML,
+		NotifySlackEnabled: updateSimpleMonitorParam.NotifySlackEnabled,
+		NotifyInterval:     updateSimpleMonitorParam.NotifyInterval,
+		SlackWebhooksURL:   updateSimpleMonitorParam.SlackWebhooksURL,
+		Availability:       types.Availabilities.Available,
+		IconID:             testIconID,
+	}
+	updateSimpleMonitorSettingsParam = &sacloud.SimpleMonitorUpdateSettingsRequest{
+		DelayLoop: 120,
+		HealthCheck: &sacloud.SimpleMonitorHealthCheck{
+			Protocol:          types.SimpleMonitorProtocols.HTTP,
+			Port:              types.StringNumber(80),
+			Path:              "/index3.html",
+			Status:            types.StringNumber(202),
+			SNI:               types.StringFalse,
+			Host:              "libsacloud-test-patch.usacloud.jp",
+			BasicAuthUsername: "username-upd2",
+			BasicAuthPassword: "password-upd2",
+		},
+		NotifyEmailEnabled: types.StringFalse,
+		NotifyEmailHTML:    types.StringFalse,
+		NotifySlackEnabled: types.StringTrue,
+		SlackWebhooksURL:   "https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXX",
+		NotifyInterval:     3 * 60 * 60,
+	}
+	updateSimpleMonitorSettingsExpected = &sacloud.SimpleMonitor{
+		Name:               createSimpleMonitorParam.Target,
+		Description:        updateSimpleMonitorParam.Description,
+		Tags:               updateSimpleMonitorParam.Tags,
+		Target:             createSimpleMonitorParam.Target,
+		DelayLoop:          updateSimpleMonitorSettingsParam.DelayLoop,
+		Enabled:            updateSimpleMonitorSettingsParam.Enabled,
+		HealthCheck:        updateSimpleMonitorSettingsParam.HealthCheck,
+		NotifyEmailEnabled: updateSimpleMonitorSettingsParam.NotifyEmailEnabled,
+		NotifyEmailHTML:    updateSimpleMonitorSettingsParam.NotifyEmailHTML,
+		NotifySlackEnabled: updateSimpleMonitorSettingsParam.NotifySlackEnabled,
+		NotifyInterval:     updateSimpleMonitorSettingsParam.NotifyInterval,
+		SlackWebhooksURL:   updateSimpleMonitorSettingsParam.SlackWebhooksURL,
+		Availability:       types.Availabilities.Available,
+		IconID:             testIconID,
+	}
 
 	updateSimpleMonitorToMinParam = &sacloud.SimpleMonitorUpdateRequest{
 		HealthCheck: &sacloud.SimpleMonitorHealthCheck{
@@ -186,6 +253,16 @@ func testSimpleMonitorRead(ctx *testutil.CRUDTestContext, caller sacloud.APICall
 func testSimpleMonitorUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewSimpleMonitorOp(caller)
 	return client.Update(ctx, ctx.ID, updateSimpleMonitorParam)
+}
+
+func testSimpleMonitorUpdateSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewSimpleMonitorOp(caller)
+	return client.UpdateSettings(ctx, ctx.ID, updateSimpleMonitorSettingsParam)
+}
+
+func testSimpleMonitorPatch(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewSimpleMonitorOp(caller)
+	return client.Patch(ctx, ctx.ID, patchSimpleMonitorParam)
 }
 
 func testSimpleMonitorUpdateToMin(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/sacloud/testutil/testing.go
+++ b/sacloud/testutil/testing.go
@@ -335,7 +335,7 @@ func Run(t TestT, testCase *CRUDTestCase) {
 // AssertEqualWithExpected 項目ごとに除外設定のできる期待値との比較
 func AssertEqualWithExpected(testExpect *CRUDTestExpect) func(TestT, *CRUDTestContext, interface{}) error {
 	return func(t TestT, testContext *CRUDTestContext, v interface{}) error {
-		actual, expect := testExpect.Prepare(v)
+		expect, actual := testExpect.Prepare(v)
 		if !assert.Equal(t, expect, actual) {
 			return errors.New("assert.Equal is failed")
 		}

--- a/sacloud/testutil/testing.go
+++ b/sacloud/testutil/testing.go
@@ -178,7 +178,7 @@ func (c *CRUDTestExpect) Prepare(actual interface{}) (interface{}, interface{}) 
 		return m
 	}
 
-	return toMap(actual), toMap(c.ExpectValue)
+	return toMap(c.ExpectValue), toMap(actual)
 }
 
 // PreCheckEnvsFunc 指定の環境変数が指定されていなかった場合にテストをスキップするためのFuncを返す

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -10449,6 +10449,41 @@ func (t *VPCRouterTracer) Update(ctx context.Context, zone string, id types.ID, 
 	return resultVPCRouter, err
 }
 
+// UpdateSettings is API call with trace log
+func (t *VPCRouterTracer) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterUpdateSettingsRequest) (*sacloud.VPCRouter, error) {
+	log.Println("[TRACE] VPCRouterAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                                `json:"id"`
+		Argparam *sacloud.VPCRouterUpdateSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] VPCRouterAPI.UpdateSettings end")
+	}()
+
+	resultVPCRouter, err := t.Internal.UpdateSettings(ctx, zone, id, param)
+	targetResults := struct {
+		VPCRouter *sacloud.VPCRouter
+		Error     error
+	}{
+		VPCRouter: resultVPCRouter,
+		Error:     err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultVPCRouter, err
+}
+
 // Patch is API call with trace log
 func (t *VPCRouterTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterPatchRequest) (*sacloud.VPCRouter, error) {
 	log.Println("[TRACE] VPCRouterAPI.Patch start")
@@ -10470,6 +10505,41 @@ func (t *VPCRouterTracer) Patch(ctx context.Context, zone string, id types.ID, p
 	}()
 
 	resultVPCRouter, err := t.Internal.Patch(ctx, zone, id, param)
+	targetResults := struct {
+		VPCRouter *sacloud.VPCRouter
+		Error     error
+	}{
+		VPCRouter: resultVPCRouter,
+		Error:     err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultVPCRouter, err
+}
+
+// PatchSettings is API call with trace log
+func (t *VPCRouterTracer) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.VPCRouterPatchSettingsRequest) (*sacloud.VPCRouter, error) {
+	log.Println("[TRACE] VPCRouterAPI.PatchSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                               `json:"id"`
+		Argparam *sacloud.VPCRouterPatchSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] VPCRouterAPI.PatchSettings end")
+	}()
+
+	resultVPCRouter, err := t.Internal.PatchSettings(ctx, zone, id, param)
 	targetResults := struct {
 		VPCRouter *sacloud.VPCRouter
 		Error     error

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -1708,6 +1708,41 @@ func (t *DatabaseTracer) Update(ctx context.Context, zone string, id types.ID, p
 	return resultDatabase, err
 }
 
+// UpdateSettings is API call with trace log
+func (t *DatabaseTracer) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.DatabaseUpdateSettingsRequest) (*sacloud.Database, error) {
+	log.Println("[TRACE] DatabaseAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                               `json:"id"`
+		Argparam *sacloud.DatabaseUpdateSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] DatabaseAPI.UpdateSettings end")
+	}()
+
+	resultDatabase, err := t.Internal.UpdateSettings(ctx, zone, id, param)
+	targetResults := struct {
+		Database *sacloud.Database
+		Error    error
+	}{
+		Database: resultDatabase,
+		Error:    err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultDatabase, err
+}
+
 // Patch is API call with trace log
 func (t *DatabaseTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.DatabasePatchRequest) (*sacloud.Database, error) {
 	log.Println("[TRACE] DatabaseAPI.Patch start")
@@ -1729,6 +1764,41 @@ func (t *DatabaseTracer) Patch(ctx context.Context, zone string, id types.ID, pa
 	}()
 
 	resultDatabase, err := t.Internal.Patch(ctx, zone, id, param)
+	targetResults := struct {
+		Database *sacloud.Database
+		Error    error
+	}{
+		Database: resultDatabase,
+		Error:    err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultDatabase, err
+}
+
+// PatchSettings is API call with trace log
+func (t *DatabaseTracer) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.DatabasePatchSettingsRequest) (*sacloud.Database, error) {
+	log.Println("[TRACE] DatabaseAPI.PatchSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                              `json:"id"`
+		Argparam *sacloud.DatabasePatchSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] DatabaseAPI.PatchSettings end")
+	}()
+
+	resultDatabase, err := t.Internal.PatchSettings(ctx, zone, id, param)
 	targetResults := struct {
 		Database *sacloud.Database
 		Error    error

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -2857,6 +2857,39 @@ func (t *DNSTracer) Update(ctx context.Context, id types.ID, param *sacloud.DNSU
 	return resultDNS, err
 }
 
+// UpdateSettings is API call with trace log
+func (t *DNSTracer) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.DNSUpdateSettingsRequest) (*sacloud.DNS, error) {
+	log.Println("[TRACE] DNSAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argid    types.ID                          `json:"id"`
+		Argparam *sacloud.DNSUpdateSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] DNSAPI.UpdateSettings end")
+	}()
+
+	resultDNS, err := t.Internal.UpdateSettings(ctx, id, param)
+	targetResults := struct {
+		DNS   *sacloud.DNS
+		Error error
+	}{
+		DNS:   resultDNS,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultDNS, err
+}
+
 // Patch is API call with trace log
 func (t *DNSTracer) Patch(ctx context.Context, id types.ID, param *sacloud.DNSPatchRequest) (*sacloud.DNS, error) {
 	log.Println("[TRACE] DNSAPI.Patch start")
@@ -2876,6 +2909,39 @@ func (t *DNSTracer) Patch(ctx context.Context, id types.ID, param *sacloud.DNSPa
 	}()
 
 	resultDNS, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		DNS   *sacloud.DNS
+		Error error
+	}{
+		DNS:   resultDNS,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultDNS, err
+}
+
+// PatchSettings is API call with trace log
+func (t *DNSTracer) PatchSettings(ctx context.Context, id types.ID, param *sacloud.DNSPatchSettingsRequest) (*sacloud.DNS, error) {
+	log.Println("[TRACE] DNSAPI.PatchSettings start")
+	targetArguments := struct {
+		Argid    types.ID                         `json:"id"`
+		Argparam *sacloud.DNSPatchSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] DNSAPI.PatchSettings end")
+	}()
+
+	resultDNS, err := t.Internal.PatchSettings(ctx, id, param)
 	targetResults := struct {
 		DNS   *sacloud.DNS
 		Error error

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -7694,6 +7694,39 @@ func (t *ProxyLBTracer) Update(ctx context.Context, id types.ID, param *sacloud.
 	return resultProxyLB, err
 }
 
+// UpdateSettings is API call with trace log
+func (t *ProxyLBTracer) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.ProxyLBUpdateSettingsRequest) (*sacloud.ProxyLB, error) {
+	log.Println("[TRACE] ProxyLBAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argid    types.ID                              `json:"id"`
+		Argparam *sacloud.ProxyLBUpdateSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ProxyLBAPI.UpdateSettings end")
+	}()
+
+	resultProxyLB, err := t.Internal.UpdateSettings(ctx, id, param)
+	targetResults := struct {
+		ProxyLB *sacloud.ProxyLB
+		Error   error
+	}{
+		ProxyLB: resultProxyLB,
+		Error:   err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultProxyLB, err
+}
+
 // Patch is API call with trace log
 func (t *ProxyLBTracer) Patch(ctx context.Context, id types.ID, param *sacloud.ProxyLBPatchRequest) (*sacloud.ProxyLB, error) {
 	log.Println("[TRACE] ProxyLBAPI.Patch start")
@@ -7713,6 +7746,39 @@ func (t *ProxyLBTracer) Patch(ctx context.Context, id types.ID, param *sacloud.P
 	}()
 
 	resultProxyLB, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		ProxyLB *sacloud.ProxyLB
+		Error   error
+	}{
+		ProxyLB: resultProxyLB,
+		Error:   err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultProxyLB, err
+}
+
+// PatchSettings is API call with trace log
+func (t *ProxyLBTracer) PatchSettings(ctx context.Context, id types.ID, param *sacloud.ProxyLBPatchSettingsRequest) (*sacloud.ProxyLB, error) {
+	log.Println("[TRACE] ProxyLBAPI.PatchSettings start")
+	targetArguments := struct {
+		Argid    types.ID                             `json:"id"`
+		Argparam *sacloud.ProxyLBPatchSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ProxyLBAPI.PatchSettings end")
+	}()
+
+	resultProxyLB, err := t.Internal.PatchSettings(ctx, id, param)
 	targetResults := struct {
 		ProxyLB *sacloud.ProxyLB
 		Error   error

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -3127,6 +3127,39 @@ func (t *GSLBTracer) Update(ctx context.Context, id types.ID, param *sacloud.GSL
 	return resultGSLB, err
 }
 
+// UpdateSettings is API call with trace log
+func (t *GSLBTracer) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.GSLBUpdateSettingsRequest) (*sacloud.GSLB, error) {
+	log.Println("[TRACE] GSLBAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argid    types.ID                           `json:"id"`
+		Argparam *sacloud.GSLBUpdateSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] GSLBAPI.UpdateSettings end")
+	}()
+
+	resultGSLB, err := t.Internal.UpdateSettings(ctx, id, param)
+	targetResults := struct {
+		GSLB  *sacloud.GSLB
+		Error error
+	}{
+		GSLB:  resultGSLB,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultGSLB, err
+}
+
 // Patch is API call with trace log
 func (t *GSLBTracer) Patch(ctx context.Context, id types.ID, param *sacloud.GSLBPatchRequest) (*sacloud.GSLB, error) {
 	log.Println("[TRACE] GSLBAPI.Patch start")
@@ -3146,6 +3179,39 @@ func (t *GSLBTracer) Patch(ctx context.Context, id types.ID, param *sacloud.GSLB
 	}()
 
 	resultGSLB, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		GSLB  *sacloud.GSLB
+		Error error
+	}{
+		GSLB:  resultGSLB,
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultGSLB, err
+}
+
+// PatchSettings is API call with trace log
+func (t *GSLBTracer) PatchSettings(ctx context.Context, id types.ID, param *sacloud.GSLBPatchSettingsRequest) (*sacloud.GSLB, error) {
+	log.Println("[TRACE] GSLBAPI.PatchSettings start")
+	targetArguments := struct {
+		Argid    types.ID                          `json:"id"`
+		Argparam *sacloud.GSLBPatchSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] GSLBAPI.PatchSettings end")
+	}()
+
+	resultGSLB, err := t.Internal.PatchSettings(ctx, id, param)
 	targetResults := struct {
 		GSLB  *sacloud.GSLB
 		Error error

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -9477,6 +9477,39 @@ func (t *SimpleMonitorTracer) Update(ctx context.Context, id types.ID, param *sa
 	return resultSimpleMonitor, err
 }
 
+// UpdateSettings is API call with trace log
+func (t *SimpleMonitorTracer) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorUpdateSettingsRequest) (*sacloud.SimpleMonitor, error) {
+	log.Println("[TRACE] SimpleMonitorAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argid    types.ID                                    `json:"id"`
+		Argparam *sacloud.SimpleMonitorUpdateSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] SimpleMonitorAPI.UpdateSettings end")
+	}()
+
+	resultSimpleMonitor, err := t.Internal.UpdateSettings(ctx, id, param)
+	targetResults := struct {
+		SimpleMonitor *sacloud.SimpleMonitor
+		Error         error
+	}{
+		SimpleMonitor: resultSimpleMonitor,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSimpleMonitor, err
+}
+
 // Patch is API call with trace log
 func (t *SimpleMonitorTracer) Patch(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorPatchRequest) (*sacloud.SimpleMonitor, error) {
 	log.Println("[TRACE] SimpleMonitorAPI.Patch start")
@@ -9496,6 +9529,39 @@ func (t *SimpleMonitorTracer) Patch(ctx context.Context, id types.ID, param *sac
 	}()
 
 	resultSimpleMonitor, err := t.Internal.Patch(ctx, id, param)
+	targetResults := struct {
+		SimpleMonitor *sacloud.SimpleMonitor
+		Error         error
+	}{
+		SimpleMonitor: resultSimpleMonitor,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultSimpleMonitor, err
+}
+
+// PatchSettings is API call with trace log
+func (t *SimpleMonitorTracer) PatchSettings(ctx context.Context, id types.ID, param *sacloud.SimpleMonitorPatchSettingsRequest) (*sacloud.SimpleMonitor, error) {
+	log.Println("[TRACE] SimpleMonitorAPI.PatchSettings start")
+	targetArguments := struct {
+		Argid    types.ID                                   `json:"id"`
+		Argparam *sacloud.SimpleMonitorPatchSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] SimpleMonitorAPI.PatchSettings end")
+	}()
+
+	resultSimpleMonitor, err := t.Internal.PatchSettings(ctx, id, param)
 	targetResults := struct {
 		SimpleMonitor *sacloud.SimpleMonitor
 		Error         error

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -5216,6 +5216,41 @@ func (t *LoadBalancerTracer) Update(ctx context.Context, zone string, id types.I
 	return resultLoadBalancer, err
 }
 
+// UpdateSettings is API call with trace log
+func (t *LoadBalancerTracer) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerUpdateSettingsRequest) (*sacloud.LoadBalancer, error) {
+	log.Println("[TRACE] LoadBalancerAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                                   `json:"id"`
+		Argparam *sacloud.LoadBalancerUpdateSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LoadBalancerAPI.UpdateSettings end")
+	}()
+
+	resultLoadBalancer, err := t.Internal.UpdateSettings(ctx, zone, id, param)
+	targetResults := struct {
+		LoadBalancer *sacloud.LoadBalancer
+		Error        error
+	}{
+		LoadBalancer: resultLoadBalancer,
+		Error:        err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLoadBalancer, err
+}
+
 // Patch is API call with trace log
 func (t *LoadBalancerTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerPatchRequest) (*sacloud.LoadBalancer, error) {
 	log.Println("[TRACE] LoadBalancerAPI.Patch start")
@@ -5237,6 +5272,41 @@ func (t *LoadBalancerTracer) Patch(ctx context.Context, zone string, id types.ID
 	}()
 
 	resultLoadBalancer, err := t.Internal.Patch(ctx, zone, id, param)
+	targetResults := struct {
+		LoadBalancer *sacloud.LoadBalancer
+		Error        error
+	}{
+		LoadBalancer: resultLoadBalancer,
+		Error:        err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLoadBalancer, err
+}
+
+// PatchSettings is API call with trace log
+func (t *LoadBalancerTracer) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.LoadBalancerPatchSettingsRequest) (*sacloud.LoadBalancer, error) {
+	log.Println("[TRACE] LoadBalancerAPI.PatchSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                                  `json:"id"`
+		Argparam *sacloud.LoadBalancerPatchSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LoadBalancerAPI.PatchSettings end")
+	}()
+
+	resultLoadBalancer, err := t.Internal.PatchSettings(ctx, zone, id, param)
 	targetResults := struct {
 		LoadBalancer *sacloud.LoadBalancer
 		Error        error

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -5696,6 +5696,41 @@ func (t *MobileGatewayTracer) Update(ctx context.Context, zone string, id types.
 	return resultMobileGateway, err
 }
 
+// UpdateSettings is API call with trace log
+func (t *MobileGatewayTracer) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayUpdateSettingsRequest) (*sacloud.MobileGateway, error) {
+	log.Println("[TRACE] MobileGatewayAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                                    `json:"id"`
+		Argparam *sacloud.MobileGatewayUpdateSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.UpdateSettings end")
+	}()
+
+	resultMobileGateway, err := t.Internal.UpdateSettings(ctx, zone, id, param)
+	targetResults := struct {
+		MobileGateway *sacloud.MobileGateway
+		Error         error
+	}{
+		MobileGateway: resultMobileGateway,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultMobileGateway, err
+}
+
 // Patch is API call with trace log
 func (t *MobileGatewayTracer) Patch(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayPatchRequest) (*sacloud.MobileGateway, error) {
 	log.Println("[TRACE] MobileGatewayAPI.Patch start")
@@ -5717,6 +5752,41 @@ func (t *MobileGatewayTracer) Patch(ctx context.Context, zone string, id types.I
 	}()
 
 	resultMobileGateway, err := t.Internal.Patch(ctx, zone, id, param)
+	targetResults := struct {
+		MobileGateway *sacloud.MobileGateway
+		Error         error
+	}{
+		MobileGateway: resultMobileGateway,
+		Error:         err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultMobileGateway, err
+}
+
+// PatchSettings is API call with trace log
+func (t *MobileGatewayTracer) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.MobileGatewayPatchSettingsRequest) (*sacloud.MobileGateway, error) {
+	log.Println("[TRACE] MobileGatewayAPI.PatchSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                                   `json:"id"`
+		Argparam *sacloud.MobileGatewayPatchSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] MobileGatewayAPI.PatchSettings end")
+	}()
+
+	resultMobileGateway, err := t.Internal.PatchSettings(ctx, zone, id, param)
 	targetResults := struct {
 		MobileGateway *sacloud.MobileGateway
 		Error         error

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -698,6 +698,76 @@ func (t *AutoBackupTracer) Patch(ctx context.Context, zone string, id types.ID, 
 	return resultAutoBackup, err
 }
 
+// UpdateSettings is API call with trace log
+func (t *AutoBackupTracer) UpdateSettings(ctx context.Context, zone string, id types.ID, param *sacloud.AutoBackupUpdateSettingsRequest) (*sacloud.AutoBackup, error) {
+	log.Println("[TRACE] AutoBackupAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                                 `json:"id"`
+		Argparam *sacloud.AutoBackupUpdateSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoBackupAPI.UpdateSettings end")
+	}()
+
+	resultAutoBackup, err := t.Internal.UpdateSettings(ctx, zone, id, param)
+	targetResults := struct {
+		AutoBackup *sacloud.AutoBackup
+		Error      error
+	}{
+		AutoBackup: resultAutoBackup,
+		Error:      err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultAutoBackup, err
+}
+
+// PatchSettings is API call with trace log
+func (t *AutoBackupTracer) PatchSettings(ctx context.Context, zone string, id types.ID, param *sacloud.AutoBackupPatchSettingsRequest) (*sacloud.AutoBackup, error) {
+	log.Println("[TRACE] AutoBackupAPI.PatchSettings start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                                `json:"id"`
+		Argparam *sacloud.AutoBackupPatchSettingsRequest `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] AutoBackupAPI.PatchSettings end")
+	}()
+
+	resultAutoBackup, err := t.Internal.PatchSettings(ctx, zone, id, param)
+	targetResults := struct {
+		AutoBackup *sacloud.AutoBackup
+		Error      error
+	}{
+		AutoBackup: resultAutoBackup,
+		Error:      err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultAutoBackup, err
+}
+
 // Delete is API call with trace log
 func (t *AutoBackupTracer) Delete(ctx context.Context, zone string, id types.ID) error {
 	log.Println("[TRACE] AutoBackupAPI.Delete start")

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -6516,6 +6516,43 @@ func (o *MobileGatewayOp) Update(ctx context.Context, zone string, id types.ID, 
 	return results.MobileGateway, nil
 }
 
+// UpdateSettings is API call
+func (o *MobileGatewayOp) UpdateSettings(ctx context.Context, zone string, id types.ID, param *MobileGatewayUpdateSettingsRequest) (*MobileGateway, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateSettingsResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.MobileGateway, nil
+}
+
 // Patch is API call
 func (o *MobileGatewayOp) Patch(ctx context.Context, zone string, id types.ID, param *MobileGatewayPatchRequest) (*MobileGateway, error) {
 	// build request URL
@@ -6574,6 +6611,61 @@ func (o *MobileGatewayOp) Patch(ctx context.Context, zone string, id types.ID, p
 
 	// build results
 	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.MobileGateway, nil
+}
+
+// PatchSettings is API call
+func (o *MobileGatewayOp) PatchSettings(ctx context.Context, zone string, id types.ID, param *MobileGatewayPatchSettingsRequest) (*MobileGateway, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToSettings {
+		param.Settings = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchSettingsResults(data)
 	if err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -8693,6 +8693,43 @@ func (o *ProxyLBOp) Update(ctx context.Context, id types.ID, param *ProxyLBUpdat
 	return results.ProxyLB, nil
 }
 
+// UpdateSettings is API call
+func (o *ProxyLBOp) UpdateSettings(ctx context.Context, id types.ID, param *ProxyLBUpdateSettingsRequest) (*ProxyLB, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateSettingsResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.ProxyLB, nil
+}
+
 // Patch is API call
 func (o *ProxyLBOp) Patch(ctx context.Context, id types.ID, param *ProxyLBPatchRequest) (*ProxyLB, error) {
 	// build request URL
@@ -8769,6 +8806,79 @@ func (o *ProxyLBOp) Patch(ctx context.Context, id types.ID, param *ProxyLBPatchR
 
 	// build results
 	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.ProxyLB, nil
+}
+
+// PatchSettings is API call
+func (o *ProxyLBOp) PatchSettings(ctx context.Context, id types.ID, param *ProxyLBPatchSettingsRequest) (*ProxyLB, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToHealthCheck {
+		param.HealthCheck = nil
+	}
+	if param.PatchEmptyToSorryServer {
+		param.SorryServer = nil
+	}
+	if param.PatchEmptyToBindPorts {
+		param.BindPorts = nil
+	}
+	if param.PatchEmptyToServers {
+		param.Servers = nil
+	}
+	if param.PatchEmptyToLetsEncrypt {
+		param.LetsEncrypt = nil
+	}
+	if param.PatchEmptyToStickySession {
+		param.StickySession = nil
+	}
+	if param.PatchEmptyToTimeout {
+		param.Timeout = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchSettingsResults(data)
 	if err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -979,6 +979,101 @@ func (o *AutoBackupOp) Patch(ctx context.Context, zone string, id types.ID, para
 	return results.AutoBackup, nil
 }
 
+// UpdateSettings is API call
+func (o *AutoBackupOp) UpdateSettings(ctx context.Context, zone string, id types.ID, param *AutoBackupUpdateSettingsRequest) (*AutoBackup, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateSettingsResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.AutoBackup, nil
+}
+
+// PatchSettings is API call
+func (o *AutoBackupOp) PatchSettings(ctx context.Context, zone string, id types.ID, param *AutoBackupPatchSettingsRequest) (*AutoBackup, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToBackupSpanWeekdays {
+		param.BackupSpanWeekdays = nil
+	}
+	if param.PatchEmptyToMaximumNumberOfArchives {
+		param.MaximumNumberOfArchives = 0
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchSettingsResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.AutoBackup, nil
+}
+
 // Delete is API call
 func (o *AutoBackupOp) Delete(ctx context.Context, zone string, id types.ID) error {
 	// build request URL

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -11858,6 +11858,43 @@ func (o *VPCRouterOp) Update(ctx context.Context, zone string, id types.ID, para
 	return results.VPCRouter, nil
 }
 
+// UpdateSettings is API call
+func (o *VPCRouterOp) UpdateSettings(ctx context.Context, zone string, id types.ID, param *VPCRouterUpdateSettingsRequest) (*VPCRouter, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateSettingsResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.VPCRouter, nil
+}
+
 // Patch is API call
 func (o *VPCRouterOp) Patch(ctx context.Context, zone string, id types.ID, param *VPCRouterPatchRequest) (*VPCRouter, error) {
 	// build request URL
@@ -11916,6 +11953,61 @@ func (o *VPCRouterOp) Patch(ctx context.Context, zone string, id types.ID, param
 
 	// build results
 	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.VPCRouter, nil
+}
+
+// PatchSettings is API call
+func (o *VPCRouterOp) PatchSettings(ctx context.Context, zone string, id types.ID, param *VPCRouterPatchSettingsRequest) (*VPCRouter, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToSettings {
+		param.Settings = nil
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchSettingsResults(data)
 	if err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -10699,6 +10699,43 @@ func (o *SimpleMonitorOp) Update(ctx context.Context, id types.ID, param *Simple
 	return results.SimpleMonitor, nil
 }
 
+// UpdateSettings is API call
+func (o *SimpleMonitorOp) UpdateSettings(ctx context.Context, id types.ID, param *SimpleMonitorUpdateSettingsRequest) (*SimpleMonitor, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateSettingsResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.SimpleMonitor, nil
+}
+
 // Patch is API call
 func (o *SimpleMonitorOp) Patch(ctx context.Context, id types.ID, param *SimpleMonitorPatchRequest) (*SimpleMonitor, error) {
 	// build request URL
@@ -10778,6 +10815,82 @@ func (o *SimpleMonitorOp) Patch(ctx context.Context, id types.ID, param *SimpleM
 
 	// build results
 	results, err := o.transformPatchResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.SimpleMonitor, nil
+}
+
+// PatchSettings is API call
+func (o *SimpleMonitorOp) PatchSettings(ctx context.Context, id types.ID, param *SimpleMonitorPatchSettingsRequest) (*SimpleMonitor, error) {
+	// build request URL
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	original, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	patchParam := make(map[string]interface{})
+	if err := mergo.Map(&patchParam, original); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(&patchParam, param); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+	if err := mergo.Map(param, &patchParam); err != nil {
+		return nil, fmt.Errorf("patch is failed: %s", err)
+	}
+
+	if param.PatchEmptyToDelayLoop {
+		param.DelayLoop = 0
+	}
+	if param.PatchEmptyToEnabled {
+		param.Enabled = types.StringFlag(false)
+	}
+	if param.PatchEmptyToHealthCheck {
+		param.HealthCheck = nil
+	}
+	if param.PatchEmptyToNotifyEmailEnabled {
+		param.NotifyEmailEnabled = types.StringFlag(false)
+	}
+	if param.PatchEmptyToNotifyEmailHTML {
+		param.NotifyEmailHTML = types.StringFlag(false)
+	}
+	if param.PatchEmptyToNotifySlackEnabled {
+		param.NotifySlackEnabled = types.StringFlag(false)
+	}
+	if param.PatchEmptyToSlackWebhooksURL {
+		param.SlackWebhooksURL = ""
+	}
+	if param.PatchEmptyToNotifyInterval {
+		param.NotifyInterval = 0
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformPatchSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformPatchSettingsResults(data)
 	if err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -2032,6 +2032,49 @@ func (o *DNSOp) transformUpdateResults(data []byte) (*dNSUpdateResult, error) {
 	return results, nil
 }
 
+func (o *DNSOp) transformUpdateSettingsArgs(id types.ID, param *DNSUpdateSettingsRequest) (*dNSUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &DNSUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &dNSUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *DNSOp) transformUpdateSettingsResults(data []byte) (*dNSUpdateSettingsResult, error) {
+	nakedResponse := &dNSUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &dNSUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *DNSOp) transformPatchArgs(id types.ID, param *DNSPatchRequest) (*dNSPatchRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -2069,6 +2112,49 @@ func (o *DNSOp) transformPatchResults(data []byte) (*dNSPatchResult, error) {
 	}
 
 	results := &dNSPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *DNSOp) transformPatchSettingsArgs(id types.ID, param *DNSPatchSettingsRequest) (*dNSPatchSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &DNSPatchSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &dNSPatchSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *DNSOp) transformPatchSettingsResults(data []byte) (*dNSPatchSettingsResult, error) {
+	nakedResponse := &dNSPatchSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &dNSPatchSettingsResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -3756,6 +3756,49 @@ func (o *LoadBalancerOp) transformUpdateResults(data []byte) (*loadBalancerUpdat
 	return results, nil
 }
 
+func (o *LoadBalancerOp) transformUpdateSettingsArgs(id types.ID, param *LoadBalancerUpdateSettingsRequest) (*loadBalancerUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &LoadBalancerUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &loadBalancerUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LoadBalancerOp) transformUpdateSettingsResults(data []byte) (*loadBalancerUpdateSettingsResult, error) {
+	nakedResponse := &loadBalancerUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &loadBalancerUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *LoadBalancerOp) transformPatchArgs(id types.ID, param *LoadBalancerPatchRequest) (*loadBalancerPatchRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -3793,6 +3836,49 @@ func (o *LoadBalancerOp) transformPatchResults(data []byte) (*loadBalancerPatchR
 	}
 
 	results := &loadBalancerPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LoadBalancerOp) transformPatchSettingsArgs(id types.ID, param *LoadBalancerPatchSettingsRequest) (*loadBalancerPatchSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &LoadBalancerPatchSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &loadBalancerPatchSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LoadBalancerOp) transformPatchSettingsResults(data []byte) (*loadBalancerPatchSettingsResult, error) {
+	nakedResponse := &loadBalancerPatchSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &loadBalancerPatchSettingsResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -1125,6 +1125,49 @@ func (o *DatabaseOp) transformUpdateResults(data []byte) (*databaseUpdateResult,
 	return results, nil
 }
 
+func (o *DatabaseOp) transformUpdateSettingsArgs(id types.ID, param *DatabaseUpdateSettingsRequest) (*databaseUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &DatabaseUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &databaseUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *DatabaseOp) transformUpdateSettingsResults(data []byte) (*databaseUpdateSettingsResult, error) {
+	nakedResponse := &databaseUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &databaseUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *DatabaseOp) transformPatchArgs(id types.ID, param *DatabasePatchRequest) (*databasePatchRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -1162,6 +1205,49 @@ func (o *DatabaseOp) transformPatchResults(data []byte) (*databasePatchResult, e
 	}
 
 	results := &databasePatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *DatabaseOp) transformPatchSettingsArgs(id types.ID, param *DatabasePatchSettingsRequest) (*databasePatchSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &DatabasePatchSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &databasePatchSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *DatabaseOp) transformPatchSettingsResults(data []byte) (*databasePatchSettingsResult, error) {
+	nakedResponse := &databasePatchSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &databasePatchSettingsResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -4095,6 +4095,49 @@ func (o *MobileGatewayOp) transformUpdateResults(data []byte) (*mobileGatewayUpd
 	return results, nil
 }
 
+func (o *MobileGatewayOp) transformUpdateSettingsArgs(id types.ID, param *MobileGatewayUpdateSettingsRequest) (*mobileGatewayUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &MobileGatewayUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &mobileGatewayUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *MobileGatewayOp) transformUpdateSettingsResults(data []byte) (*mobileGatewayUpdateSettingsResult, error) {
+	nakedResponse := &mobileGatewayUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *MobileGatewayOp) transformPatchArgs(id types.ID, param *MobileGatewayPatchRequest) (*mobileGatewayPatchRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -4132,6 +4175,49 @@ func (o *MobileGatewayOp) transformPatchResults(data []byte) (*mobileGatewayPatc
 	}
 
 	results := &mobileGatewayPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *MobileGatewayOp) transformPatchSettingsArgs(id types.ID, param *MobileGatewayPatchSettingsRequest) (*mobileGatewayPatchSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &MobileGatewayPatchSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &mobileGatewayPatchSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *MobileGatewayOp) transformPatchSettingsResults(data []byte) (*mobileGatewayPatchSettingsResult, error) {
+	nakedResponse := &mobileGatewayPatchSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &mobileGatewayPatchSettingsResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -2285,6 +2285,49 @@ func (o *GSLBOp) transformUpdateResults(data []byte) (*gSLBUpdateResult, error) 
 	return results, nil
 }
 
+func (o *GSLBOp) transformUpdateSettingsArgs(id types.ID, param *GSLBUpdateSettingsRequest) (*gSLBUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &GSLBUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &gSLBUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *GSLBOp) transformUpdateSettingsResults(data []byte) (*gSLBUpdateSettingsResult, error) {
+	nakedResponse := &gSLBUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &gSLBUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *GSLBOp) transformPatchArgs(id types.ID, param *GSLBPatchRequest) (*gSLBPatchRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -2322,6 +2365,49 @@ func (o *GSLBOp) transformPatchResults(data []byte) (*gSLBPatchResult, error) {
 	}
 
 	results := &gSLBPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *GSLBOp) transformPatchSettingsArgs(id types.ID, param *GSLBPatchSettingsRequest) (*gSLBPatchSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &GSLBPatchSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &gSLBPatchSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *GSLBOp) transformPatchSettingsResults(data []byte) (*gSLBPatchSettingsResult, error) {
+	nakedResponse := &gSLBPatchSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &gSLBPatchSettingsResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -7487,6 +7487,49 @@ func (o *VPCRouterOp) transformUpdateResults(data []byte) (*vPCRouterUpdateResul
 	return results, nil
 }
 
+func (o *VPCRouterOp) transformUpdateSettingsArgs(id types.ID, param *VPCRouterUpdateSettingsRequest) (*vPCRouterUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &VPCRouterUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &vPCRouterUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *VPCRouterOp) transformUpdateSettingsResults(data []byte) (*vPCRouterUpdateSettingsResult, error) {
+	nakedResponse := &vPCRouterUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &vPCRouterUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *VPCRouterOp) transformPatchArgs(id types.ID, param *VPCRouterPatchRequest) (*vPCRouterPatchRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -7524,6 +7567,49 @@ func (o *VPCRouterOp) transformPatchResults(data []byte) (*vPCRouterPatchResult,
 	}
 
 	results := &vPCRouterPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *VPCRouterOp) transformPatchSettingsArgs(id types.ID, param *VPCRouterPatchSettingsRequest) (*vPCRouterPatchSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &VPCRouterPatchSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"Appliance,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &vPCRouterPatchSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *VPCRouterOp) transformPatchSettingsResults(data []byte) (*vPCRouterPatchSettingsResult, error) {
+	nakedResponse := &vPCRouterPatchSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &vPCRouterPatchSettingsResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -447,6 +447,92 @@ func (o *AutoBackupOp) transformPatchResults(data []byte) (*autoBackupPatchResul
 	return results, nil
 }
 
+func (o *AutoBackupOp) transformUpdateSettingsArgs(id types.ID, param *AutoBackupUpdateSettingsRequest) (*autoBackupUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &AutoBackupUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &autoBackupUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *AutoBackupOp) transformUpdateSettingsResults(data []byte) (*autoBackupUpdateSettingsResult, error) {
+	nakedResponse := &autoBackupUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &autoBackupUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *AutoBackupOp) transformPatchSettingsArgs(id types.ID, param *AutoBackupPatchSettingsRequest) (*autoBackupPatchSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &AutoBackupPatchSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &autoBackupPatchSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *AutoBackupOp) transformPatchSettingsResults(data []byte) (*autoBackupPatchSettingsResult, error) {
+	nakedResponse := &autoBackupPatchSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &autoBackupPatchSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *BillOp) transformByContractResults(data []byte) (*BillByContractResult, error) {
 	nakedResponse := &billByContractResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -5459,6 +5459,49 @@ func (o *ProxyLBOp) transformUpdateResults(data []byte) (*proxyLBUpdateResult, e
 	return results, nil
 }
 
+func (o *ProxyLBOp) transformUpdateSettingsArgs(id types.ID, param *ProxyLBUpdateSettingsRequest) (*proxyLBUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &ProxyLBUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &proxyLBUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ProxyLBOp) transformUpdateSettingsResults(data []byte) (*proxyLBUpdateSettingsResult, error) {
+	nakedResponse := &proxyLBUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &proxyLBUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *ProxyLBOp) transformPatchArgs(id types.ID, param *ProxyLBPatchRequest) (*proxyLBPatchRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -5496,6 +5539,49 @@ func (o *ProxyLBOp) transformPatchResults(data []byte) (*proxyLBPatchResult, err
 	}
 
 	results := &proxyLBPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *ProxyLBOp) transformPatchSettingsArgs(id types.ID, param *ProxyLBPatchSettingsRequest) (*proxyLBPatchSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &ProxyLBPatchSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &proxyLBPatchSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ProxyLBOp) transformPatchSettingsResults(data []byte) (*proxyLBPatchSettingsResult, error) {
+	nakedResponse := &proxyLBPatchSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &proxyLBPatchSettingsResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -6750,6 +6750,49 @@ func (o *SimpleMonitorOp) transformUpdateResults(data []byte) (*simpleMonitorUpd
 	return results, nil
 }
 
+func (o *SimpleMonitorOp) transformUpdateSettingsArgs(id types.ID, param *SimpleMonitorUpdateSettingsRequest) (*simpleMonitorUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &SimpleMonitorUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &simpleMonitorUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *SimpleMonitorOp) transformUpdateSettingsResults(data []byte) (*simpleMonitorUpdateSettingsResult, error) {
+	nakedResponse := &simpleMonitorUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &simpleMonitorUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *SimpleMonitorOp) transformPatchArgs(id types.ID, param *SimpleMonitorPatchRequest) (*simpleMonitorPatchRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -6787,6 +6830,49 @@ func (o *SimpleMonitorOp) transformPatchResults(data []byte) (*simpleMonitorPatc
 	}
 
 	results := &simpleMonitorPatchResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *SimpleMonitorOp) transformPatchSettingsArgs(id types.ID, param *SimpleMonitorPatchSettingsRequest) (*simpleMonitorPatchSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &SimpleMonitorPatchSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &simpleMonitorPatchSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *SimpleMonitorOp) transformPatchSettingsResults(data []byte) (*simpleMonitorPatchSettingsResult, error) {
+	nakedResponse := &simpleMonitorPatchSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &simpleMonitorPatchSettingsResult{}
 	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
 		return nil, err
 	}

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -127,7 +127,9 @@ type DatabaseAPI interface {
 	Create(ctx context.Context, zone string, param *DatabaseCreateRequest) (*Database, error)
 	Read(ctx context.Context, zone string, id types.ID) (*Database, error)
 	Update(ctx context.Context, zone string, id types.ID, param *DatabaseUpdateRequest) (*Database, error)
+	UpdateSettings(ctx context.Context, zone string, id types.ID, param *DatabaseUpdateSettingsRequest) (*Database, error)
 	Patch(ctx context.Context, zone string, id types.ID, param *DatabasePatchRequest) (*Database, error)
+	PatchSettings(ctx context.Context, zone string, id types.ID, param *DatabasePatchSettingsRequest) (*Database, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Config(ctx context.Context, zone string, id types.ID) error
 	Boot(ctx context.Context, zone string, id types.ID) error

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -361,7 +361,9 @@ type MobileGatewayAPI interface {
 	Create(ctx context.Context, zone string, param *MobileGatewayCreateRequest) (*MobileGateway, error)
 	Read(ctx context.Context, zone string, id types.ID) (*MobileGateway, error)
 	Update(ctx context.Context, zone string, id types.ID, param *MobileGatewayUpdateRequest) (*MobileGateway, error)
+	UpdateSettings(ctx context.Context, zone string, id types.ID, param *MobileGatewayUpdateSettingsRequest) (*MobileGateway, error)
 	Patch(ctx context.Context, zone string, id types.ID, param *MobileGatewayPatchRequest) (*MobileGateway, error)
+	PatchSettings(ctx context.Context, zone string, id types.ID, param *MobileGatewayPatchSettingsRequest) (*MobileGateway, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Config(ctx context.Context, zone string, id types.ID) error
 	Boot(ctx context.Context, zone string, id types.ID) error

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -628,7 +628,9 @@ type VPCRouterAPI interface {
 	Create(ctx context.Context, zone string, param *VPCRouterCreateRequest) (*VPCRouter, error)
 	Read(ctx context.Context, zone string, id types.ID) (*VPCRouter, error)
 	Update(ctx context.Context, zone string, id types.ID, param *VPCRouterUpdateRequest) (*VPCRouter, error)
+	UpdateSettings(ctx context.Context, zone string, id types.ID, param *VPCRouterUpdateSettingsRequest) (*VPCRouter, error)
 	Patch(ctx context.Context, zone string, id types.ID, param *VPCRouterPatchRequest) (*VPCRouter, error)
+	PatchSettings(ctx context.Context, zone string, id types.ID, param *VPCRouterPatchSettingsRequest) (*VPCRouter, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Config(ctx context.Context, zone string, id types.ID) error
 	Boot(ctx context.Context, zone string, id types.ID) error

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -59,6 +59,8 @@ type AutoBackupAPI interface {
 	Read(ctx context.Context, zone string, id types.ID) (*AutoBackup, error)
 	Update(ctx context.Context, zone string, id types.ID, param *AutoBackupUpdateRequest) (*AutoBackup, error)
 	Patch(ctx context.Context, zone string, id types.ID, param *AutoBackupPatchRequest) (*AutoBackup, error)
+	UpdateSettings(ctx context.Context, zone string, id types.ID, param *AutoBackupUpdateSettingsRequest) (*AutoBackup, error)
+	PatchSettings(ctx context.Context, zone string, id types.ID, param *AutoBackupPatchSettingsRequest) (*AutoBackup, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 }
 

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -184,7 +184,9 @@ type DNSAPI interface {
 	Create(ctx context.Context, param *DNSCreateRequest) (*DNS, error)
 	Read(ctx context.Context, id types.ID) (*DNS, error)
 	Update(ctx context.Context, id types.ID, param *DNSUpdateRequest) (*DNS, error)
+	UpdateSettings(ctx context.Context, id types.ID, param *DNSUpdateSettingsRequest) (*DNS, error)
 	Patch(ctx context.Context, id types.ID, param *DNSPatchRequest) (*DNS, error)
+	PatchSettings(ctx context.Context, id types.ID, param *DNSPatchSettingsRequest) (*DNS, error)
 	Delete(ctx context.Context, id types.ID) error
 }
 

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -339,7 +339,9 @@ type LoadBalancerAPI interface {
 	Create(ctx context.Context, zone string, param *LoadBalancerCreateRequest) (*LoadBalancer, error)
 	Read(ctx context.Context, zone string, id types.ID) (*LoadBalancer, error)
 	Update(ctx context.Context, zone string, id types.ID, param *LoadBalancerUpdateRequest) (*LoadBalancer, error)
+	UpdateSettings(ctx context.Context, zone string, id types.ID, param *LoadBalancerUpdateSettingsRequest) (*LoadBalancer, error)
 	Patch(ctx context.Context, zone string, id types.ID, param *LoadBalancerPatchRequest) (*LoadBalancer, error)
+	PatchSettings(ctx context.Context, zone string, id types.ID, param *LoadBalancerPatchSettingsRequest) (*LoadBalancer, error)
 	Delete(ctx context.Context, zone string, id types.ID) error
 	Config(ctx context.Context, zone string, id types.ID) error
 	Boot(ctx context.Context, zone string, id types.ID) error

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -200,7 +200,9 @@ type GSLBAPI interface {
 	Create(ctx context.Context, param *GSLBCreateRequest) (*GSLB, error)
 	Read(ctx context.Context, id types.ID) (*GSLB, error)
 	Update(ctx context.Context, id types.ID, param *GSLBUpdateRequest) (*GSLB, error)
+	UpdateSettings(ctx context.Context, id types.ID, param *GSLBUpdateSettingsRequest) (*GSLB, error)
 	Patch(ctx context.Context, id types.ID, param *GSLBPatchRequest) (*GSLB, error)
+	PatchSettings(ctx context.Context, id types.ID, param *GSLBPatchSettingsRequest) (*GSLB, error)
 	Delete(ctx context.Context, id types.ID) error
 }
 

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -568,7 +568,9 @@ type SimpleMonitorAPI interface {
 	Create(ctx context.Context, param *SimpleMonitorCreateRequest) (*SimpleMonitor, error)
 	Read(ctx context.Context, id types.ID) (*SimpleMonitor, error)
 	Update(ctx context.Context, id types.ID, param *SimpleMonitorUpdateRequest) (*SimpleMonitor, error)
+	UpdateSettings(ctx context.Context, id types.ID, param *SimpleMonitorUpdateSettingsRequest) (*SimpleMonitor, error)
 	Patch(ctx context.Context, id types.ID, param *SimpleMonitorPatchRequest) (*SimpleMonitor, error)
+	PatchSettings(ctx context.Context, id types.ID, param *SimpleMonitorPatchSettingsRequest) (*SimpleMonitor, error)
 	Delete(ctx context.Context, id types.ID) error
 	MonitorResponseTime(ctx context.Context, id types.ID, condition *MonitorCondition) (*ResponseTimeSecActivity, error)
 	HealthStatus(ctx context.Context, id types.ID) (*SimpleMonitorHealthStatus, error)

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -467,7 +467,9 @@ type ProxyLBAPI interface {
 	Create(ctx context.Context, param *ProxyLBCreateRequest) (*ProxyLB, error)
 	Read(ctx context.Context, id types.ID) (*ProxyLB, error)
 	Update(ctx context.Context, id types.ID, param *ProxyLBUpdateRequest) (*ProxyLB, error)
+	UpdateSettings(ctx context.Context, id types.ID, param *ProxyLBUpdateSettingsRequest) (*ProxyLB, error)
 	Patch(ctx context.Context, id types.ID, param *ProxyLBPatchRequest) (*ProxyLB, error)
+	PatchSettings(ctx context.Context, id types.ID, param *ProxyLBPatchSettingsRequest) (*ProxyLB, error)
 	Delete(ctx context.Context, id types.ID) error
 	ChangePlan(ctx context.Context, id types.ID, param *ProxyLBChangePlanRequest) (*ProxyLB, error)
 	GetCertificates(ctx context.Context, id types.ID) (*ProxyLBCertificates, error)

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -201,7 +201,7 @@ type autoBackupUpdateSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
-	CommonServiceItem *naked.AutoBackupSettingsUpdate `json:",omitempty"`
+	CommonServiceItem *naked.AutoBackup `json:",omitempty"`
 }
 
 // autoBackupPatchSettingsRequestEnvelope is envelop of API request
@@ -214,7 +214,7 @@ type autoBackupPatchSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 
-	CommonServiceItem *naked.AutoBackupSettingsUpdate `json:",omitempty"`
+	CommonServiceItem *naked.AutoBackup `json:",omitempty"`
 }
 
 // billByContractResponseEnvelope is envelop of API response
@@ -478,6 +478,19 @@ type databaseUpdateResponseEnvelope struct {
 	Appliance *naked.Database `json:",omitempty"`
 }
 
+// databaseUpdateSettingsRequestEnvelope is envelop of API request
+type databaseUpdateSettingsRequestEnvelope struct {
+	Appliance *naked.DatabaseSettingsUpdate `json:",omitempty"`
+}
+
+// databaseUpdateSettingsResponseEnvelope is envelop of API response
+type databaseUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.Database `json:",omitempty"`
+}
+
 // databasePatchRequestEnvelope is envelop of API request
 type databasePatchRequestEnvelope struct {
 	Appliance *naked.Database `json:",omitempty"`
@@ -485,6 +498,19 @@ type databasePatchRequestEnvelope struct {
 
 // databasePatchResponseEnvelope is envelop of API response
 type databasePatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.Database `json:",omitempty"`
+}
+
+// databasePatchSettingsRequestEnvelope is envelop of API request
+type databasePatchSettingsRequestEnvelope struct {
+	Appliance *naked.DatabaseSettingsUpdate `json:",omitempty"`
+}
+
+// databasePatchSettingsResponseEnvelope is envelop of API response
+type databasePatchSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -1595,6 +1595,19 @@ type mobileGatewayUpdateResponseEnvelope struct {
 	Appliance *naked.MobileGateway `json:",omitempty"`
 }
 
+// mobileGatewayUpdateSettingsRequestEnvelope is envelop of API request
+type mobileGatewayUpdateSettingsRequestEnvelope struct {
+	Appliance *naked.MobileGatewaySettingsUpdate `json:",omitempty"`
+}
+
+// mobileGatewayUpdateSettingsResponseEnvelope is envelop of API response
+type mobileGatewayUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.MobileGateway `json:",omitempty"`
+}
+
 // mobileGatewayPatchRequestEnvelope is envelop of API request
 type mobileGatewayPatchRequestEnvelope struct {
 	Appliance *naked.MobileGateway `json:",omitempty"`
@@ -1602,6 +1615,19 @@ type mobileGatewayPatchRequestEnvelope struct {
 
 // mobileGatewayPatchResponseEnvelope is envelop of API response
 type mobileGatewayPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.MobileGateway `json:",omitempty"`
+}
+
+// mobileGatewayPatchSettingsRequestEnvelope is envelop of API request
+type mobileGatewayPatchSettingsRequestEnvelope struct {
+	Appliance *naked.MobileGatewaySettingsUpdate `json:",omitempty"`
+}
+
+// mobileGatewayPatchSettingsResponseEnvelope is envelop of API response
+type mobileGatewayPatchSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -191,6 +191,32 @@ type autoBackupPatchResponseEnvelope struct {
 	CommonServiceItem *naked.AutoBackup `json:",omitempty"`
 }
 
+// autoBackupUpdateSettingsRequestEnvelope is envelop of API request
+type autoBackupUpdateSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.AutoBackupSettingsUpdate `json:",omitempty"`
+}
+
+// autoBackupUpdateSettingsResponseEnvelope is envelop of API response
+type autoBackupUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.AutoBackupSettingsUpdate `json:",omitempty"`
+}
+
+// autoBackupPatchSettingsRequestEnvelope is envelop of API request
+type autoBackupPatchSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.AutoBackupSettingsUpdate `json:",omitempty"`
+}
+
+// autoBackupPatchSettingsResponseEnvelope is envelop of API response
+type autoBackupPatchSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.AutoBackupSettingsUpdate `json:",omitempty"`
+}
+
 // billByContractResponseEnvelope is envelop of API response
 type billByContractResponseEnvelope struct {
 	Total int `json:",omitempty"` // トータル件数

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -2569,6 +2569,19 @@ type simpleMonitorUpdateResponseEnvelope struct {
 	CommonServiceItem *naked.SimpleMonitor `json:",omitempty"`
 }
 
+// simpleMonitorUpdateSettingsRequestEnvelope is envelop of API request
+type simpleMonitorUpdateSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.SimpleMonitorSettingsUpdate `json:",omitempty"`
+}
+
+// simpleMonitorUpdateSettingsResponseEnvelope is envelop of API response
+type simpleMonitorUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.SimpleMonitor `json:",omitempty"`
+}
+
 // simpleMonitorPatchRequestEnvelope is envelop of API request
 type simpleMonitorPatchRequestEnvelope struct {
 	CommonServiceItem *naked.SimpleMonitor `json:",omitempty"`
@@ -2576,6 +2589,19 @@ type simpleMonitorPatchRequestEnvelope struct {
 
 // simpleMonitorPatchResponseEnvelope is envelop of API response
 type simpleMonitorPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.SimpleMonitor `json:",omitempty"`
+}
+
+// simpleMonitorPatchSettingsRequestEnvelope is envelop of API request
+type simpleMonitorPatchSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.SimpleMonitorSettingsUpdate `json:",omitempty"`
+}
+
+// simpleMonitorPatchSettingsResponseEnvelope is envelop of API response
+type simpleMonitorPatchSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -1475,6 +1475,19 @@ type loadBalancerUpdateResponseEnvelope struct {
 	Appliance *naked.LoadBalancer `json:",omitempty"`
 }
 
+// loadBalancerUpdateSettingsRequestEnvelope is envelop of API request
+type loadBalancerUpdateSettingsRequestEnvelope struct {
+	Appliance *naked.LoadBalancerSettingsUpdate `json:",omitempty"`
+}
+
+// loadBalancerUpdateSettingsResponseEnvelope is envelop of API response
+type loadBalancerUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.LoadBalancer `json:",omitempty"`
+}
+
 // loadBalancerPatchRequestEnvelope is envelop of API request
 type loadBalancerPatchRequestEnvelope struct {
 	Appliance *naked.LoadBalancer `json:",omitempty"`
@@ -1482,6 +1495,19 @@ type loadBalancerPatchRequestEnvelope struct {
 
 // loadBalancerPatchResponseEnvelope is envelop of API response
 type loadBalancerPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.LoadBalancer `json:",omitempty"`
+}
+
+// loadBalancerPatchSettingsRequestEnvelope is envelop of API request
+type loadBalancerPatchSettingsRequestEnvelope struct {
+	Appliance *naked.LoadBalancerSettingsUpdate `json:",omitempty"`
+}
+
+// loadBalancerPatchSettingsResponseEnvelope is envelop of API response
+type loadBalancerPatchSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -2864,6 +2864,19 @@ type vPCRouterUpdateResponseEnvelope struct {
 	Appliance *naked.VPCRouter `json:",omitempty"`
 }
 
+// vPCRouterUpdateSettingsRequestEnvelope is envelop of API request
+type vPCRouterUpdateSettingsRequestEnvelope struct {
+	Appliance *naked.VPCRouterSettingsUpdate `json:",omitempty"`
+}
+
+// vPCRouterUpdateSettingsResponseEnvelope is envelop of API response
+type vPCRouterUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.VPCRouter `json:",omitempty"`
+}
+
 // vPCRouterPatchRequestEnvelope is envelop of API request
 type vPCRouterPatchRequestEnvelope struct {
 	Appliance *naked.VPCRouter `json:",omitempty"`
@@ -2871,6 +2884,19 @@ type vPCRouterPatchRequestEnvelope struct {
 
 // vPCRouterPatchResponseEnvelope is envelop of API response
 type vPCRouterPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Appliance *naked.VPCRouter `json:",omitempty"`
+}
+
+// vPCRouterPatchSettingsRequestEnvelope is envelop of API request
+type vPCRouterPatchSettingsRequestEnvelope struct {
+	Appliance *naked.VPCRouterSettingsUpdate `json:",omitempty"`
+}
+
+// vPCRouterPatchSettingsResponseEnvelope is envelop of API response
+type vPCRouterPatchSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -2098,6 +2098,19 @@ type proxyLBUpdateResponseEnvelope struct {
 	CommonServiceItem *naked.ProxyLB `json:",omitempty"`
 }
 
+// proxyLBUpdateSettingsRequestEnvelope is envelop of API request
+type proxyLBUpdateSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.ProxyLBSettingsUpdate `json:",omitempty"`
+}
+
+// proxyLBUpdateSettingsResponseEnvelope is envelop of API response
+type proxyLBUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.ProxyLB `json:",omitempty"`
+}
+
 // proxyLBPatchRequestEnvelope is envelop of API request
 type proxyLBPatchRequestEnvelope struct {
 	CommonServiceItem *naked.ProxyLB `json:",omitempty"`
@@ -2105,6 +2118,19 @@ type proxyLBPatchRequestEnvelope struct {
 
 // proxyLBPatchResponseEnvelope is envelop of API response
 type proxyLBPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.ProxyLB `json:",omitempty"`
+}
+
+// proxyLBPatchSettingsRequestEnvelope is envelop of API request
+type proxyLBPatchSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.ProxyLBSettingsUpdate `json:",omitempty"`
+}
+
+// proxyLBPatchSettingsResponseEnvelope is envelop of API response
+type proxyLBPatchSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -889,6 +889,19 @@ type gSLBUpdateResponseEnvelope struct {
 	CommonServiceItem *naked.GSLB `json:",omitempty"`
 }
 
+// gSLBUpdateSettingsRequestEnvelope is envelop of API request
+type gSLBUpdateSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.GSLBSettingsUpdate `json:",omitempty"`
+}
+
+// gSLBUpdateSettingsResponseEnvelope is envelop of API response
+type gSLBUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.GSLB `json:",omitempty"`
+}
+
 // gSLBPatchRequestEnvelope is envelop of API request
 type gSLBPatchRequestEnvelope struct {
 	CommonServiceItem *naked.GSLB `json:",omitempty"`
@@ -896,6 +909,19 @@ type gSLBPatchRequestEnvelope struct {
 
 // gSLBPatchResponseEnvelope is envelop of API response
 type gSLBPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.GSLB `json:",omitempty"`
+}
+
+// gSLBPatchSettingsRequestEnvelope is envelop of API request
+type gSLBPatchSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.GSLBSettingsUpdate `json:",omitempty"`
+}
+
+// gSLBPatchSettingsResponseEnvelope is envelop of API response
+type gSLBPatchSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -797,6 +797,19 @@ type dNSUpdateResponseEnvelope struct {
 	CommonServiceItem *naked.DNS `json:",omitempty"`
 }
 
+// dNSUpdateSettingsRequestEnvelope is envelop of API request
+type dNSUpdateSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.DNSSettingsUpdate `json:",omitempty"`
+}
+
+// dNSUpdateSettingsResponseEnvelope is envelop of API response
+type dNSUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.DNS `json:",omitempty"`
+}
+
 // dNSPatchRequestEnvelope is envelop of API request
 type dNSPatchRequestEnvelope struct {
 	CommonServiceItem *naked.DNS `json:",omitempty"`
@@ -804,6 +817,19 @@ type dNSPatchRequestEnvelope struct {
 
 // dNSPatchResponseEnvelope is envelop of API response
 type dNSPatchResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.DNS `json:",omitempty"`
+}
+
+// dNSPatchSettingsRequestEnvelope is envelop of API request
+type dNSPatchSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.DNSSettingsUpdate `json:",omitempty"`
+}
+
+// dNSPatchSettingsResponseEnvelope is envelop of API response
+type dNSPatchSettingsResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
 	Success types.APIResult `json:",omitempty"`      // success項目
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -2204,6 +2204,154 @@ func (o *AutoBackupPatchRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* AutoBackupUpdateSettingsRequest
+*************************************************/
+
+// AutoBackupUpdateSettingsRequest represents API parameter/response structure
+type AutoBackupUpdateSettingsRequest struct {
+	BackupSpanWeekdays      []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
+	MaximumNumberOfArchives int                        `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
+	SettingsHash            string                     `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *AutoBackupUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *AutoBackupUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		BackupSpanWeekdays      []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
+		MaximumNumberOfArchives int                        `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
+		SettingsHash            string                     `json:",omitempty" mapconv:",omitempty"`
+		BackupSpanType          types.EBackupSpanType      `mapconv:"Settings.Autobackup.BackupSpanType"`
+	}{
+		BackupSpanWeekdays:      o.GetBackupSpanWeekdays(),
+		MaximumNumberOfArchives: o.GetMaximumNumberOfArchives(),
+		SettingsHash:            o.GetSettingsHash(),
+		BackupSpanType:          types.BackupSpanTypes.Weekdays,
+	}
+}
+
+// GetBackupSpanWeekdays returns value of BackupSpanWeekdays
+func (o *AutoBackupUpdateSettingsRequest) GetBackupSpanWeekdays() []types.EBackupSpanWeekday {
+	return o.BackupSpanWeekdays
+}
+
+// SetBackupSpanWeekdays sets value to BackupSpanWeekdays
+func (o *AutoBackupUpdateSettingsRequest) SetBackupSpanWeekdays(v []types.EBackupSpanWeekday) {
+	o.BackupSpanWeekdays = v
+}
+
+// GetMaximumNumberOfArchives returns value of MaximumNumberOfArchives
+func (o *AutoBackupUpdateSettingsRequest) GetMaximumNumberOfArchives() int {
+	return o.MaximumNumberOfArchives
+}
+
+// SetMaximumNumberOfArchives sets value to MaximumNumberOfArchives
+func (o *AutoBackupUpdateSettingsRequest) SetMaximumNumberOfArchives(v int) {
+	o.MaximumNumberOfArchives = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *AutoBackupUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *AutoBackupUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* AutoBackupPatchSettingsRequest
+*************************************************/
+
+// AutoBackupPatchSettingsRequest represents API parameter/response structure
+type AutoBackupPatchSettingsRequest struct {
+	BackupSpanWeekdays                  []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
+	PatchEmptyToBackupSpanWeekdays      bool
+	MaximumNumberOfArchives             int `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
+	PatchEmptyToMaximumNumberOfArchives bool
+	SettingsHash                        string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *AutoBackupPatchSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *AutoBackupPatchSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		BackupSpanWeekdays                  []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
+		PatchEmptyToBackupSpanWeekdays      bool
+		MaximumNumberOfArchives             int `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
+		PatchEmptyToMaximumNumberOfArchives bool
+		SettingsHash                        string                `json:",omitempty" mapconv:",omitempty"`
+		BackupSpanType                      types.EBackupSpanType `mapconv:"Settings.Autobackup.BackupSpanType"`
+	}{
+		BackupSpanWeekdays:                  o.GetBackupSpanWeekdays(),
+		PatchEmptyToBackupSpanWeekdays:      o.GetPatchEmptyToBackupSpanWeekdays(),
+		MaximumNumberOfArchives:             o.GetMaximumNumberOfArchives(),
+		PatchEmptyToMaximumNumberOfArchives: o.GetPatchEmptyToMaximumNumberOfArchives(),
+		SettingsHash:                        o.GetSettingsHash(),
+		BackupSpanType:                      types.BackupSpanTypes.Weekdays,
+	}
+}
+
+// GetBackupSpanWeekdays returns value of BackupSpanWeekdays
+func (o *AutoBackupPatchSettingsRequest) GetBackupSpanWeekdays() []types.EBackupSpanWeekday {
+	return o.BackupSpanWeekdays
+}
+
+// SetBackupSpanWeekdays sets value to BackupSpanWeekdays
+func (o *AutoBackupPatchSettingsRequest) SetBackupSpanWeekdays(v []types.EBackupSpanWeekday) {
+	o.BackupSpanWeekdays = v
+}
+
+// GetPatchEmptyToBackupSpanWeekdays returns value of PatchEmptyToBackupSpanWeekdays
+func (o *AutoBackupPatchSettingsRequest) GetPatchEmptyToBackupSpanWeekdays() bool {
+	return o.PatchEmptyToBackupSpanWeekdays
+}
+
+// SetPatchEmptyToBackupSpanWeekdays sets value to PatchEmptyToBackupSpanWeekdays
+func (o *AutoBackupPatchSettingsRequest) SetPatchEmptyToBackupSpanWeekdays(v bool) {
+	o.PatchEmptyToBackupSpanWeekdays = v
+}
+
+// GetMaximumNumberOfArchives returns value of MaximumNumberOfArchives
+func (o *AutoBackupPatchSettingsRequest) GetMaximumNumberOfArchives() int {
+	return o.MaximumNumberOfArchives
+}
+
+// SetMaximumNumberOfArchives sets value to MaximumNumberOfArchives
+func (o *AutoBackupPatchSettingsRequest) SetMaximumNumberOfArchives(v int) {
+	o.MaximumNumberOfArchives = v
+}
+
+// GetPatchEmptyToMaximumNumberOfArchives returns value of PatchEmptyToMaximumNumberOfArchives
+func (o *AutoBackupPatchSettingsRequest) GetPatchEmptyToMaximumNumberOfArchives() bool {
+	return o.PatchEmptyToMaximumNumberOfArchives
+}
+
+// SetPatchEmptyToMaximumNumberOfArchives sets value to PatchEmptyToMaximumNumberOfArchives
+func (o *AutoBackupPatchSettingsRequest) SetPatchEmptyToMaximumNumberOfArchives(v bool) {
+	o.PatchEmptyToMaximumNumberOfArchives = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *AutoBackupPatchSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *AutoBackupPatchSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * Bill
 *************************************************/
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -5358,6 +5358,78 @@ func (o *DatabaseUpdateRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* DatabaseUpdateSettingsRequest
+*************************************************/
+
+// DatabaseUpdateSettingsRequest represents API parameter/response structure
+type DatabaseUpdateSettingsRequest struct {
+	CommonSetting      *DatabaseSettingCommon      `mapconv:"Settings.DBConf.Common,recursive"`
+	BackupSetting      *DatabaseSettingBackup      `mapconv:"Settings.DBConf.Backup,recursive"`
+	ReplicationSetting *DatabaseReplicationSetting `mapconv:"Settings.DBConf.Replication,recursive"`
+	SettingsHash       string                      `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *DatabaseUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *DatabaseUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		CommonSetting      *DatabaseSettingCommon      `mapconv:"Settings.DBConf.Common,recursive"`
+		BackupSetting      *DatabaseSettingBackup      `mapconv:"Settings.DBConf.Backup,recursive"`
+		ReplicationSetting *DatabaseReplicationSetting `mapconv:"Settings.DBConf.Replication,recursive"`
+		SettingsHash       string                      `json:",omitempty" mapconv:",omitempty"`
+	}{
+		CommonSetting:      o.GetCommonSetting(),
+		BackupSetting:      o.GetBackupSetting(),
+		ReplicationSetting: o.GetReplicationSetting(),
+		SettingsHash:       o.GetSettingsHash(),
+	}
+}
+
+// GetCommonSetting returns value of CommonSetting
+func (o *DatabaseUpdateSettingsRequest) GetCommonSetting() *DatabaseSettingCommon {
+	return o.CommonSetting
+}
+
+// SetCommonSetting sets value to CommonSetting
+func (o *DatabaseUpdateSettingsRequest) SetCommonSetting(v *DatabaseSettingCommon) {
+	o.CommonSetting = v
+}
+
+// GetBackupSetting returns value of BackupSetting
+func (o *DatabaseUpdateSettingsRequest) GetBackupSetting() *DatabaseSettingBackup {
+	return o.BackupSetting
+}
+
+// SetBackupSetting sets value to BackupSetting
+func (o *DatabaseUpdateSettingsRequest) SetBackupSetting(v *DatabaseSettingBackup) {
+	o.BackupSetting = v
+}
+
+// GetReplicationSetting returns value of ReplicationSetting
+func (o *DatabaseUpdateSettingsRequest) GetReplicationSetting() *DatabaseReplicationSetting {
+	return o.ReplicationSetting
+}
+
+// SetReplicationSetting sets value to ReplicationSetting
+func (o *DatabaseUpdateSettingsRequest) SetReplicationSetting(v *DatabaseReplicationSetting) {
+	o.ReplicationSetting = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *DatabaseUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *DatabaseUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * DatabasePatchRequest
 *************************************************/
 
@@ -5576,6 +5648,117 @@ func (o *DatabasePatchRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *DatabasePatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* DatabasePatchSettingsRequest
+*************************************************/
+
+// DatabasePatchSettingsRequest represents API parameter/response structure
+type DatabasePatchSettingsRequest struct {
+	CommonSetting                  *DatabaseSettingCommon `mapconv:"Settings.DBConf.Common,recursive"`
+	PatchEmptyToCommonSetting      bool
+	BackupSetting                  *DatabaseSettingBackup `mapconv:"Settings.DBConf.Backup,recursive"`
+	PatchEmptyToBackupSetting      bool
+	ReplicationSetting             *DatabaseReplicationSetting `mapconv:"Settings.DBConf.Replication,recursive"`
+	PatchEmptyToReplicationSetting bool
+	SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *DatabasePatchSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *DatabasePatchSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		CommonSetting                  *DatabaseSettingCommon `mapconv:"Settings.DBConf.Common,recursive"`
+		PatchEmptyToCommonSetting      bool
+		BackupSetting                  *DatabaseSettingBackup `mapconv:"Settings.DBConf.Backup,recursive"`
+		PatchEmptyToBackupSetting      bool
+		ReplicationSetting             *DatabaseReplicationSetting `mapconv:"Settings.DBConf.Replication,recursive"`
+		PatchEmptyToReplicationSetting bool
+		SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		CommonSetting:                  o.GetCommonSetting(),
+		PatchEmptyToCommonSetting:      o.GetPatchEmptyToCommonSetting(),
+		BackupSetting:                  o.GetBackupSetting(),
+		PatchEmptyToBackupSetting:      o.GetPatchEmptyToBackupSetting(),
+		ReplicationSetting:             o.GetReplicationSetting(),
+		PatchEmptyToReplicationSetting: o.GetPatchEmptyToReplicationSetting(),
+		SettingsHash:                   o.GetSettingsHash(),
+	}
+}
+
+// GetCommonSetting returns value of CommonSetting
+func (o *DatabasePatchSettingsRequest) GetCommonSetting() *DatabaseSettingCommon {
+	return o.CommonSetting
+}
+
+// SetCommonSetting sets value to CommonSetting
+func (o *DatabasePatchSettingsRequest) SetCommonSetting(v *DatabaseSettingCommon) {
+	o.CommonSetting = v
+}
+
+// GetPatchEmptyToCommonSetting returns value of PatchEmptyToCommonSetting
+func (o *DatabasePatchSettingsRequest) GetPatchEmptyToCommonSetting() bool {
+	return o.PatchEmptyToCommonSetting
+}
+
+// SetPatchEmptyToCommonSetting sets value to PatchEmptyToCommonSetting
+func (o *DatabasePatchSettingsRequest) SetPatchEmptyToCommonSetting(v bool) {
+	o.PatchEmptyToCommonSetting = v
+}
+
+// GetBackupSetting returns value of BackupSetting
+func (o *DatabasePatchSettingsRequest) GetBackupSetting() *DatabaseSettingBackup {
+	return o.BackupSetting
+}
+
+// SetBackupSetting sets value to BackupSetting
+func (o *DatabasePatchSettingsRequest) SetBackupSetting(v *DatabaseSettingBackup) {
+	o.BackupSetting = v
+}
+
+// GetPatchEmptyToBackupSetting returns value of PatchEmptyToBackupSetting
+func (o *DatabasePatchSettingsRequest) GetPatchEmptyToBackupSetting() bool {
+	return o.PatchEmptyToBackupSetting
+}
+
+// SetPatchEmptyToBackupSetting sets value to PatchEmptyToBackupSetting
+func (o *DatabasePatchSettingsRequest) SetPatchEmptyToBackupSetting(v bool) {
+	o.PatchEmptyToBackupSetting = v
+}
+
+// GetReplicationSetting returns value of ReplicationSetting
+func (o *DatabasePatchSettingsRequest) GetReplicationSetting() *DatabaseReplicationSetting {
+	return o.ReplicationSetting
+}
+
+// SetReplicationSetting sets value to ReplicationSetting
+func (o *DatabasePatchSettingsRequest) SetReplicationSetting(v *DatabaseReplicationSetting) {
+	o.ReplicationSetting = v
+}
+
+// GetPatchEmptyToReplicationSetting returns value of PatchEmptyToReplicationSetting
+func (o *DatabasePatchSettingsRequest) GetPatchEmptyToReplicationSetting() bool {
+	return o.PatchEmptyToReplicationSetting
+}
+
+// SetPatchEmptyToReplicationSetting sets value to PatchEmptyToReplicationSetting
+func (o *DatabasePatchSettingsRequest) SetPatchEmptyToReplicationSetting(v bool) {
+	o.PatchEmptyToReplicationSetting = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *DatabasePatchSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *DatabasePatchSettingsRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -24985,6 +24985,149 @@ func (o *SimpleMonitorUpdateRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* SimpleMonitorUpdateSettingsRequest
+*************************************************/
+
+// SimpleMonitorUpdateSettingsRequest represents API parameter/response structure
+type SimpleMonitorUpdateSettingsRequest struct {
+	DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+	Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
+	HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
+	NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
+	NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
+	NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
+	SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
+	NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+	SettingsHash       string                    `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *SimpleMonitorUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *SimpleMonitorUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+		Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
+		HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
+		NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
+		NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
+		NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
+		SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
+		NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+		SettingsHash       string                    `json:",omitempty" mapconv:",omitempty"`
+	}{
+		DelayLoop:          o.GetDelayLoop(),
+		Enabled:            o.GetEnabled(),
+		HealthCheck:        o.GetHealthCheck(),
+		NotifyEmailEnabled: o.GetNotifyEmailEnabled(),
+		NotifyEmailHTML:    o.GetNotifyEmailHTML(),
+		NotifySlackEnabled: o.GetNotifySlackEnabled(),
+		SlackWebhooksURL:   o.GetSlackWebhooksURL(),
+		NotifyInterval:     o.GetNotifyInterval(),
+		SettingsHash:       o.GetSettingsHash(),
+	}
+}
+
+// GetDelayLoop returns value of DelayLoop
+func (o *SimpleMonitorUpdateSettingsRequest) GetDelayLoop() int {
+	if o.DelayLoop == 0 {
+		return 60
+	}
+	return o.DelayLoop
+}
+
+// SetDelayLoop sets value to DelayLoop
+func (o *SimpleMonitorUpdateSettingsRequest) SetDelayLoop(v int) {
+	o.DelayLoop = v
+}
+
+// GetEnabled returns value of Enabled
+func (o *SimpleMonitorUpdateSettingsRequest) GetEnabled() types.StringFlag {
+	return o.Enabled
+}
+
+// SetEnabled sets value to Enabled
+func (o *SimpleMonitorUpdateSettingsRequest) SetEnabled(v types.StringFlag) {
+	o.Enabled = v
+}
+
+// GetHealthCheck returns value of HealthCheck
+func (o *SimpleMonitorUpdateSettingsRequest) GetHealthCheck() *SimpleMonitorHealthCheck {
+	return o.HealthCheck
+}
+
+// SetHealthCheck sets value to HealthCheck
+func (o *SimpleMonitorUpdateSettingsRequest) SetHealthCheck(v *SimpleMonitorHealthCheck) {
+	o.HealthCheck = v
+}
+
+// GetNotifyEmailEnabled returns value of NotifyEmailEnabled
+func (o *SimpleMonitorUpdateSettingsRequest) GetNotifyEmailEnabled() types.StringFlag {
+	return o.NotifyEmailEnabled
+}
+
+// SetNotifyEmailEnabled sets value to NotifyEmailEnabled
+func (o *SimpleMonitorUpdateSettingsRequest) SetNotifyEmailEnabled(v types.StringFlag) {
+	o.NotifyEmailEnabled = v
+}
+
+// GetNotifyEmailHTML returns value of NotifyEmailHTML
+func (o *SimpleMonitorUpdateSettingsRequest) GetNotifyEmailHTML() types.StringFlag {
+	return o.NotifyEmailHTML
+}
+
+// SetNotifyEmailHTML sets value to NotifyEmailHTML
+func (o *SimpleMonitorUpdateSettingsRequest) SetNotifyEmailHTML(v types.StringFlag) {
+	o.NotifyEmailHTML = v
+}
+
+// GetNotifySlackEnabled returns value of NotifySlackEnabled
+func (o *SimpleMonitorUpdateSettingsRequest) GetNotifySlackEnabled() types.StringFlag {
+	return o.NotifySlackEnabled
+}
+
+// SetNotifySlackEnabled sets value to NotifySlackEnabled
+func (o *SimpleMonitorUpdateSettingsRequest) SetNotifySlackEnabled(v types.StringFlag) {
+	o.NotifySlackEnabled = v
+}
+
+// GetSlackWebhooksURL returns value of SlackWebhooksURL
+func (o *SimpleMonitorUpdateSettingsRequest) GetSlackWebhooksURL() string {
+	return o.SlackWebhooksURL
+}
+
+// SetSlackWebhooksURL sets value to SlackWebhooksURL
+func (o *SimpleMonitorUpdateSettingsRequest) SetSlackWebhooksURL(v string) {
+	o.SlackWebhooksURL = v
+}
+
+// GetNotifyInterval returns value of NotifyInterval
+func (o *SimpleMonitorUpdateSettingsRequest) GetNotifyInterval() int {
+	if o.NotifyInterval == 0 {
+		return 7200
+	}
+	return o.NotifyInterval
+}
+
+// SetNotifyInterval sets value to NotifyInterval
+func (o *SimpleMonitorUpdateSettingsRequest) SetNotifyInterval(v int) {
+	o.NotifyInterval = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *SimpleMonitorUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *SimpleMonitorUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * SimpleMonitorPatchRequest
 *************************************************/
 
@@ -25326,6 +25469,253 @@ func (o *SimpleMonitorPatchRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *SimpleMonitorPatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* SimpleMonitorPatchSettingsRequest
+*************************************************/
+
+// SimpleMonitorPatchSettingsRequest represents API parameter/response structure
+type SimpleMonitorPatchSettingsRequest struct {
+	DelayLoop                      int `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+	PatchEmptyToDelayLoop          bool
+	Enabled                        types.StringFlag `mapconv:"Settings.SimpleMonitor.Enabled"`
+	PatchEmptyToEnabled            bool
+	HealthCheck                    *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
+	PatchEmptyToHealthCheck        bool
+	NotifyEmailEnabled             types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
+	PatchEmptyToNotifyEmailEnabled bool
+	NotifyEmailHTML                types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
+	PatchEmptyToNotifyEmailHTML    bool
+	NotifySlackEnabled             types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
+	PatchEmptyToNotifySlackEnabled bool
+	SlackWebhooksURL               string `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
+	PatchEmptyToSlackWebhooksURL   bool
+	NotifyInterval                 int `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+	PatchEmptyToNotifyInterval     bool
+	SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *SimpleMonitorPatchSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *SimpleMonitorPatchSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		DelayLoop                      int `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+		PatchEmptyToDelayLoop          bool
+		Enabled                        types.StringFlag `mapconv:"Settings.SimpleMonitor.Enabled"`
+		PatchEmptyToEnabled            bool
+		HealthCheck                    *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
+		PatchEmptyToHealthCheck        bool
+		NotifyEmailEnabled             types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
+		PatchEmptyToNotifyEmailEnabled bool
+		NotifyEmailHTML                types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
+		PatchEmptyToNotifyEmailHTML    bool
+		NotifySlackEnabled             types.StringFlag `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
+		PatchEmptyToNotifySlackEnabled bool
+		SlackWebhooksURL               string `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
+		PatchEmptyToSlackWebhooksURL   bool
+		NotifyInterval                 int `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+		PatchEmptyToNotifyInterval     bool
+		SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		DelayLoop:                      o.GetDelayLoop(),
+		PatchEmptyToDelayLoop:          o.GetPatchEmptyToDelayLoop(),
+		Enabled:                        o.GetEnabled(),
+		PatchEmptyToEnabled:            o.GetPatchEmptyToEnabled(),
+		HealthCheck:                    o.GetHealthCheck(),
+		PatchEmptyToHealthCheck:        o.GetPatchEmptyToHealthCheck(),
+		NotifyEmailEnabled:             o.GetNotifyEmailEnabled(),
+		PatchEmptyToNotifyEmailEnabled: o.GetPatchEmptyToNotifyEmailEnabled(),
+		NotifyEmailHTML:                o.GetNotifyEmailHTML(),
+		PatchEmptyToNotifyEmailHTML:    o.GetPatchEmptyToNotifyEmailHTML(),
+		NotifySlackEnabled:             o.GetNotifySlackEnabled(),
+		PatchEmptyToNotifySlackEnabled: o.GetPatchEmptyToNotifySlackEnabled(),
+		SlackWebhooksURL:               o.GetSlackWebhooksURL(),
+		PatchEmptyToSlackWebhooksURL:   o.GetPatchEmptyToSlackWebhooksURL(),
+		NotifyInterval:                 o.GetNotifyInterval(),
+		PatchEmptyToNotifyInterval:     o.GetPatchEmptyToNotifyInterval(),
+		SettingsHash:                   o.GetSettingsHash(),
+	}
+}
+
+// GetDelayLoop returns value of DelayLoop
+func (o *SimpleMonitorPatchSettingsRequest) GetDelayLoop() int {
+	if o.DelayLoop == 0 {
+		return 60
+	}
+	return o.DelayLoop
+}
+
+// SetDelayLoop sets value to DelayLoop
+func (o *SimpleMonitorPatchSettingsRequest) SetDelayLoop(v int) {
+	o.DelayLoop = v
+}
+
+// GetPatchEmptyToDelayLoop returns value of PatchEmptyToDelayLoop
+func (o *SimpleMonitorPatchSettingsRequest) GetPatchEmptyToDelayLoop() bool {
+	return o.PatchEmptyToDelayLoop
+}
+
+// SetPatchEmptyToDelayLoop sets value to PatchEmptyToDelayLoop
+func (o *SimpleMonitorPatchSettingsRequest) SetPatchEmptyToDelayLoop(v bool) {
+	o.PatchEmptyToDelayLoop = v
+}
+
+// GetEnabled returns value of Enabled
+func (o *SimpleMonitorPatchSettingsRequest) GetEnabled() types.StringFlag {
+	return o.Enabled
+}
+
+// SetEnabled sets value to Enabled
+func (o *SimpleMonitorPatchSettingsRequest) SetEnabled(v types.StringFlag) {
+	o.Enabled = v
+}
+
+// GetPatchEmptyToEnabled returns value of PatchEmptyToEnabled
+func (o *SimpleMonitorPatchSettingsRequest) GetPatchEmptyToEnabled() bool {
+	return o.PatchEmptyToEnabled
+}
+
+// SetPatchEmptyToEnabled sets value to PatchEmptyToEnabled
+func (o *SimpleMonitorPatchSettingsRequest) SetPatchEmptyToEnabled(v bool) {
+	o.PatchEmptyToEnabled = v
+}
+
+// GetHealthCheck returns value of HealthCheck
+func (o *SimpleMonitorPatchSettingsRequest) GetHealthCheck() *SimpleMonitorHealthCheck {
+	return o.HealthCheck
+}
+
+// SetHealthCheck sets value to HealthCheck
+func (o *SimpleMonitorPatchSettingsRequest) SetHealthCheck(v *SimpleMonitorHealthCheck) {
+	o.HealthCheck = v
+}
+
+// GetPatchEmptyToHealthCheck returns value of PatchEmptyToHealthCheck
+func (o *SimpleMonitorPatchSettingsRequest) GetPatchEmptyToHealthCheck() bool {
+	return o.PatchEmptyToHealthCheck
+}
+
+// SetPatchEmptyToHealthCheck sets value to PatchEmptyToHealthCheck
+func (o *SimpleMonitorPatchSettingsRequest) SetPatchEmptyToHealthCheck(v bool) {
+	o.PatchEmptyToHealthCheck = v
+}
+
+// GetNotifyEmailEnabled returns value of NotifyEmailEnabled
+func (o *SimpleMonitorPatchSettingsRequest) GetNotifyEmailEnabled() types.StringFlag {
+	return o.NotifyEmailEnabled
+}
+
+// SetNotifyEmailEnabled sets value to NotifyEmailEnabled
+func (o *SimpleMonitorPatchSettingsRequest) SetNotifyEmailEnabled(v types.StringFlag) {
+	o.NotifyEmailEnabled = v
+}
+
+// GetPatchEmptyToNotifyEmailEnabled returns value of PatchEmptyToNotifyEmailEnabled
+func (o *SimpleMonitorPatchSettingsRequest) GetPatchEmptyToNotifyEmailEnabled() bool {
+	return o.PatchEmptyToNotifyEmailEnabled
+}
+
+// SetPatchEmptyToNotifyEmailEnabled sets value to PatchEmptyToNotifyEmailEnabled
+func (o *SimpleMonitorPatchSettingsRequest) SetPatchEmptyToNotifyEmailEnabled(v bool) {
+	o.PatchEmptyToNotifyEmailEnabled = v
+}
+
+// GetNotifyEmailHTML returns value of NotifyEmailHTML
+func (o *SimpleMonitorPatchSettingsRequest) GetNotifyEmailHTML() types.StringFlag {
+	return o.NotifyEmailHTML
+}
+
+// SetNotifyEmailHTML sets value to NotifyEmailHTML
+func (o *SimpleMonitorPatchSettingsRequest) SetNotifyEmailHTML(v types.StringFlag) {
+	o.NotifyEmailHTML = v
+}
+
+// GetPatchEmptyToNotifyEmailHTML returns value of PatchEmptyToNotifyEmailHTML
+func (o *SimpleMonitorPatchSettingsRequest) GetPatchEmptyToNotifyEmailHTML() bool {
+	return o.PatchEmptyToNotifyEmailHTML
+}
+
+// SetPatchEmptyToNotifyEmailHTML sets value to PatchEmptyToNotifyEmailHTML
+func (o *SimpleMonitorPatchSettingsRequest) SetPatchEmptyToNotifyEmailHTML(v bool) {
+	o.PatchEmptyToNotifyEmailHTML = v
+}
+
+// GetNotifySlackEnabled returns value of NotifySlackEnabled
+func (o *SimpleMonitorPatchSettingsRequest) GetNotifySlackEnabled() types.StringFlag {
+	return o.NotifySlackEnabled
+}
+
+// SetNotifySlackEnabled sets value to NotifySlackEnabled
+func (o *SimpleMonitorPatchSettingsRequest) SetNotifySlackEnabled(v types.StringFlag) {
+	o.NotifySlackEnabled = v
+}
+
+// GetPatchEmptyToNotifySlackEnabled returns value of PatchEmptyToNotifySlackEnabled
+func (o *SimpleMonitorPatchSettingsRequest) GetPatchEmptyToNotifySlackEnabled() bool {
+	return o.PatchEmptyToNotifySlackEnabled
+}
+
+// SetPatchEmptyToNotifySlackEnabled sets value to PatchEmptyToNotifySlackEnabled
+func (o *SimpleMonitorPatchSettingsRequest) SetPatchEmptyToNotifySlackEnabled(v bool) {
+	o.PatchEmptyToNotifySlackEnabled = v
+}
+
+// GetSlackWebhooksURL returns value of SlackWebhooksURL
+func (o *SimpleMonitorPatchSettingsRequest) GetSlackWebhooksURL() string {
+	return o.SlackWebhooksURL
+}
+
+// SetSlackWebhooksURL sets value to SlackWebhooksURL
+func (o *SimpleMonitorPatchSettingsRequest) SetSlackWebhooksURL(v string) {
+	o.SlackWebhooksURL = v
+}
+
+// GetPatchEmptyToSlackWebhooksURL returns value of PatchEmptyToSlackWebhooksURL
+func (o *SimpleMonitorPatchSettingsRequest) GetPatchEmptyToSlackWebhooksURL() bool {
+	return o.PatchEmptyToSlackWebhooksURL
+}
+
+// SetPatchEmptyToSlackWebhooksURL sets value to PatchEmptyToSlackWebhooksURL
+func (o *SimpleMonitorPatchSettingsRequest) SetPatchEmptyToSlackWebhooksURL(v bool) {
+	o.PatchEmptyToSlackWebhooksURL = v
+}
+
+// GetNotifyInterval returns value of NotifyInterval
+func (o *SimpleMonitorPatchSettingsRequest) GetNotifyInterval() int {
+	if o.NotifyInterval == 0 {
+		return 7200
+	}
+	return o.NotifyInterval
+}
+
+// SetNotifyInterval sets value to NotifyInterval
+func (o *SimpleMonitorPatchSettingsRequest) SetNotifyInterval(v int) {
+	o.NotifyInterval = v
+}
+
+// GetPatchEmptyToNotifyInterval returns value of PatchEmptyToNotifyInterval
+func (o *SimpleMonitorPatchSettingsRequest) GetPatchEmptyToNotifyInterval() bool {
+	return o.PatchEmptyToNotifyInterval
+}
+
+// SetPatchEmptyToNotifyInterval sets value to PatchEmptyToNotifyInterval
+func (o *SimpleMonitorPatchSettingsRequest) SetPatchEmptyToNotifyInterval(v bool) {
+	o.PatchEmptyToNotifyInterval = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *SimpleMonitorPatchSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *SimpleMonitorPatchSettingsRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -19851,6 +19851,130 @@ func (o *ProxyLBUpdateRequest) SetIconID(v types.ID) {
 }
 
 /*************************************************
+* ProxyLBUpdateSettingsRequest
+*************************************************/
+
+// ProxyLBUpdateSettingsRequest represents API parameter/response structure
+type ProxyLBUpdateSettingsRequest struct {
+	HealthCheck   *ProxyLBHealthCheck   `mapconv:"Settings.ProxyLB.HealthCheck,recursive"`
+	SorryServer   *ProxyLBSorryServer   `mapconv:"Settings.ProxyLB.SorryServer,recursive"`
+	BindPorts     []*ProxyLBBindPort    `mapconv:"Settings.ProxyLB.[]BindPorts,recursive"`
+	Servers       []*ProxyLBServer      `mapconv:"Settings.ProxyLB.[]Servers,recursive"`
+	LetsEncrypt   *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
+	StickySession *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
+	Timeout       *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+	SettingsHash  string                `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *ProxyLBUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ProxyLBUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		HealthCheck   *ProxyLBHealthCheck   `mapconv:"Settings.ProxyLB.HealthCheck,recursive"`
+		SorryServer   *ProxyLBSorryServer   `mapconv:"Settings.ProxyLB.SorryServer,recursive"`
+		BindPorts     []*ProxyLBBindPort    `mapconv:"Settings.ProxyLB.[]BindPorts,recursive"`
+		Servers       []*ProxyLBServer      `mapconv:"Settings.ProxyLB.[]Servers,recursive"`
+		LetsEncrypt   *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
+		StickySession *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
+		Timeout       *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+		SettingsHash  string                `json:",omitempty" mapconv:",omitempty"`
+	}{
+		HealthCheck:   o.GetHealthCheck(),
+		SorryServer:   o.GetSorryServer(),
+		BindPorts:     o.GetBindPorts(),
+		Servers:       o.GetServers(),
+		LetsEncrypt:   o.GetLetsEncrypt(),
+		StickySession: o.GetStickySession(),
+		Timeout:       o.GetTimeout(),
+		SettingsHash:  o.GetSettingsHash(),
+	}
+}
+
+// GetHealthCheck returns value of HealthCheck
+func (o *ProxyLBUpdateSettingsRequest) GetHealthCheck() *ProxyLBHealthCheck {
+	return o.HealthCheck
+}
+
+// SetHealthCheck sets value to HealthCheck
+func (o *ProxyLBUpdateSettingsRequest) SetHealthCheck(v *ProxyLBHealthCheck) {
+	o.HealthCheck = v
+}
+
+// GetSorryServer returns value of SorryServer
+func (o *ProxyLBUpdateSettingsRequest) GetSorryServer() *ProxyLBSorryServer {
+	return o.SorryServer
+}
+
+// SetSorryServer sets value to SorryServer
+func (o *ProxyLBUpdateSettingsRequest) SetSorryServer(v *ProxyLBSorryServer) {
+	o.SorryServer = v
+}
+
+// GetBindPorts returns value of BindPorts
+func (o *ProxyLBUpdateSettingsRequest) GetBindPorts() []*ProxyLBBindPort {
+	return o.BindPorts
+}
+
+// SetBindPorts sets value to BindPorts
+func (o *ProxyLBUpdateSettingsRequest) SetBindPorts(v []*ProxyLBBindPort) {
+	o.BindPorts = v
+}
+
+// GetServers returns value of Servers
+func (o *ProxyLBUpdateSettingsRequest) GetServers() []*ProxyLBServer {
+	return o.Servers
+}
+
+// SetServers sets value to Servers
+func (o *ProxyLBUpdateSettingsRequest) SetServers(v []*ProxyLBServer) {
+	o.Servers = v
+}
+
+// GetLetsEncrypt returns value of LetsEncrypt
+func (o *ProxyLBUpdateSettingsRequest) GetLetsEncrypt() *ProxyLBACMESetting {
+	return o.LetsEncrypt
+}
+
+// SetLetsEncrypt sets value to LetsEncrypt
+func (o *ProxyLBUpdateSettingsRequest) SetLetsEncrypt(v *ProxyLBACMESetting) {
+	o.LetsEncrypt = v
+}
+
+// GetStickySession returns value of StickySession
+func (o *ProxyLBUpdateSettingsRequest) GetStickySession() *ProxyLBStickySession {
+	return o.StickySession
+}
+
+// SetStickySession sets value to StickySession
+func (o *ProxyLBUpdateSettingsRequest) SetStickySession(v *ProxyLBStickySession) {
+	o.StickySession = v
+}
+
+// GetTimeout returns value of Timeout
+func (o *ProxyLBUpdateSettingsRequest) GetTimeout() *ProxyLBTimeout {
+	return o.Timeout
+}
+
+// SetTimeout sets value to Timeout
+func (o *ProxyLBUpdateSettingsRequest) SetTimeout(v *ProxyLBTimeout) {
+	o.Timeout = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *ProxyLBUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *ProxyLBUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * ProxyLBPatchRequest
 *************************************************/
 
@@ -20174,6 +20298,221 @@ func (o *ProxyLBPatchRequest) GetPatchEmptyToIconID() bool {
 // SetPatchEmptyToIconID sets value to PatchEmptyToIconID
 func (o *ProxyLBPatchRequest) SetPatchEmptyToIconID(v bool) {
 	o.PatchEmptyToIconID = v
+}
+
+/*************************************************
+* ProxyLBPatchSettingsRequest
+*************************************************/
+
+// ProxyLBPatchSettingsRequest represents API parameter/response structure
+type ProxyLBPatchSettingsRequest struct {
+	HealthCheck               *ProxyLBHealthCheck `mapconv:"Settings.ProxyLB.HealthCheck,recursive"`
+	PatchEmptyToHealthCheck   bool
+	SorryServer               *ProxyLBSorryServer `mapconv:"Settings.ProxyLB.SorryServer,recursive"`
+	PatchEmptyToSorryServer   bool
+	BindPorts                 []*ProxyLBBindPort `mapconv:"Settings.ProxyLB.[]BindPorts,recursive"`
+	PatchEmptyToBindPorts     bool
+	Servers                   []*ProxyLBServer `mapconv:"Settings.ProxyLB.[]Servers,recursive"`
+	PatchEmptyToServers       bool
+	LetsEncrypt               *ProxyLBACMESetting `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
+	PatchEmptyToLetsEncrypt   bool
+	StickySession             *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
+	PatchEmptyToStickySession bool
+	Timeout                   *ProxyLBTimeout `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+	PatchEmptyToTimeout       bool
+	SettingsHash              string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *ProxyLBPatchSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ProxyLBPatchSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		HealthCheck               *ProxyLBHealthCheck `mapconv:"Settings.ProxyLB.HealthCheck,recursive"`
+		PatchEmptyToHealthCheck   bool
+		SorryServer               *ProxyLBSorryServer `mapconv:"Settings.ProxyLB.SorryServer,recursive"`
+		PatchEmptyToSorryServer   bool
+		BindPorts                 []*ProxyLBBindPort `mapconv:"Settings.ProxyLB.[]BindPorts,recursive"`
+		PatchEmptyToBindPorts     bool
+		Servers                   []*ProxyLBServer `mapconv:"Settings.ProxyLB.[]Servers,recursive"`
+		PatchEmptyToServers       bool
+		LetsEncrypt               *ProxyLBACMESetting `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
+		PatchEmptyToLetsEncrypt   bool
+		StickySession             *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
+		PatchEmptyToStickySession bool
+		Timeout                   *ProxyLBTimeout `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+		PatchEmptyToTimeout       bool
+		SettingsHash              string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		HealthCheck:               o.GetHealthCheck(),
+		PatchEmptyToHealthCheck:   o.GetPatchEmptyToHealthCheck(),
+		SorryServer:               o.GetSorryServer(),
+		PatchEmptyToSorryServer:   o.GetPatchEmptyToSorryServer(),
+		BindPorts:                 o.GetBindPorts(),
+		PatchEmptyToBindPorts:     o.GetPatchEmptyToBindPorts(),
+		Servers:                   o.GetServers(),
+		PatchEmptyToServers:       o.GetPatchEmptyToServers(),
+		LetsEncrypt:               o.GetLetsEncrypt(),
+		PatchEmptyToLetsEncrypt:   o.GetPatchEmptyToLetsEncrypt(),
+		StickySession:             o.GetStickySession(),
+		PatchEmptyToStickySession: o.GetPatchEmptyToStickySession(),
+		Timeout:                   o.GetTimeout(),
+		PatchEmptyToTimeout:       o.GetPatchEmptyToTimeout(),
+		SettingsHash:              o.GetSettingsHash(),
+	}
+}
+
+// GetHealthCheck returns value of HealthCheck
+func (o *ProxyLBPatchSettingsRequest) GetHealthCheck() *ProxyLBHealthCheck {
+	return o.HealthCheck
+}
+
+// SetHealthCheck sets value to HealthCheck
+func (o *ProxyLBPatchSettingsRequest) SetHealthCheck(v *ProxyLBHealthCheck) {
+	o.HealthCheck = v
+}
+
+// GetPatchEmptyToHealthCheck returns value of PatchEmptyToHealthCheck
+func (o *ProxyLBPatchSettingsRequest) GetPatchEmptyToHealthCheck() bool {
+	return o.PatchEmptyToHealthCheck
+}
+
+// SetPatchEmptyToHealthCheck sets value to PatchEmptyToHealthCheck
+func (o *ProxyLBPatchSettingsRequest) SetPatchEmptyToHealthCheck(v bool) {
+	o.PatchEmptyToHealthCheck = v
+}
+
+// GetSorryServer returns value of SorryServer
+func (o *ProxyLBPatchSettingsRequest) GetSorryServer() *ProxyLBSorryServer {
+	return o.SorryServer
+}
+
+// SetSorryServer sets value to SorryServer
+func (o *ProxyLBPatchSettingsRequest) SetSorryServer(v *ProxyLBSorryServer) {
+	o.SorryServer = v
+}
+
+// GetPatchEmptyToSorryServer returns value of PatchEmptyToSorryServer
+func (o *ProxyLBPatchSettingsRequest) GetPatchEmptyToSorryServer() bool {
+	return o.PatchEmptyToSorryServer
+}
+
+// SetPatchEmptyToSorryServer sets value to PatchEmptyToSorryServer
+func (o *ProxyLBPatchSettingsRequest) SetPatchEmptyToSorryServer(v bool) {
+	o.PatchEmptyToSorryServer = v
+}
+
+// GetBindPorts returns value of BindPorts
+func (o *ProxyLBPatchSettingsRequest) GetBindPorts() []*ProxyLBBindPort {
+	return o.BindPorts
+}
+
+// SetBindPorts sets value to BindPorts
+func (o *ProxyLBPatchSettingsRequest) SetBindPorts(v []*ProxyLBBindPort) {
+	o.BindPorts = v
+}
+
+// GetPatchEmptyToBindPorts returns value of PatchEmptyToBindPorts
+func (o *ProxyLBPatchSettingsRequest) GetPatchEmptyToBindPorts() bool {
+	return o.PatchEmptyToBindPorts
+}
+
+// SetPatchEmptyToBindPorts sets value to PatchEmptyToBindPorts
+func (o *ProxyLBPatchSettingsRequest) SetPatchEmptyToBindPorts(v bool) {
+	o.PatchEmptyToBindPorts = v
+}
+
+// GetServers returns value of Servers
+func (o *ProxyLBPatchSettingsRequest) GetServers() []*ProxyLBServer {
+	return o.Servers
+}
+
+// SetServers sets value to Servers
+func (o *ProxyLBPatchSettingsRequest) SetServers(v []*ProxyLBServer) {
+	o.Servers = v
+}
+
+// GetPatchEmptyToServers returns value of PatchEmptyToServers
+func (o *ProxyLBPatchSettingsRequest) GetPatchEmptyToServers() bool {
+	return o.PatchEmptyToServers
+}
+
+// SetPatchEmptyToServers sets value to PatchEmptyToServers
+func (o *ProxyLBPatchSettingsRequest) SetPatchEmptyToServers(v bool) {
+	o.PatchEmptyToServers = v
+}
+
+// GetLetsEncrypt returns value of LetsEncrypt
+func (o *ProxyLBPatchSettingsRequest) GetLetsEncrypt() *ProxyLBACMESetting {
+	return o.LetsEncrypt
+}
+
+// SetLetsEncrypt sets value to LetsEncrypt
+func (o *ProxyLBPatchSettingsRequest) SetLetsEncrypt(v *ProxyLBACMESetting) {
+	o.LetsEncrypt = v
+}
+
+// GetPatchEmptyToLetsEncrypt returns value of PatchEmptyToLetsEncrypt
+func (o *ProxyLBPatchSettingsRequest) GetPatchEmptyToLetsEncrypt() bool {
+	return o.PatchEmptyToLetsEncrypt
+}
+
+// SetPatchEmptyToLetsEncrypt sets value to PatchEmptyToLetsEncrypt
+func (o *ProxyLBPatchSettingsRequest) SetPatchEmptyToLetsEncrypt(v bool) {
+	o.PatchEmptyToLetsEncrypt = v
+}
+
+// GetStickySession returns value of StickySession
+func (o *ProxyLBPatchSettingsRequest) GetStickySession() *ProxyLBStickySession {
+	return o.StickySession
+}
+
+// SetStickySession sets value to StickySession
+func (o *ProxyLBPatchSettingsRequest) SetStickySession(v *ProxyLBStickySession) {
+	o.StickySession = v
+}
+
+// GetPatchEmptyToStickySession returns value of PatchEmptyToStickySession
+func (o *ProxyLBPatchSettingsRequest) GetPatchEmptyToStickySession() bool {
+	return o.PatchEmptyToStickySession
+}
+
+// SetPatchEmptyToStickySession sets value to PatchEmptyToStickySession
+func (o *ProxyLBPatchSettingsRequest) SetPatchEmptyToStickySession(v bool) {
+	o.PatchEmptyToStickySession = v
+}
+
+// GetTimeout returns value of Timeout
+func (o *ProxyLBPatchSettingsRequest) GetTimeout() *ProxyLBTimeout {
+	return o.Timeout
+}
+
+// SetTimeout sets value to Timeout
+func (o *ProxyLBPatchSettingsRequest) SetTimeout(v *ProxyLBTimeout) {
+	o.Timeout = v
+}
+
+// GetPatchEmptyToTimeout returns value of PatchEmptyToTimeout
+func (o *ProxyLBPatchSettingsRequest) GetPatchEmptyToTimeout() bool {
+	return o.PatchEmptyToTimeout
+}
+
+// SetPatchEmptyToTimeout sets value to PatchEmptyToTimeout
+func (o *ProxyLBPatchSettingsRequest) SetPatchEmptyToTimeout(v bool) {
+	o.PatchEmptyToTimeout = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *ProxyLBPatchSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *ProxyLBPatchSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
 }
 
 /*************************************************

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -9605,6 +9605,107 @@ func (o *GSLBUpdateRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* GSLBUpdateSettingsRequest
+*************************************************/
+
+// GSLBUpdateSettingsRequest represents API parameter/response structure
+type GSLBUpdateSettingsRequest struct {
+	HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
+	DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+	Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
+	SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
+	DestinationServers []*GSLBServer    `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+	SettingsHash       string           `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *GSLBUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *GSLBUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
+		DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+		Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
+		SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
+		DestinationServers []*GSLBServer    `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+		SettingsHash       string           `json:",omitempty" mapconv:",omitempty"`
+	}{
+		HealthCheck:        o.GetHealthCheck(),
+		DelayLoop:          o.GetDelayLoop(),
+		Weighted:           o.GetWeighted(),
+		SorryServer:        o.GetSorryServer(),
+		DestinationServers: o.GetDestinationServers(),
+		SettingsHash:       o.GetSettingsHash(),
+	}
+}
+
+// GetHealthCheck returns value of HealthCheck
+func (o *GSLBUpdateSettingsRequest) GetHealthCheck() *GSLBHealthCheck {
+	return o.HealthCheck
+}
+
+// SetHealthCheck sets value to HealthCheck
+func (o *GSLBUpdateSettingsRequest) SetHealthCheck(v *GSLBHealthCheck) {
+	o.HealthCheck = v
+}
+
+// GetDelayLoop returns value of DelayLoop
+func (o *GSLBUpdateSettingsRequest) GetDelayLoop() int {
+	if o.DelayLoop == 0 {
+		return 10
+	}
+	return o.DelayLoop
+}
+
+// SetDelayLoop sets value to DelayLoop
+func (o *GSLBUpdateSettingsRequest) SetDelayLoop(v int) {
+	o.DelayLoop = v
+}
+
+// GetWeighted returns value of Weighted
+func (o *GSLBUpdateSettingsRequest) GetWeighted() types.StringFlag {
+	return o.Weighted
+}
+
+// SetWeighted sets value to Weighted
+func (o *GSLBUpdateSettingsRequest) SetWeighted(v types.StringFlag) {
+	o.Weighted = v
+}
+
+// GetSorryServer returns value of SorryServer
+func (o *GSLBUpdateSettingsRequest) GetSorryServer() string {
+	return o.SorryServer
+}
+
+// SetSorryServer sets value to SorryServer
+func (o *GSLBUpdateSettingsRequest) SetSorryServer(v string) {
+	o.SorryServer = v
+}
+
+// GetDestinationServers returns value of DestinationServers
+func (o *GSLBUpdateSettingsRequest) GetDestinationServers() []*GSLBServer {
+	return o.DestinationServers
+}
+
+// SetDestinationServers sets value to DestinationServers
+func (o *GSLBUpdateSettingsRequest) SetDestinationServers(v []*GSLBServer) {
+	o.DestinationServers = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *GSLBUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *GSLBUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * GSLBPatchRequest
 *************************************************/
 
@@ -9878,6 +9979,172 @@ func (o *GSLBPatchRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *GSLBPatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* GSLBPatchSettingsRequest
+*************************************************/
+
+// GSLBPatchSettingsRequest represents API parameter/response structure
+type GSLBPatchSettingsRequest struct {
+	HealthCheck                    *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
+	PatchEmptyToHealthCheck        bool
+	DelayLoop                      int `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+	PatchEmptyToDelayLoop          bool
+	Weighted                       types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
+	PatchEmptyToWeighted           bool
+	SorryServer                    string `mapconv:"Settings.GSLB.SorryServer"`
+	PatchEmptyToSorryServer        bool
+	DestinationServers             []*GSLBServer `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+	PatchEmptyToDestinationServers bool
+	SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *GSLBPatchSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *GSLBPatchSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		HealthCheck                    *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
+		PatchEmptyToHealthCheck        bool
+		DelayLoop                      int `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+		PatchEmptyToDelayLoop          bool
+		Weighted                       types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
+		PatchEmptyToWeighted           bool
+		SorryServer                    string `mapconv:"Settings.GSLB.SorryServer"`
+		PatchEmptyToSorryServer        bool
+		DestinationServers             []*GSLBServer `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+		PatchEmptyToDestinationServers bool
+		SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		HealthCheck:                    o.GetHealthCheck(),
+		PatchEmptyToHealthCheck:        o.GetPatchEmptyToHealthCheck(),
+		DelayLoop:                      o.GetDelayLoop(),
+		PatchEmptyToDelayLoop:          o.GetPatchEmptyToDelayLoop(),
+		Weighted:                       o.GetWeighted(),
+		PatchEmptyToWeighted:           o.GetPatchEmptyToWeighted(),
+		SorryServer:                    o.GetSorryServer(),
+		PatchEmptyToSorryServer:        o.GetPatchEmptyToSorryServer(),
+		DestinationServers:             o.GetDestinationServers(),
+		PatchEmptyToDestinationServers: o.GetPatchEmptyToDestinationServers(),
+		SettingsHash:                   o.GetSettingsHash(),
+	}
+}
+
+// GetHealthCheck returns value of HealthCheck
+func (o *GSLBPatchSettingsRequest) GetHealthCheck() *GSLBHealthCheck {
+	return o.HealthCheck
+}
+
+// SetHealthCheck sets value to HealthCheck
+func (o *GSLBPatchSettingsRequest) SetHealthCheck(v *GSLBHealthCheck) {
+	o.HealthCheck = v
+}
+
+// GetPatchEmptyToHealthCheck returns value of PatchEmptyToHealthCheck
+func (o *GSLBPatchSettingsRequest) GetPatchEmptyToHealthCheck() bool {
+	return o.PatchEmptyToHealthCheck
+}
+
+// SetPatchEmptyToHealthCheck sets value to PatchEmptyToHealthCheck
+func (o *GSLBPatchSettingsRequest) SetPatchEmptyToHealthCheck(v bool) {
+	o.PatchEmptyToHealthCheck = v
+}
+
+// GetDelayLoop returns value of DelayLoop
+func (o *GSLBPatchSettingsRequest) GetDelayLoop() int {
+	if o.DelayLoop == 0 {
+		return 10
+	}
+	return o.DelayLoop
+}
+
+// SetDelayLoop sets value to DelayLoop
+func (o *GSLBPatchSettingsRequest) SetDelayLoop(v int) {
+	o.DelayLoop = v
+}
+
+// GetPatchEmptyToDelayLoop returns value of PatchEmptyToDelayLoop
+func (o *GSLBPatchSettingsRequest) GetPatchEmptyToDelayLoop() bool {
+	return o.PatchEmptyToDelayLoop
+}
+
+// SetPatchEmptyToDelayLoop sets value to PatchEmptyToDelayLoop
+func (o *GSLBPatchSettingsRequest) SetPatchEmptyToDelayLoop(v bool) {
+	o.PatchEmptyToDelayLoop = v
+}
+
+// GetWeighted returns value of Weighted
+func (o *GSLBPatchSettingsRequest) GetWeighted() types.StringFlag {
+	return o.Weighted
+}
+
+// SetWeighted sets value to Weighted
+func (o *GSLBPatchSettingsRequest) SetWeighted(v types.StringFlag) {
+	o.Weighted = v
+}
+
+// GetPatchEmptyToWeighted returns value of PatchEmptyToWeighted
+func (o *GSLBPatchSettingsRequest) GetPatchEmptyToWeighted() bool {
+	return o.PatchEmptyToWeighted
+}
+
+// SetPatchEmptyToWeighted sets value to PatchEmptyToWeighted
+func (o *GSLBPatchSettingsRequest) SetPatchEmptyToWeighted(v bool) {
+	o.PatchEmptyToWeighted = v
+}
+
+// GetSorryServer returns value of SorryServer
+func (o *GSLBPatchSettingsRequest) GetSorryServer() string {
+	return o.SorryServer
+}
+
+// SetSorryServer sets value to SorryServer
+func (o *GSLBPatchSettingsRequest) SetSorryServer(v string) {
+	o.SorryServer = v
+}
+
+// GetPatchEmptyToSorryServer returns value of PatchEmptyToSorryServer
+func (o *GSLBPatchSettingsRequest) GetPatchEmptyToSorryServer() bool {
+	return o.PatchEmptyToSorryServer
+}
+
+// SetPatchEmptyToSorryServer sets value to PatchEmptyToSorryServer
+func (o *GSLBPatchSettingsRequest) SetPatchEmptyToSorryServer(v bool) {
+	o.PatchEmptyToSorryServer = v
+}
+
+// GetDestinationServers returns value of DestinationServers
+func (o *GSLBPatchSettingsRequest) GetDestinationServers() []*GSLBServer {
+	return o.DestinationServers
+}
+
+// SetDestinationServers sets value to DestinationServers
+func (o *GSLBPatchSettingsRequest) SetDestinationServers(v []*GSLBServer) {
+	o.DestinationServers = v
+}
+
+// GetPatchEmptyToDestinationServers returns value of PatchEmptyToDestinationServers
+func (o *GSLBPatchSettingsRequest) GetPatchEmptyToDestinationServers() bool {
+	return o.PatchEmptyToDestinationServers
+}
+
+// SetPatchEmptyToDestinationServers sets value to PatchEmptyToDestinationServers
+func (o *GSLBPatchSettingsRequest) SetPatchEmptyToDestinationServers(v bool) {
+	o.PatchEmptyToDestinationServers = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *GSLBPatchSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *GSLBPatchSettingsRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -13734,6 +13734,52 @@ func (o *LoadBalancerUpdateRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* LoadBalancerUpdateSettingsRequest
+*************************************************/
+
+// LoadBalancerUpdateSettingsRequest represents API parameter/response structure
+type LoadBalancerUpdateSettingsRequest struct {
+	VirtualIPAddresses []*LoadBalancerVirtualIPAddress `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+	SettingsHash       string                          `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *LoadBalancerUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LoadBalancerUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		VirtualIPAddresses []*LoadBalancerVirtualIPAddress `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+		SettingsHash       string                          `json:",omitempty" mapconv:",omitempty"`
+	}{
+		VirtualIPAddresses: o.GetVirtualIPAddresses(),
+		SettingsHash:       o.GetSettingsHash(),
+	}
+}
+
+// GetVirtualIPAddresses returns value of VirtualIPAddresses
+func (o *LoadBalancerUpdateSettingsRequest) GetVirtualIPAddresses() []*LoadBalancerVirtualIPAddress {
+	return o.VirtualIPAddresses
+}
+
+// SetVirtualIPAddresses sets value to VirtualIPAddresses
+func (o *LoadBalancerUpdateSettingsRequest) SetVirtualIPAddresses(v []*LoadBalancerVirtualIPAddress) {
+	o.VirtualIPAddresses = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *LoadBalancerUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *LoadBalancerUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * LoadBalancerPatchRequest
 *************************************************/
 
@@ -13900,6 +13946,65 @@ func (o *LoadBalancerPatchRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *LoadBalancerPatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* LoadBalancerPatchSettingsRequest
+*************************************************/
+
+// LoadBalancerPatchSettingsRequest represents API parameter/response structure
+type LoadBalancerPatchSettingsRequest struct {
+	VirtualIPAddresses             []*LoadBalancerVirtualIPAddress `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+	PatchEmptyToVirtualIPAddresses bool
+	SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *LoadBalancerPatchSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LoadBalancerPatchSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		VirtualIPAddresses             []*LoadBalancerVirtualIPAddress `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+		PatchEmptyToVirtualIPAddresses bool
+		SettingsHash                   string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		VirtualIPAddresses:             o.GetVirtualIPAddresses(),
+		PatchEmptyToVirtualIPAddresses: o.GetPatchEmptyToVirtualIPAddresses(),
+		SettingsHash:                   o.GetSettingsHash(),
+	}
+}
+
+// GetVirtualIPAddresses returns value of VirtualIPAddresses
+func (o *LoadBalancerPatchSettingsRequest) GetVirtualIPAddresses() []*LoadBalancerVirtualIPAddress {
+	return o.VirtualIPAddresses
+}
+
+// SetVirtualIPAddresses sets value to VirtualIPAddresses
+func (o *LoadBalancerPatchSettingsRequest) SetVirtualIPAddresses(v []*LoadBalancerVirtualIPAddress) {
+	o.VirtualIPAddresses = v
+}
+
+// GetPatchEmptyToVirtualIPAddresses returns value of PatchEmptyToVirtualIPAddresses
+func (o *LoadBalancerPatchSettingsRequest) GetPatchEmptyToVirtualIPAddresses() bool {
+	return o.PatchEmptyToVirtualIPAddresses
+}
+
+// SetPatchEmptyToVirtualIPAddresses sets value to PatchEmptyToVirtualIPAddresses
+func (o *LoadBalancerPatchSettingsRequest) SetPatchEmptyToVirtualIPAddresses(v bool) {
+	o.PatchEmptyToVirtualIPAddresses = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *LoadBalancerPatchSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *LoadBalancerPatchSettingsRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -8606,6 +8606,52 @@ func (o *DNSUpdateRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* DNSUpdateSettingsRequest
+*************************************************/
+
+// DNSUpdateSettingsRequest represents API parameter/response structure
+type DNSUpdateSettingsRequest struct {
+	Records      []*DNSRecord `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+	SettingsHash string       `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *DNSUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *DNSUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		Records      []*DNSRecord `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+		SettingsHash string       `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Records:      o.GetRecords(),
+		SettingsHash: o.GetSettingsHash(),
+	}
+}
+
+// GetRecords returns value of Records
+func (o *DNSUpdateSettingsRequest) GetRecords() []*DNSRecord {
+	return o.Records
+}
+
+// SetRecords sets value to Records
+func (o *DNSUpdateSettingsRequest) SetRecords(v []*DNSRecord) {
+	o.Records = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *DNSUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *DNSUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * DNSPatchRequest
 *************************************************/
 
@@ -8759,6 +8805,65 @@ func (o *DNSPatchRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *DNSPatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* DNSPatchSettingsRequest
+*************************************************/
+
+// DNSPatchSettingsRequest represents API parameter/response structure
+type DNSPatchSettingsRequest struct {
+	Records             []*DNSRecord `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+	PatchEmptyToRecords bool
+	SettingsHash        string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *DNSPatchSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *DNSPatchSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		Records             []*DNSRecord `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+		PatchEmptyToRecords bool
+		SettingsHash        string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Records:             o.GetRecords(),
+		PatchEmptyToRecords: o.GetPatchEmptyToRecords(),
+		SettingsHash:        o.GetSettingsHash(),
+	}
+}
+
+// GetRecords returns value of Records
+func (o *DNSPatchSettingsRequest) GetRecords() []*DNSRecord {
+	return o.Records
+}
+
+// SetRecords sets value to Records
+func (o *DNSPatchSettingsRequest) SetRecords(v []*DNSRecord) {
+	o.Records = v
+}
+
+// GetPatchEmptyToRecords returns value of PatchEmptyToRecords
+func (o *DNSPatchSettingsRequest) GetPatchEmptyToRecords() bool {
+	return o.PatchEmptyToRecords
+}
+
+// SetPatchEmptyToRecords sets value to PatchEmptyToRecords
+func (o *DNSPatchSettingsRequest) SetPatchEmptyToRecords(v bool) {
+	o.PatchEmptyToRecords = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *DNSPatchSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *DNSPatchSettingsRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -15186,6 +15186,52 @@ func (o *MobileGatewayUpdateRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* MobileGatewayUpdateSettingsRequest
+*************************************************/
+
+// MobileGatewayUpdateSettingsRequest represents API parameter/response structure
+type MobileGatewayUpdateSettingsRequest struct {
+	Settings     *MobileGatewaySetting `json:",omitempty" mapconv:",omitempty,recursive"`
+	SettingsHash string                `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *MobileGatewayUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		Settings     *MobileGatewaySetting `json:",omitempty" mapconv:",omitempty,recursive"`
+		SettingsHash string                `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Settings:     o.GetSettings(),
+		SettingsHash: o.GetSettingsHash(),
+	}
+}
+
+// GetSettings returns value of Settings
+func (o *MobileGatewayUpdateSettingsRequest) GetSettings() *MobileGatewaySetting {
+	return o.Settings
+}
+
+// SetSettings sets value to Settings
+func (o *MobileGatewayUpdateSettingsRequest) SetSettings(v *MobileGatewaySetting) {
+	o.Settings = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *MobileGatewayUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *MobileGatewayUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * MobileGatewayPatchRequest
 *************************************************/
 
@@ -15352,6 +15398,65 @@ func (o *MobileGatewayPatchRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *MobileGatewayPatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* MobileGatewayPatchSettingsRequest
+*************************************************/
+
+// MobileGatewayPatchSettingsRequest represents API parameter/response structure
+type MobileGatewayPatchSettingsRequest struct {
+	Settings             *MobileGatewaySetting `json:",omitempty" mapconv:",omitempty,recursive"`
+	PatchEmptyToSettings bool
+	SettingsHash         string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *MobileGatewayPatchSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *MobileGatewayPatchSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		Settings             *MobileGatewaySetting `json:",omitempty" mapconv:",omitempty,recursive"`
+		PatchEmptyToSettings bool
+		SettingsHash         string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Settings:             o.GetSettings(),
+		PatchEmptyToSettings: o.GetPatchEmptyToSettings(),
+		SettingsHash:         o.GetSettingsHash(),
+	}
+}
+
+// GetSettings returns value of Settings
+func (o *MobileGatewayPatchSettingsRequest) GetSettings() *MobileGatewaySetting {
+	return o.Settings
+}
+
+// SetSettings sets value to Settings
+func (o *MobileGatewayPatchSettingsRequest) SetSettings(v *MobileGatewaySetting) {
+	o.Settings = v
+}
+
+// GetPatchEmptyToSettings returns value of PatchEmptyToSettings
+func (o *MobileGatewayPatchSettingsRequest) GetPatchEmptyToSettings() bool {
+	return o.PatchEmptyToSettings
+}
+
+// SetPatchEmptyToSettings sets value to PatchEmptyToSettings
+func (o *MobileGatewayPatchSettingsRequest) SetPatchEmptyToSettings(v bool) {
+	o.PatchEmptyToSettings = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *MobileGatewayPatchSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *MobileGatewayPatchSettingsRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -29270,6 +29270,52 @@ func (o *VPCRouterUpdateRequest) SetSettingsHash(v string) {
 }
 
 /*************************************************
+* VPCRouterUpdateSettingsRequest
+*************************************************/
+
+// VPCRouterUpdateSettingsRequest represents API parameter/response structure
+type VPCRouterUpdateSettingsRequest struct {
+	Settings     *VPCRouterSetting `mapconv:",omitempty,recursive"`
+	SettingsHash string            `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *VPCRouterUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *VPCRouterUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		Settings     *VPCRouterSetting `mapconv:",omitempty,recursive"`
+		SettingsHash string            `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Settings:     o.GetSettings(),
+		SettingsHash: o.GetSettingsHash(),
+	}
+}
+
+// GetSettings returns value of Settings
+func (o *VPCRouterUpdateSettingsRequest) GetSettings() *VPCRouterSetting {
+	return o.Settings
+}
+
+// SetSettings sets value to Settings
+func (o *VPCRouterUpdateSettingsRequest) SetSettings(v *VPCRouterSetting) {
+	o.Settings = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *VPCRouterUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *VPCRouterUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
 * VPCRouterPatchRequest
 *************************************************/
 
@@ -29436,6 +29482,65 @@ func (o *VPCRouterPatchRequest) GetSettingsHash() string {
 
 // SetSettingsHash sets value to SettingsHash
 func (o *VPCRouterPatchRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* VPCRouterPatchSettingsRequest
+*************************************************/
+
+// VPCRouterPatchSettingsRequest represents API parameter/response structure
+type VPCRouterPatchSettingsRequest struct {
+	Settings             *VPCRouterSetting `mapconv:",omitempty,recursive"`
+	PatchEmptyToSettings bool
+	SettingsHash         string `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *VPCRouterPatchSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *VPCRouterPatchSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		Settings             *VPCRouterSetting `mapconv:",omitempty,recursive"`
+		PatchEmptyToSettings bool
+		SettingsHash         string `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Settings:             o.GetSettings(),
+		PatchEmptyToSettings: o.GetPatchEmptyToSettings(),
+		SettingsHash:         o.GetSettingsHash(),
+	}
+}
+
+// GetSettings returns value of Settings
+func (o *VPCRouterPatchSettingsRequest) GetSettings() *VPCRouterSetting {
+	return o.Settings
+}
+
+// SetSettings sets value to Settings
+func (o *VPCRouterPatchSettingsRequest) SetSettings(v *VPCRouterSetting) {
+	o.Settings = v
+}
+
+// GetPatchEmptyToSettings returns value of PatchEmptyToSettings
+func (o *VPCRouterPatchSettingsRequest) GetPatchEmptyToSettings() bool {
+	return o.PatchEmptyToSettings
+}
+
+// SetPatchEmptyToSettings sets value to PatchEmptyToSettings
+func (o *VPCRouterPatchSettingsRequest) SetPatchEmptyToSettings(v bool) {
+	o.PatchEmptyToSettings = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *VPCRouterPatchSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *VPCRouterPatchSettingsRequest) SetSettingsHash(v string) {
 	o.SettingsHash = v
 }
 

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -510,8 +510,22 @@ type gSLBUpdateResult struct {
 	GSLB *GSLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
 }
 
+// gSLBUpdateSettingsResult represents the Result of API
+type gSLBUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	GSLB *GSLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
 // gSLBPatchResult represents the Result of API
 type gSLBPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	GSLB *GSLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// gSLBPatchSettingsResult represents the Result of API
+type gSLBPatchSettingsResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	GSLB *GSLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -1197,8 +1197,22 @@ type proxyLBUpdateResult struct {
 	ProxyLB *ProxyLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
 }
 
+// proxyLBUpdateSettingsResult represents the Result of API
+type proxyLBUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	ProxyLB *ProxyLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
 // proxyLBPatchResult represents the Result of API
 type proxyLBPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	ProxyLB *ProxyLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// proxyLBPatchSettingsResult represents the Result of API
+type proxyLBPatchSettingsResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	ProxyLB *ProxyLB `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -1449,8 +1449,22 @@ type simpleMonitorUpdateResult struct {
 	SimpleMonitor *SimpleMonitor `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
 }
 
+// simpleMonitorUpdateSettingsResult represents the Result of API
+type simpleMonitorUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	SimpleMonitor *SimpleMonitor `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
 // simpleMonitorPatchResult represents the Result of API
 type simpleMonitorPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	SimpleMonitor *SimpleMonitor `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// simpleMonitorPatchSettingsResult represents the Result of API
+type simpleMonitorPatchSettingsResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	SimpleMonitor *SimpleMonitor `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -112,6 +112,20 @@ type autoBackupPatchResult struct {
 	AutoBackup *AutoBackup `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
 }
 
+// autoBackupUpdateSettingsResult represents the Result of API
+type autoBackupUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	AutoBackup *AutoBackup `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// autoBackupPatchSettingsResult represents the Result of API
+type autoBackupPatchSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	AutoBackup *AutoBackup `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
 // BillByContractResult represents the Result of API
 type BillByContractResult struct {
 	Total int `json:",omitempty"` // Total count of target resources

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -919,8 +919,22 @@ type mobileGatewayUpdateResult struct {
 	MobileGateway *MobileGateway `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
 }
 
+// mobileGatewayUpdateSettingsResult represents the Result of API
+type mobileGatewayUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	MobileGateway *MobileGateway `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
 // mobileGatewayPatchResult represents the Result of API
 type mobileGatewayPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	MobileGateway *MobileGateway `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// mobileGatewayPatchSettingsResult represents the Result of API
+type mobileGatewayPatchSettingsResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	MobileGateway *MobileGateway `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -299,8 +299,22 @@ type databaseUpdateResult struct {
 	Database *Database `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
 }
 
+// databaseUpdateSettingsResult represents the Result of API
+type databaseUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Database *Database `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
 // databasePatchResult represents the Result of API
 type databasePatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Database *Database `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// databasePatchSettingsResult represents the Result of API
+type databasePatchSettingsResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	Database *Database `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -852,8 +852,22 @@ type loadBalancerUpdateResult struct {
 	LoadBalancer *LoadBalancer `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
 }
 
+// loadBalancerUpdateSettingsResult represents the Result of API
+type loadBalancerUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LoadBalancer *LoadBalancer `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
 // loadBalancerPatchResult represents the Result of API
 type loadBalancerPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LoadBalancer *LoadBalancer `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// loadBalancerPatchSettingsResult represents the Result of API
+type loadBalancerPatchSettingsResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	LoadBalancer *LoadBalancer `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -459,8 +459,22 @@ type dNSUpdateResult struct {
 	DNS *DNS `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
 }
 
+// dNSUpdateSettingsResult represents the Result of API
+type dNSUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	DNS *DNS `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
 // dNSPatchResult represents the Result of API
 type dNSPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	DNS *DNS `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// dNSPatchSettingsResult represents the Result of API
+type dNSPatchSettingsResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	DNS *DNS `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -1620,8 +1620,22 @@ type vPCRouterUpdateResult struct {
 	VPCRouter *VPCRouter `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
 }
 
+// vPCRouterUpdateSettingsResult represents the Result of API
+type vPCRouterUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	VPCRouter *VPCRouter `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
 // vPCRouterPatchResult represents the Result of API
 type vPCRouterPatchResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	VPCRouter *VPCRouter `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// vPCRouterPatchSettingsResult represents the Result of API
+type vPCRouterPatchSettingsResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	VPCRouter *VPCRouter `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`


### PR DESCRIPTION
fixes #397 

以下のリソースに対し`UpdateSettings`と`PatchSettings`を実装する。

- [x] AutoBackup
- [x] Database
- [x] DNS
- [x] GSLB
- [x] LoadBBalancer
- [x] MobileGateway
- [x] ProxyLB
- [x] SimpleMonitor
- [x] VPCRouter

Note: ApplianceとCommonServiceItemが対象。リストに記載のないものとしてNFSアプライアンスがあるが、`Settings`フィールドを持たない(Remarkのみ)なため除外した。
