### PR TITLE
Add VPCRouter builder

### DIFF
--- a/utils/vpcrouter/builder.go
+++ b/utils/vpcrouter/builder.go
@@ -1,0 +1,183 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpcrouter
+
+import (
+	"context"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/accessor"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/setup"
+)
+
+// Builder VPCルータの構築を行う
+type Builder struct {
+	Name                  string
+	Description           string
+	Tags                  types.Tags
+	IconID                types.ID
+	PlanID                types.ID
+	NICSetting            NICSettingHolder
+	AdditionalNICSettings []AdditionalNICSettingHolder
+	RouterSetting         *RouterSetting
+
+	BootAfterBuild bool
+	SetupOptions   *RetryableSetupParameter
+}
+
+// RouterSetting VPCルータの設定
+type RouterSetting struct {
+	VRID                      int
+	InternetConnectionEnabled types.StringFlag
+	StaticNAT                 []*sacloud.VPCRouterStaticNAT
+	PortForwarding            []*sacloud.VPCRouterPortForwarding
+	Firewall                  []*sacloud.VPCRouterFirewall
+	DHCPServer                []*sacloud.VPCRouterDHCPServer
+	DHCPStaticMapping         []*sacloud.VPCRouterDHCPStaticMapping
+	PPTPServer                *sacloud.VPCRouterPPTPServer
+	L2TPIPsecServer           *sacloud.VPCRouterL2TPIPsecServer
+	RemoteAccessUsers         []*sacloud.VPCRouterRemoteAccessUser
+	SiteToSiteIPsecVPN        []*sacloud.VPCRouterSiteToSiteIPsecVPN
+	StaticRoute               []*sacloud.VPCRouterStaticRoute
+	SyslogHost                string
+}
+
+// RetryableSetupParameter VPCルータ作成時に利用するsetup.RetryableSetupのパラメータ
+type RetryableSetupParameter struct {
+	// RetryCount リトライ回数
+	RetryCount int
+	// DeleteRetryCount 削除リトライ回数
+	DeleteRetryCount int
+	// DeleteRetryInterval 削除リトライ間隔
+	DeleteRetryInterval time.Duration
+	// sacloud.StateWaiterによるステート待ちの間隔
+	PollInterval time.Duration
+}
+
+func (b *Builder) init() {
+	if b.SetupOptions == nil {
+		b.SetupOptions = &RetryableSetupParameter{}
+	}
+}
+
+func (b *Builder) getInitInterfaceSettings() []*sacloud.VPCRouterInterfaceSetting {
+	s := b.NICSetting.getInterfaceSetting()
+	if s != nil {
+		return []*sacloud.VPCRouterInterfaceSetting{s}
+	}
+	return nil
+}
+
+func (b *Builder) getInterfaceSettings() []*sacloud.VPCRouterInterfaceSetting {
+	var settings []*sacloud.VPCRouterInterfaceSetting
+	if s := b.NICSetting.getInterfaceSetting(); s != nil {
+		settings = append(settings, s)
+	}
+	for _, additionalNIC := range b.AdditionalNICSettings {
+		settings = append(settings, additionalNIC.getInterfaceSetting())
+	}
+	return settings
+}
+
+// Build VPCルータの作成、スイッチの接続をまとめて行う
+func (b *Builder) Build(ctx context.Context, client sacloud.VPCRouterAPI, zone string) (*sacloud.VPCRouter, error) {
+	b.init()
+
+	builder := &setup.RetryableSetup{
+		Create: func(ctx context.Context, zone string) (accessor.ID, error) {
+			return client.Create(ctx, zone, &sacloud.VPCRouterCreateRequest{
+				Name:        b.Name,
+				Description: b.Description,
+				Tags:        b.Tags,
+				IconID:      b.IconID,
+				PlanID:      b.PlanID,
+				Switch:      b.NICSetting.getConnectedSwitch(),
+				IPAddresses: b.NICSetting.getIPAddresses(),
+				Settings: &sacloud.VPCRouterSetting{
+					VRID:                      b.RouterSetting.VRID,
+					InternetConnectionEnabled: b.RouterSetting.InternetConnectionEnabled,
+					Interfaces:                b.getInitInterfaceSettings(),
+					SyslogHost:                b.RouterSetting.SyslogHost,
+				},
+			})
+		},
+		ProvisionBeforeUp: func(ctx context.Context, zone string, id types.ID, target interface{}) error {
+			vpcRouter := target.(*sacloud.VPCRouter)
+
+			// スイッチの接続
+			for _, additionalNIC := range b.AdditionalNICSettings {
+				switchID, index := additionalNIC.getSwitchInfo()
+				if err := client.ConnectToSwitch(ctx, zone, id, index, switchID); err != nil {
+					return err
+				}
+			}
+
+			// [HACK] スイッチ接続直後だとエラーになることがあるため数秒待つ
+			time.Sleep(3 * time.Second)
+
+			// 残りの設定の投入
+			_, err := client.UpdateSettings(ctx, zone, id, &sacloud.VPCRouterUpdateSettingsRequest{
+				Settings: &sacloud.VPCRouterSetting{
+					VRID:                      b.RouterSetting.VRID,
+					InternetConnectionEnabled: b.RouterSetting.InternetConnectionEnabled,
+					Interfaces:                b.getInterfaceSettings(),
+					StaticNAT:                 b.RouterSetting.StaticNAT,
+					PortForwarding:            b.RouterSetting.PortForwarding,
+					Firewall:                  b.RouterSetting.Firewall,
+					DHCPServer:                b.RouterSetting.DHCPServer,
+					DHCPStaticMapping:         b.RouterSetting.DHCPStaticMapping,
+					PPTPServer:                b.RouterSetting.PPTPServer,
+					PPTPServerEnabled:         b.RouterSetting.PPTPServer != nil,
+					L2TPIPsecServer:           b.RouterSetting.L2TPIPsecServer,
+					L2TPIPsecServerEnabled:    b.RouterSetting.L2TPIPsecServer != nil,
+					RemoteAccessUsers:         b.RouterSetting.RemoteAccessUsers,
+					SiteToSiteIPsecVPN:        b.RouterSetting.SiteToSiteIPsecVPN,
+					StaticRoute:               b.RouterSetting.StaticRoute,
+					SyslogHost:                b.RouterSetting.SyslogHost,
+				},
+				SettingsHash: vpcRouter.SettingsHash,
+			})
+			if err != nil {
+				return err
+			}
+
+			if b.BootAfterBuild {
+				return client.Boot(ctx, zone, id)
+			}
+			return nil
+		},
+		Delete: func(ctx context.Context, zone string, id types.ID) error {
+			return client.Delete(ctx, zone, id)
+		},
+		Read: func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
+			return client.Read(ctx, zone, id)
+		},
+		IsWaitForCopy:          true,
+		IsWaitForUp:            b.BootAfterBuild,
+		RetryCount:             b.SetupOptions.RetryCount,
+		ProvisioningRetryCount: 1,
+		DeleteRetryCount:       b.SetupOptions.DeleteRetryCount,
+		DeleteRetryInterval:    b.SetupOptions.DeleteRetryInterval,
+		PollInterval:           b.SetupOptions.PollInterval,
+	}
+
+	result, err := builder.Setup(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
+	return result.(*sacloud.VPCRouter), nil
+}

