### PR TITLE
Improve VPCRouter handling

### DIFF
--- a/internal/define/models.go
+++ b/internal/define/models.go
@@ -781,7 +781,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "InternetConnectionEnabled",
 				Type: meta.TypeStringFlag,
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.InternetConnection.Enabled,omitempty",
 				},
 			},
@@ -845,7 +844,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "PPTPServerEnabled",
 				Type: meta.TypeStringFlag,
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.PPTPServer.Enabled,omitempty",
 				},
 			},
@@ -861,7 +859,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "L2TPIPsecServerEnabled",
 				Type: meta.TypeStringFlag,
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.L2TPIPsecServer.Enabled,omitempty",
 				},
 			},
@@ -1007,6 +1004,10 @@ func (m *modelsDef) vpcRouterFirewall() *dsl.Model {
 			{
 				Name: "Receive",
 				Type: m.vpcRouterFirewallRule(),
+			},
+			{
+				Name: "Index",
+				Type: meta.TypeInt,
 			},
 		},
 	}

--- a/internal/define/models.go
+++ b/internal/define/models.go
@@ -788,7 +788,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "Interfaces",
 				Type: m.vpcRouterInterface(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.[]Interfaces,omitempty,recursive",
 				},
 			},
@@ -796,7 +795,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "StaticNAT",
 				Type: m.vpcRouterStaticNAT(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.StaticNAT.[]Config,omitempty,recursive",
 				},
 			},
@@ -804,7 +802,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "PortForwarding",
 				Type: m.vpcRouterPortForwarding(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.PortForwarding.[]Config,omitempty,recursive",
 				},
 			},
@@ -812,7 +809,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "Firewall",
 				Type: m.vpcRouterFirewall(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.Firewall.[]Config,omitempty,recursive",
 				},
 			},
@@ -820,7 +816,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "DHCPServer",
 				Type: m.vpcRouterDHCPServer(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.DHCPServer.[]Config,omitempty,recursive",
 				},
 			},
@@ -828,7 +823,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "DHCPStaticMapping",
 				Type: m.vpcRouterDHCPStaticMapping(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.DHCPStaticMapping.[]Config,omitempty,recursive",
 				},
 			},
@@ -836,7 +830,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "PPTPServer",
 				Type: m.vpcRouterPPTPServer(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.PPTPServer.Config,omitempty,recursive",
 				},
 			},
@@ -851,7 +844,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "L2TPIPsecServer",
 				Type: m.vpcRouterL2TPIPsecServer(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.L2TPIPsecServer.Config,omitempty,recursive",
 				},
 			},
@@ -866,7 +858,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "RemoteAccessUsers",
 				Type: m.vpcRouterRemoteAccessUser(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.RemoteAccessUsers.[]Config,omitempty,recursive",
 				},
 			},
@@ -874,7 +865,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "SiteToSiteIPsecVPN",
 				Type: m.vpcRouterSiteToSiteIPsecVPN(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive",
 				},
 			},
@@ -882,7 +872,6 @@ func (m *modelsDef) vpcRouterSetting() *dsl.Model {
 				Name: "StaticRoute",
 				Type: m.vpcRouterStaticRoute(),
 				Tags: &dsl.FieldTags{
-					JSON:    ",omitempty",
 					MapConv: "Router.StaticRoutes.[]Config,omitempty,recursive",
 				},
 			},

--- a/sacloud/naked/vpc_router.go
+++ b/sacloud/naked/vpc_router.go
@@ -84,7 +84,7 @@ type VPCRouterInterface struct {
 	// Index 仮想フィールド、VPCルータなどでInterfaces(実体は[]*Interface)を扱う場合にUnmarshalJSONの中で設定される
 	//
 	// Findした際のAPIからの応答にも同名のフィールドが含まれるが無関係。
-	Index int
+	Index int `json:"-"`
 }
 
 // VPCRouterInterfaces Interface配列
@@ -282,7 +282,7 @@ type VPCRouterFirewallConfig struct {
 	Send    []*VPCRouterFirewallRule `yaml:"send"`
 
 	// Index 仮想フィールド UnmarshalJSONの中で設定される
-	Index int
+	Index int `json:"-"`
 }
 
 // VPCRouterFirewallRule ファイアウォール ルール

