### PR TITLE
Fix tags: ProxyLB.SorryServer

### DIFF
--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -1255,6 +1255,7 @@ func (f *fieldsDef) ProxyLBSorryServer() *dsl.FieldDesc {
 					Type: meta.TypeInt,
 					Tags: &dsl.FieldTags{
 						Validate: "min=0,max=65535",
+						MapConv:  ",omitempty",
 					},
 				},
 			},

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -19086,7 +19086,7 @@ func (o *ProxyLBHealthCheck) SetDelayLoop(v int) {
 // ProxyLBSorryServer represents API parameter/response structure
 type ProxyLBSorryServer struct {
 	IPAddress string `validate:"ipv4"`
-	Port      int    `validate:"min=0,max=65535"`
+	Port      int    `mapconv:",omitempty" validate:"min=0,max=65535"`
 }
 
 // Validate validates by field tags
@@ -19098,7 +19098,7 @@ func (o *ProxyLBSorryServer) Validate() error {
 func (o *ProxyLBSorryServer) setDefaults() interface{} {
 	return &struct {
 		IPAddress string `validate:"ipv4"`
-		Port      int    `validate:"min=0,max=65535"`
+		Port      int    `mapconv:",omitempty" validate:"min=0,max=65535"`
 	}{
 		IPAddress: o.GetIPAddress(),
 		Port:      o.GetPort(),


### PR DESCRIPTION
fixes #411 

naked型は以下のように定義されている。

```
// ProxyLBSorryServer ソーリーサーバ設定
type ProxyLBSorryServer struct {
	IPAddress string `yaml:"ip_address"`
	Port      *int   `yaml:"port"`
}
```

このためnaked型は対応不要。
mapconvでの変換がゼロ値に対して行われないように`mapconv:",omitempty"`を追加する。