--- a/utils/vpcrouter/builder_nic.go
+++ b/utils/vpcrouter/builder_nic.go
@@ -1,0 +1,119 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpcrouter
+
+import (
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// NICSettingHolder VPCルータのeth0の設定 SharedNICSettingまたはRouterNICSettingを指定する
+type NICSettingHolder interface {
+	getConnectedSwitch() *sacloud.ApplianceConnectedSwitch
+	getIPAddresses() []string
+	getInterfaceSetting() *sacloud.VPCRouterInterfaceSetting
+}
+
+// StandardNICSetting VPCルータのeth0を共有セグメントに接続するためのSetting(スタンダードプラン)
+type StandardNICSetting struct{}
+
+func (s *StandardNICSetting) getConnectedSwitch() *sacloud.ApplianceConnectedSwitch {
+	return &sacloud.ApplianceConnectedSwitch{Scope: types.Scopes.Shared}
+}
+
+func (s *StandardNICSetting) getIPAddresses() []string {
+	return nil
+}
+
+func (s *StandardNICSetting) getInterfaceSetting() *sacloud.VPCRouterInterfaceSetting {
+	return nil
+}
+
+// PremiumNICSetting VPCルータのeth0をスイッチ+ルータに接続するためのSetting(プレミアム/ハイスペックプラン)
+type PremiumNICSetting struct {
+	SwitchID         types.ID
+	IPAddress1       string
+	IPAddress2       string
+	VirtualIPAddress string
+	IPAliases        []string
+	NetworkMaskLen   int
+}
+
+func (s *PremiumNICSetting) getConnectedSwitch() *sacloud.ApplianceConnectedSwitch {
+	return &sacloud.ApplianceConnectedSwitch{ID: s.SwitchID}
+}
+
+func (s *PremiumNICSetting) getIPAddresses() []string {
+	return []string{s.IPAddress1, s.IPAddress2}
+}
+
+func (s *PremiumNICSetting) getInterfaceSetting() *sacloud.VPCRouterInterfaceSetting {
+	return &sacloud.VPCRouterInterfaceSetting{
+		IPAddress:        []string{s.IPAddress1, s.IPAddress2},
+		VirtualIPAddress: s.VirtualIPAddress,
+		IPAliases:        s.IPAliases,
+		NetworkMaskLen:   s.NetworkMaskLen,
+		Index:            0,
+	}
+}
+
+// AdditionalNICSettingHolder VPCルータのeth1-eth7の設定
+type AdditionalNICSettingHolder interface {
+	getSwitchInfo() (switchID types.ID, index int)
+	getInterfaceSetting() *sacloud.VPCRouterInterfaceSetting
+}
+
+// AdditionalStandardNICSetting VPCルータのeth1-eth7の設定(スタンダードプラン向け)
+type AdditionalStandardNICSetting struct {
+	SwitchID       types.ID
+	IPAddress      string
+	NetworkMaskLen int
+	Index          int
+}
+
+func (s *AdditionalStandardNICSetting) getSwitchInfo() (switchID types.ID, index int) {
+	return s.SwitchID, s.Index
+}
+
+func (s *AdditionalStandardNICSetting) getInterfaceSetting() *sacloud.VPCRouterInterfaceSetting {
+	return &sacloud.VPCRouterInterfaceSetting{
+		IPAddress:      []string{s.IPAddress},
+		NetworkMaskLen: s.NetworkMaskLen,
+		Index:          s.Index,
+	}
+}
+
+// AdditionalPremiumNICSetting VPCルータのeth1-eth7の設定(プレミアム/ハイスペックプラン向け)
+type AdditionalPremiumNICSetting struct {
+	SwitchID         types.ID
+	IPAddress1       string
+	IPAddress2       string
+	VirtualIPAddress string
+	NetworkMaskLen   int
+	Index            int
+}
+
+func (s *AdditionalPremiumNICSetting) getSwitchInfo() (switchID types.ID, index int) {
+	return s.SwitchID, s.Index
+}
+
+func (s *AdditionalPremiumNICSetting) getInterfaceSetting() *sacloud.VPCRouterInterfaceSetting {
+	return &sacloud.VPCRouterInterfaceSetting{
+		IPAddress:        []string{s.IPAddress1, s.IPAddress2},
+		VirtualIPAddress: s.VirtualIPAddress,
+		NetworkMaskLen:   s.NetworkMaskLen,
+		Index:            s.Index,
+	}
+}

--- a/utils/vpcrouter/builder_test.go
+++ b/utils/vpcrouter/builder_test.go
@@ -1,0 +1,220 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpcrouter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+func TestBuilder_Build(t *testing.T) {
+	var switchID types.ID
+	var testZone = testutil.TestZone()
+
+	testutil.Run(t, &testutil.CRUDTestCase{
+		SetupAPICallerFunc: func() sacloud.APICaller {
+			return testutil.SingletonAPICaller()
+		},
+		Parallel:          true,
+		IgnoreStartupWait: true,
+		Setup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+			swOp := sacloud.NewSwitchOp(caller)
+
+			sw, err := swOp.Create(ctx, testZone, &sacloud.SwitchCreateRequest{
+				Name: testutil.ResourceName("vpc-router-builder"),
+			})
+			if err != nil {
+				return err
+			}
+			switchID = sw.ID
+			return nil
+		},
+		Create: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				builder := &Builder{
+					Name:        testutil.ResourceName("vpc-router-builder"),
+					Description: "description",
+					Tags:        types.Tags{"tag1", "tag2"},
+					PlanID:      types.VPCRouterPlans.Standard,
+					NICSetting:  &StandardNICSetting{},
+					AdditionalNICSettings: []AdditionalNICSettingHolder{
+						&AdditionalStandardNICSetting{
+							SwitchID:       switchID,
+							IPAddress:      "192.168.0.1",
+							NetworkMaskLen: 24,
+							Index:          2,
+						},
+					},
+					RouterSetting: &RouterSetting{
+						InternetConnectionEnabled: types.StringTrue,
+					},
+				}
+				return builder.Build(ctx, sacloud.NewVPCRouterOp(caller), testZone)
+			},
+		},
+		Read: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				vpcRouterOp := sacloud.NewVPCRouterOp(caller)
+				return vpcRouterOp.Read(ctx, testZone, ctx.ID)
+			},
+			CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, value interface{}) error {
+				vpcRouter := value.(*sacloud.VPCRouter)
+				return testutil.DoAsserts(
+					testutil.AssertNotNilFunc(t, vpcRouter, "VPCRouter"),
+					testutil.AssertNotNilFunc(t, vpcRouter.Settings, "VPCRouter.Settings"),
+					testutil.AssertLenFunc(t, vpcRouter.Settings.Interfaces, 1, "VPCRouter.Settings.Interfaces"),
+				)
+			},
+		},
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+				vpcRouterOp := sacloud.NewVPCRouterOp(caller)
+				return vpcRouterOp.Delete(ctx, testZone, ctx.ID)
+			},
+		},
+		Cleanup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+			swOp := sacloud.NewSwitchOp(caller)
+			return swOp.Delete(ctx, testZone, switchID)
+		},
+	})
+
+}
+
+func TestBuilder_BuildWithRouter(t *testing.T) {
+	var routerID, routerSwitchID, switchID types.ID
+	var addresses []string
+	var testZone = testutil.TestZone()
+
+	testutil.Run(t, &testutil.CRUDTestCase{
+		SetupAPICallerFunc: func() sacloud.APICaller {
+			return testutil.SingletonAPICaller()
+		},
+		Parallel:          true,
+		IgnoreStartupWait: true,
+		Setup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+			internetOp := sacloud.NewInternetOp(caller)
+
+			created, err := internetOp.Create(ctx, testZone, &sacloud.InternetCreateRequest{
+				Name:           testutil.ResourceName("vpc-router-builder"),
+				NetworkMaskLen: 28,
+				BandWidthMbps:  100,
+			})
+			if err != nil {
+				return err
+			}
+
+			routerID = created.ID
+			routerSwitchID = created.Switch.ID
+			max := 30
+			for {
+				if max == 0 {
+					break
+				}
+				_, err := internetOp.Read(ctx, testZone, routerID)
+				if err != nil || sacloud.IsNotFoundError(err) {
+					max--
+					time.Sleep(3 * time.Second)
+					continue
+				}
+				break
+			}
+
+			swOp := sacloud.NewSwitchOp(caller)
+			sw, err := swOp.Create(ctx, testZone, &sacloud.SwitchCreateRequest{
+				Name: testutil.ResourceName("vpc-router-builder"),
+			})
+			if err != nil {
+				return err
+			}
+			switchID = sw.ID
+
+			routerSwitch, err := swOp.Read(ctx, testZone, created.Switch.ID)
+			if err != nil {
+				return err
+			}
+			addresses = routerSwitch.Subnets[0].GetAssignedIPAddresses()
+			return nil
+		},
+		Create: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				builder := &Builder{
+					Name:        testutil.ResourceName("vpc-router-builder"),
+					Description: "description",
+					Tags:        types.Tags{"tag1", "tag2"},
+					PlanID:      types.VPCRouterPlans.Premium,
+					NICSetting: &PremiumNICSetting{
+						SwitchID:         routerSwitchID,
+						VirtualIPAddress: addresses[0],
+						IPAddress1:       addresses[1],
+						IPAddress2:       addresses[2],
+						IPAliases:        []string{addresses[3], addresses[4]},
+						NetworkMaskLen:   28,
+					},
+					AdditionalNICSettings: []AdditionalNICSettingHolder{
+						&AdditionalPremiumNICSetting{
+							SwitchID:         switchID,
+							IPAddress1:       "192.168.0.11",
+							IPAddress2:       "192.168.0.12",
+							VirtualIPAddress: "192.168.0.1",
+							NetworkMaskLen:   24,
+							Index:            2,
+						},
+					},
+					RouterSetting: &RouterSetting{
+						VRID:                      1,
+						InternetConnectionEnabled: types.StringTrue,
+					},
+					BootAfterBuild: false,
+					SetupOptions:   nil,
+				}
+				return builder.Build(ctx, sacloud.NewVPCRouterOp(caller), testZone)
+			},
+		},
+		Read: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				vpcRouterOp := sacloud.NewVPCRouterOp(caller)
+				return vpcRouterOp.Read(ctx, testZone, ctx.ID)
+			},
+			CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, value interface{}) error {
+				vpcRouter := value.(*sacloud.VPCRouter)
+				return testutil.DoAsserts(
+					testutil.AssertNotNilFunc(t, vpcRouter, "VPCRouter"),
+					testutil.AssertNotNilFunc(t, vpcRouter.Settings, "VPCRouter.Settings"),
+					testutil.AssertLenFunc(t, vpcRouter.Settings.Interfaces, 2, "VPCRouter.Settings.Interfaces"),
+				)
+			},
+		},
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+				vpcRouterOp := sacloud.NewVPCRouterOp(caller)
+				if err := vpcRouterOp.Delete(ctx, testZone, ctx.ID); err != nil {
+					return err
+				}
+
+				internetOp := sacloud.NewInternetOp(caller)
+				if err := internetOp.Delete(ctx, testZone, routerID); err != nil {
+					return err
+				}
+				swOp := sacloud.NewSwitchOp(caller)
+				return swOp.Delete(ctx, testZone, switchID)
+			},
+		},
+	})
+
+}