--- a/sacloud/naked/vpc_router.go
+++ b/sacloud/naked/vpc_router.go
@@ -205,27 +205,84 @@ type VPCRouterPortForwardingConfig struct {
 
 // VPCRouterFirewall ファイアウォール
 type VPCRouterFirewall struct {
-	Config  []*VPCRouterFirewallConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag           `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Config  VPCRouterFirewallConfigs `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag         `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 }
 
-// MarshalJSON Configが一つ以上ある場合にEnabledをtrueに設定する
+// MarshalJSON 常にEnabledをtrueに設定する
 func (f *VPCRouterFirewall) MarshalJSON() ([]byte, error) {
 	if f == nil {
 		return nil, nil
 	}
-	if len(f.Config) > 0 {
-		f.Enabled = types.StringTrue
-	}
+	f.Enabled = types.StringTrue
 	type alias VPCRouterFirewall
 	a := alias(*f)
 	return json.Marshal(&a)
 }
 
+// VPCRouterFirewallConfigs VPCルータのファイアウォール設定
+//
+// 配列のインデックスで対象インターフェースを表す
+type VPCRouterFirewallConfigs [8]*VPCRouterFirewallConfig
+
+// UnmarshalJSON 配列中にnullが返ってくる(VPCルータなど)への対応
+func (i *VPCRouterFirewallConfigs) UnmarshalJSON(b []byte) error {
+	type alias VPCRouterFirewallConfigs
+	var a alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+
+	var dest [8]*VPCRouterFirewallConfig
+	for i, v := range a {
+		if v != nil {
+			if v.Index == 0 {
+				v.Index = i
+			}
+			dest[v.Index] = v
+		}
+	}
+
+	*i = VPCRouterFirewallConfigs(dest)
+	return nil
+}
+
+// MarshalJSON 配列中にnullが入る場合(VPCルータなど)への対応
+func (i *VPCRouterFirewallConfigs) MarshalJSON() ([]byte, error) {
+
+	var dest [8]*VPCRouterFirewallConfig
+	for _, iface := range *i {
+		if iface != nil {
+			if iface.Receive == nil {
+				iface.Receive = make([]*VPCRouterFirewallRule, 0)
+			}
+			if iface.Send == nil {
+				iface.Send = make([]*VPCRouterFirewallRule, 0)
+			}
+			dest[iface.Index] = iface
+		}
+	}
+
+	for i, v := range dest {
+		if v == nil {
+			dest[i] = &VPCRouterFirewallConfig{
+				Receive: make([]*VPCRouterFirewallRule, 0),
+				Send:    make([]*VPCRouterFirewallRule, 0),
+				Index:   i,
+			}
+		}
+	}
+
+	return json.Marshal(dest)
+}
+
 // VPCRouterFirewallConfig ファイアウォール
 type VPCRouterFirewallConfig struct {
-	Receive []*VPCRouterFirewallRule `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Send    []*VPCRouterFirewallRule `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Receive []*VPCRouterFirewallRule `yaml:"receive"`
+	Send    []*VPCRouterFirewallRule `yaml:"send"`
+
+	// Index 仮想フィールド UnmarshalJSONの中で設定される
+	Index int
 }
 
 // VPCRouterFirewallRule ファイアウォール ルール

--- a/sacloud/naked/vpc_router_test.go
+++ b/sacloud/naked/vpc_router_test.go
@@ -144,7 +144,7 @@ const vpcRouterMultipleFirewallJSON = `
 }
 `
 
-var vpcRouterFirewallMarshaled = `{"Config":[{"Receive":[],"Send":[],"Index":0},{"Receive":[],"Send":[],"Index":1},{"Receive":[],"Send":[{"Protocol":"ip","Action":"deny","Description":""}],"Index":2},{"Receive":[],"Send":[],"Index":3},{"Receive":[],"Send":[],"Index":4},{"Receive":[],"Send":[],"Index":5},{"Receive":[],"Send":[],"Index":6},{"Receive":[],"Send":[],"Index":7}],"Enabled":"True"}`
+var vpcRouterFirewallMarshaled = `{"Config":[{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[{"Protocol":"ip","Action":"deny","Description":""}]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]}],"Enabled":"True"}`
 
 func TestVPCRouterFirewall_UnmarshalJSON(t *testing.T) {
 	var firewallConfig VPCRouterFirewall

--- a/sacloud/naked/vpc_router_test.go
+++ b/sacloud/naked/vpc_router_test.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,4 +91,88 @@ func TestVPCRouterRemarkServers_UnmarshalJSON(t *testing.T) {
 	err = json.Unmarshal([]byte(vpcRouterRemarkServersNotEmptyJSON), &remarkServers)
 	require.NoError(t, err)
 	require.Len(t, remarkServers, 1)
+}
+
+const vpcRouterMultipleFirewallJSON = `
+{
+	"Config": [
+      {
+		"Receive": [],
+		"Send": []
+      },
+      {
+		"Receive": [],
+		"Send": []
+      },
+      {
+		"Receive": [],
+		"Send": [
+			{
+                  "Protocol": "ip",
+                  "SourceNetwork": null,
+                  "SourcePort": null,
+                  "DestinationNetwork": null,
+                  "DestinationPort": null,
+                  "Action": "deny",
+                  "Logging": "False",
+                  "Description": ""
+            }
+		]
+      },
+      {
+		"Receive": [],
+		"Send": []
+      },
+      {
+		"Receive": [],
+		"Send": []
+      },
+      {
+		"Receive": [],
+		"Send": []
+      },
+      {
+		"Receive": [],
+		"Send": []
+      },
+      {
+		"Receive": [],
+		"Send": []
+      }
+	],
+	"Enabled": "True"
+}
+`
+
+var vpcRouterFirewallMarshaled = `{"Config":[{"Receive":[],"Send":[],"Index":0},{"Receive":[],"Send":[],"Index":1},{"Receive":[],"Send":[{"Protocol":"ip","Action":"deny","Description":""}],"Index":2},{"Receive":[],"Send":[],"Index":3},{"Receive":[],"Send":[],"Index":4},{"Receive":[],"Send":[],"Index":5},{"Receive":[],"Send":[],"Index":6},{"Receive":[],"Send":[],"Index":7}],"Enabled":"True"}`
+
+func TestVPCRouterFirewall_UnmarshalJSON(t *testing.T) {
+	var firewallConfig VPCRouterFirewall
+	err := json.Unmarshal([]byte(vpcRouterMultipleFirewallJSON), &firewallConfig)
+	require.NoError(t, err)
+	for i, v := range firewallConfig.Config {
+		require.Equal(t, i, v.Index)
+	}
+
+}
+
+func TestVPCRouterFirewall_MarshalJSON(t *testing.T) {
+	firewallConfig := &VPCRouterFirewall{
+		Config: VPCRouterFirewallConfigs{
+			{
+				Send: []*VPCRouterFirewallRule{
+					{
+						Protocol: "ip",
+						Action:   types.Actions.Deny,
+					},
+				},
+				Index: 2,
+			},
+		},
+		Enabled: types.StringFlag(true),
+	}
+
+	data, err := json.Marshal(firewallConfig)
+	require.NoError(t, err)
+	require.Equal(t, vpcRouterFirewallMarshaled, string(data))
 }

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -27743,19 +27743,19 @@ func (o *VPCRouter) SetZoneID(v types.ID) {
 type VPCRouterSetting struct {
 	VRID                      int                            `json:",omitempty" mapconv:"Router.VRID"`
 	InternetConnectionEnabled types.StringFlag               `mapconv:"Router.InternetConnection.Enabled,omitempty"`
-	Interfaces                []*VPCRouterInterfaceSetting   `json:",omitempty" mapconv:"Router.[]Interfaces,omitempty,recursive"`
-	StaticNAT                 []*VPCRouterStaticNAT          `json:",omitempty" mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
-	PortForwarding            []*VPCRouterPortForwarding     `json:",omitempty" mapconv:"Router.PortForwarding.[]Config,omitempty,recursive"`
-	Firewall                  []*VPCRouterFirewall           `json:",omitempty" mapconv:"Router.Firewall.[]Config,omitempty,recursive"`
-	DHCPServer                []*VPCRouterDHCPServer         `json:",omitempty" mapconv:"Router.DHCPServer.[]Config,omitempty,recursive"`
-	DHCPStaticMapping         []*VPCRouterDHCPStaticMapping  `json:",omitempty" mapconv:"Router.DHCPStaticMapping.[]Config,omitempty,recursive"`
-	PPTPServer                *VPCRouterPPTPServer           `json:",omitempty" mapconv:"Router.PPTPServer.Config,omitempty,recursive"`
+	Interfaces                []*VPCRouterInterfaceSetting   `mapconv:"Router.[]Interfaces,omitempty,recursive"`
+	StaticNAT                 []*VPCRouterStaticNAT          `mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
+	PortForwarding            []*VPCRouterPortForwarding     `mapconv:"Router.PortForwarding.[]Config,omitempty,recursive"`
+	Firewall                  []*VPCRouterFirewall           `mapconv:"Router.Firewall.[]Config,omitempty,recursive"`
+	DHCPServer                []*VPCRouterDHCPServer         `mapconv:"Router.DHCPServer.[]Config,omitempty,recursive"`
+	DHCPStaticMapping         []*VPCRouterDHCPStaticMapping  `mapconv:"Router.DHCPStaticMapping.[]Config,omitempty,recursive"`
+	PPTPServer                *VPCRouterPPTPServer           `mapconv:"Router.PPTPServer.Config,omitempty,recursive"`
 	PPTPServerEnabled         types.StringFlag               `mapconv:"Router.PPTPServer.Enabled,omitempty"`
-	L2TPIPsecServer           *VPCRouterL2TPIPsecServer      `json:",omitempty" mapconv:"Router.L2TPIPsecServer.Config,omitempty,recursive"`
+	L2TPIPsecServer           *VPCRouterL2TPIPsecServer      `mapconv:"Router.L2TPIPsecServer.Config,omitempty,recursive"`
 	L2TPIPsecServerEnabled    types.StringFlag               `mapconv:"Router.L2TPIPsecServer.Enabled,omitempty"`
-	RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `json:",omitempty" mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
-	SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `json:",omitempty" mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
-	StaticRoute               []*VPCRouterStaticRoute        `json:",omitempty" mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
+	RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
+	SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
+	StaticRoute               []*VPCRouterStaticRoute        `mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
 	SyslogHost                string                         `mapconv:"Router.SyslogHost"`
 }
 
@@ -27769,19 +27769,19 @@ func (o *VPCRouterSetting) setDefaults() interface{} {
 	return &struct {
 		VRID                      int                            `json:",omitempty" mapconv:"Router.VRID"`
 		InternetConnectionEnabled types.StringFlag               `mapconv:"Router.InternetConnection.Enabled,omitempty"`
-		Interfaces                []*VPCRouterInterfaceSetting   `json:",omitempty" mapconv:"Router.[]Interfaces,omitempty,recursive"`
-		StaticNAT                 []*VPCRouterStaticNAT          `json:",omitempty" mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
-		PortForwarding            []*VPCRouterPortForwarding     `json:",omitempty" mapconv:"Router.PortForwarding.[]Config,omitempty,recursive"`
-		Firewall                  []*VPCRouterFirewall           `json:",omitempty" mapconv:"Router.Firewall.[]Config,omitempty,recursive"`
-		DHCPServer                []*VPCRouterDHCPServer         `json:",omitempty" mapconv:"Router.DHCPServer.[]Config,omitempty,recursive"`
-		DHCPStaticMapping         []*VPCRouterDHCPStaticMapping  `json:",omitempty" mapconv:"Router.DHCPStaticMapping.[]Config,omitempty,recursive"`
-		PPTPServer                *VPCRouterPPTPServer           `json:",omitempty" mapconv:"Router.PPTPServer.Config,omitempty,recursive"`
+		Interfaces                []*VPCRouterInterfaceSetting   `mapconv:"Router.[]Interfaces,omitempty,recursive"`
+		StaticNAT                 []*VPCRouterStaticNAT          `mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
+		PortForwarding            []*VPCRouterPortForwarding     `mapconv:"Router.PortForwarding.[]Config,omitempty,recursive"`
+		Firewall                  []*VPCRouterFirewall           `mapconv:"Router.Firewall.[]Config,omitempty,recursive"`
+		DHCPServer                []*VPCRouterDHCPServer         `mapconv:"Router.DHCPServer.[]Config,omitempty,recursive"`
+		DHCPStaticMapping         []*VPCRouterDHCPStaticMapping  `mapconv:"Router.DHCPStaticMapping.[]Config,omitempty,recursive"`
+		PPTPServer                *VPCRouterPPTPServer           `mapconv:"Router.PPTPServer.Config,omitempty,recursive"`
 		PPTPServerEnabled         types.StringFlag               `mapconv:"Router.PPTPServer.Enabled,omitempty"`
-		L2TPIPsecServer           *VPCRouterL2TPIPsecServer      `json:",omitempty" mapconv:"Router.L2TPIPsecServer.Config,omitempty,recursive"`
+		L2TPIPsecServer           *VPCRouterL2TPIPsecServer      `mapconv:"Router.L2TPIPsecServer.Config,omitempty,recursive"`
 		L2TPIPsecServerEnabled    types.StringFlag               `mapconv:"Router.L2TPIPsecServer.Enabled,omitempty"`
-		RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `json:",omitempty" mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
-		SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `json:",omitempty" mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
-		StaticRoute               []*VPCRouterStaticRoute        `json:",omitempty" mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
+		RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
+		SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
+		StaticRoute               []*VPCRouterStaticRoute        `mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
 		SyslogHost                string                         `mapconv:"Router.SyslogHost"`
 	}{
 		VRID:                      o.GetVRID(),

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -27742,7 +27742,7 @@ func (o *VPCRouter) SetZoneID(v types.ID) {
 // VPCRouterSetting represents API parameter/response structure
 type VPCRouterSetting struct {
 	VRID                      int                            `json:",omitempty" mapconv:"Router.VRID"`
-	InternetConnectionEnabled types.StringFlag               `json:",omitempty" mapconv:"Router.InternetConnection.Enabled,omitempty"`
+	InternetConnectionEnabled types.StringFlag               `mapconv:"Router.InternetConnection.Enabled,omitempty"`
 	Interfaces                []*VPCRouterInterfaceSetting   `json:",omitempty" mapconv:"Router.[]Interfaces,omitempty,recursive"`
 	StaticNAT                 []*VPCRouterStaticNAT          `json:",omitempty" mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
 	PortForwarding            []*VPCRouterPortForwarding     `json:",omitempty" mapconv:"Router.PortForwarding.[]Config,omitempty,recursive"`
@@ -27750,9 +27750,9 @@ type VPCRouterSetting struct {
 	DHCPServer                []*VPCRouterDHCPServer         `json:",omitempty" mapconv:"Router.DHCPServer.[]Config,omitempty,recursive"`
 	DHCPStaticMapping         []*VPCRouterDHCPStaticMapping  `json:",omitempty" mapconv:"Router.DHCPStaticMapping.[]Config,omitempty,recursive"`
 	PPTPServer                *VPCRouterPPTPServer           `json:",omitempty" mapconv:"Router.PPTPServer.Config,omitempty,recursive"`
-	PPTPServerEnabled         types.StringFlag               `json:",omitempty" mapconv:"Router.PPTPServer.Enabled,omitempty"`
+	PPTPServerEnabled         types.StringFlag               `mapconv:"Router.PPTPServer.Enabled,omitempty"`
 	L2TPIPsecServer           *VPCRouterL2TPIPsecServer      `json:",omitempty" mapconv:"Router.L2TPIPsecServer.Config,omitempty,recursive"`
-	L2TPIPsecServerEnabled    types.StringFlag               `json:",omitempty" mapconv:"Router.L2TPIPsecServer.Enabled,omitempty"`
+	L2TPIPsecServerEnabled    types.StringFlag               `mapconv:"Router.L2TPIPsecServer.Enabled,omitempty"`
 	RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `json:",omitempty" mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
 	SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `json:",omitempty" mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
 	StaticRoute               []*VPCRouterStaticRoute        `json:",omitempty" mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
@@ -27768,7 +27768,7 @@ func (o *VPCRouterSetting) Validate() error {
 func (o *VPCRouterSetting) setDefaults() interface{} {
 	return &struct {
 		VRID                      int                            `json:",omitempty" mapconv:"Router.VRID"`
-		InternetConnectionEnabled types.StringFlag               `json:",omitempty" mapconv:"Router.InternetConnection.Enabled,omitempty"`
+		InternetConnectionEnabled types.StringFlag               `mapconv:"Router.InternetConnection.Enabled,omitempty"`
 		Interfaces                []*VPCRouterInterfaceSetting   `json:",omitempty" mapconv:"Router.[]Interfaces,omitempty,recursive"`
 		StaticNAT                 []*VPCRouterStaticNAT          `json:",omitempty" mapconv:"Router.StaticNAT.[]Config,omitempty,recursive"`
 		PortForwarding            []*VPCRouterPortForwarding     `json:",omitempty" mapconv:"Router.PortForwarding.[]Config,omitempty,recursive"`
@@ -27776,9 +27776,9 @@ func (o *VPCRouterSetting) setDefaults() interface{} {
 		DHCPServer                []*VPCRouterDHCPServer         `json:",omitempty" mapconv:"Router.DHCPServer.[]Config,omitempty,recursive"`
 		DHCPStaticMapping         []*VPCRouterDHCPStaticMapping  `json:",omitempty" mapconv:"Router.DHCPStaticMapping.[]Config,omitempty,recursive"`
 		PPTPServer                *VPCRouterPPTPServer           `json:",omitempty" mapconv:"Router.PPTPServer.Config,omitempty,recursive"`
-		PPTPServerEnabled         types.StringFlag               `json:",omitempty" mapconv:"Router.PPTPServer.Enabled,omitempty"`
+		PPTPServerEnabled         types.StringFlag               `mapconv:"Router.PPTPServer.Enabled,omitempty"`
 		L2TPIPsecServer           *VPCRouterL2TPIPsecServer      `json:",omitempty" mapconv:"Router.L2TPIPsecServer.Config,omitempty,recursive"`
-		L2TPIPsecServerEnabled    types.StringFlag               `json:",omitempty" mapconv:"Router.L2TPIPsecServer.Enabled,omitempty"`
+		L2TPIPsecServerEnabled    types.StringFlag               `mapconv:"Router.L2TPIPsecServer.Enabled,omitempty"`
 		RemoteAccessUsers         []*VPCRouterRemoteAccessUser   `json:",omitempty" mapconv:"Router.RemoteAccessUsers.[]Config,omitempty,recursive"`
 		SiteToSiteIPsecVPN        []*VPCRouterSiteToSiteIPsecVPN `json:",omitempty" mapconv:"Router.SiteToSiteIPsecVPN.[]Config,omitempty,recursive"`
 		StaticRoute               []*VPCRouterStaticRoute        `json:",omitempty" mapconv:"Router.StaticRoutes.[]Config,omitempty,recursive"`
@@ -28200,6 +28200,7 @@ func (o *VPCRouterPortForwarding) SetDescription(v string) {
 type VPCRouterFirewall struct {
 	Send    []*VPCRouterFirewallRule
 	Receive []*VPCRouterFirewallRule
+	Index   int
 }
 
 // Validate validates by field tags
@@ -28212,9 +28213,11 @@ func (o *VPCRouterFirewall) setDefaults() interface{} {
 	return &struct {
 		Send    []*VPCRouterFirewallRule
 		Receive []*VPCRouterFirewallRule
+		Index   int
 	}{
 		Send:    o.GetSend(),
 		Receive: o.GetReceive(),
+		Index:   o.GetIndex(),
 	}
 }
 
@@ -28236,6 +28239,16 @@ func (o *VPCRouterFirewall) GetReceive() []*VPCRouterFirewallRule {
 // SetReceive sets value to Receive
 func (o *VPCRouterFirewall) SetReceive(v []*VPCRouterFirewallRule) {
 	o.Receive = v
+}
+
+// GetIndex returns value of Index
+func (o *VPCRouterFirewall) GetIndex() int {
+	return o.Index
+}
+
+// SetIndex sets value to Index
+func (o *VPCRouterFirewall) SetIndex(v int) {
+	o.Index = v
 }
 
 /*************************************************

--- a/utils/vpcrouter/builder.go
+++ b/utils/vpcrouter/builder.go
@@ -26,8 +26,14 @@ import (
 	"github.com/sacloud/libsacloud/v2/utils/setup"
 )
 
-// DefaultNICUpdateWaitDuration NIC切断/削除後の待ち時間デフォルト値
-var DefaultNICUpdateWaitDuration = 5 * time.Second
+var (
+	// DefaultNICUpdateWaitDuration NIC切断/削除後の待ち時間デフォルト値
+	DefaultNICUpdateWaitDuration = 5 * time.Second
+	// DefaultSetupOptions RetryableSetupのデフォルトオプション
+	DefaultSetupOptions = &RetryableSetupParameter{
+		NICUpdateWaitDuration: DefaultNICUpdateWaitDuration,
+	}
+)
 
 // Builder VPCルータの構築を行う
 type Builder struct {
@@ -80,9 +86,7 @@ type RetryableSetupParameter struct {
 
 func (b *Builder) init() {
 	if b.SetupOptions == nil {
-		b.SetupOptions = &RetryableSetupParameter{
-			NICUpdateWaitDuration: DefaultNICUpdateWaitDuration,
-		}
+		b.SetupOptions = DefaultSetupOptions
 	}
 	if b.RouterSetting == nil {
 		b.RouterSetting = &RouterSetting{

--- a/utils/vpcrouter/builder_nic.go
+++ b/utils/vpcrouter/builder_nic.go
@@ -48,7 +48,6 @@ type PremiumNICSetting struct {
 	IPAddress2       string
 	VirtualIPAddress string
 	IPAliases        []string
-	NetworkMaskLen   int
 }
 
 func (s *PremiumNICSetting) getConnectedSwitch() *sacloud.ApplianceConnectedSwitch {
@@ -64,7 +63,6 @@ func (s *PremiumNICSetting) getInterfaceSetting() *sacloud.VPCRouterInterfaceSet
 		IPAddress:        []string{s.IPAddress1, s.IPAddress2},
 		VirtualIPAddress: s.VirtualIPAddress,
 		IPAliases:        s.IPAliases,
-		NetworkMaskLen:   s.NetworkMaskLen,
 		Index:            0,
 	}
 }

--- a/utils/vpcrouter/builder_test.go
+++ b/utils/vpcrouter/builder_test.go
@@ -185,7 +185,6 @@ func TestBuilder_BuildWithRouter(t *testing.T) {
 						IPAddress1:       addresses[1],
 						IPAddress2:       addresses[2],
 						IPAliases:        []string{addresses[3], addresses[4]},
-						NetworkMaskLen:   28,
 					},
 					AdditionalNICSettings: []AdditionalNICSettingHolder{
 						&AdditionalPremiumNICSetting{
@@ -247,7 +246,6 @@ func TestBuilder_BuildWithRouter(t *testing.T) {
 							IPAddress1:       addresses[1],
 							IPAddress2:       addresses[2],
 							IPAliases:        []string{addresses[3], addresses[4]},
-							NetworkMaskLen:   28,
 						},
 						AdditionalNICSettings: []AdditionalNICSettingHolder{
 							&AdditionalPremiumNICSetting{


### PR DESCRIPTION
(feedback from terraform-provider-sakuracloud)

VPCルータ周りの改善


- 不要な`omitempty`タグを除去
- utils/vpcrouterでBuild時にルータのネットワークマスク長の指定を不要に
- ファイアウォール設定にIndexを付与

#### `ファイアウォール設定にIndexを付与する`の詳細

VPCルータのファイアウォール設定は以下のようにインターフェースごとにルールを保持しておく必要がある。(Configの各要素がインターフェースに対応する。)

```js
{
	"Config": [
      {
		"Receive": [],
		"Send": []
      },
      {
		"Receive": [],
		"Send": []
      },
      {
		"Receive": [],
		"Send": [
			{
                  "Protocol": "ip",
                  "SourceNetwork": null,
                  "SourcePort": null,
                  "DestinationNetwork": null,
                  "DestinationPort": null,
                  "Action": "deny",
                  "Logging": "False",
                  "Description": ""
            }
		]
      },
      {
		"Receive": [],
		"Send": []
      },
      {
		"Receive": [],
		"Send": []
      },
      {
		"Receive": [],
		"Send": []
      },
      {
		"Receive": [],
		"Send": []
      },
      {
		"Receive": [],
		"Send": []
      }
	],
	"Enabled": "True"
}
```

このままだと扱いづらいため、擬似的にIndexを持たせカスタムMarshal/UnmarshalJSONを実装することで配列を意識せずとも扱えるようにする。

この例に対応するgoのコードは以下のようになる。

```go
&VPCRouterFirewall{
	Config: VPCRouterFirewallConfigs{
		{
			Send: []*VPCRouterFirewallRule{
				{
					Protocol: "ip",
					Action:   types.Actions.Deny,
				},
			},
			Index: 2,
		},
	},
	Enabled: types.StringFlag(true),
}
```