### PR DESCRIPTION
#414 の修正版

利用例(スタンダードプラン)

```go
builder := &Builder{
	Name:        "example",
	Description: "description",
	Tags:        types.Tags{"tag1", "tag2"},
	PlanID:      types.VPCRouterPlans.Standard,
	NICSetting:  &SharedNICSetting{},
	AdditionalNICSettings: []AdditionalNICSettingHolder{
		&AdditionalStandardNICSetting{
			SwitchID:       switchID,
			IPAddress:      "192.168.0.1",
			NetworkMaskLen: 24,
			Index:          2,
		},
	},
	RouterSetting: &RouterSetting{
		InternetConnectionEnabled: types.StringTrue,
	},
}
return builder.Build(ctx, sacloud.NewVPCRouterOp(caller), "is1a")
```


利用例(プレミアムプラン以上)

```go
builder := &Builder{
	Name:        "example",
	Description: "description",
	Tags:        types.Tags{"tag1", "tag2"},
	PlanID:      types.VPCRouterPlans.Premium,
	NICSetting: &RouterNICSetting{
		SwitchID:         routerSwitchID,
		VirtualIPAddress: addresses[0],
		IPAddress1:       addresses[1],
		IPAddress2:       addresses[2],
		IPAliases:        []string{addresses[3], addresses[4]},
		NetworkMaskLen:   28,
	},
	AdditionalNICSettings: []AdditionalNICSettingHolder{
		&AdditionalPremiumNICSetting{
			SwitchID:         switchID,
			IPAddress1:       "192.168.0.11",
			IPAddress2:       "192.168.0.12",
			VirtualIPAddress: "192.168.0.1",
			NetworkMaskLen:   24,
			Index:            2,
		},
	},
	RouterSetting: &RouterSetting{
		VRID:                      1,
		InternetConnectionEnabled: types.StringTrue,
	},
}
return builder.Build(ctx, sacloud.NewVPCRouterOp(caller), "is1b")
```