### PR TITLE
Fix typo: from pool to polling

### DIFF
--- a/sacloud/state_functions.go
+++ b/sacloud/state_functions.go
@@ -18,7 +18,7 @@ import "github.com/sacloud/libsacloud/v2/sacloud/types"
 
 // WaiterForUp 起動完了まで待つためのStateWaiterを返す
 func WaiterForUp(readFunc StateReadFunc) StateWaiter {
-	return &StatePollWaiter{
+	return &StatePollingWaiter{
 		ReadFunc: readFunc,
 		TargetAvailability: []types.EAvailability{
 			types.Availabilities.Available,
@@ -45,7 +45,7 @@ func WaiterForUp(readFunc StateReadFunc) StateWaiter {
 //
 // アプライアンス向けに404発生時のリトライを設定可能
 func WaiterForApplianceUp(readFunc StateReadFunc, notFoundRetry int) StateWaiter {
-	return &StatePollWaiter{
+	return &StatePollingWaiter{
 		ReadFunc: readFunc,
 		TargetAvailability: []types.EAvailability{
 			types.Availabilities.Available,
@@ -71,7 +71,7 @@ func WaiterForApplianceUp(readFunc StateReadFunc, notFoundRetry int) StateWaiter
 
 // WaiterForDown シャットダウン完了まで待つためのStateWaiterを返す
 func WaiterForDown(readFunc StateReadFunc) StateWaiter {
-	return &StatePollWaiter{
+	return &StatePollingWaiter{
 		ReadFunc: readFunc,
 		TargetAvailability: []types.EAvailability{
 			types.Availabilities.Available,
@@ -92,7 +92,7 @@ func WaiterForDown(readFunc StateReadFunc) StateWaiter {
 
 // WaiterForReady リソースの利用準備完了まで待つためのStateWaiterを返す
 func WaiterForReady(readFunc StateReadFunc) StateWaiter {
-	return &StatePollWaiter{
+	return &StatePollingWaiter{
 		ReadFunc: readFunc,
 		TargetAvailability: []types.EAvailability{
 			types.Availabilities.Available,

--- a/sacloud/testutil/util.go
+++ b/sacloud/testutil/util.go
@@ -56,7 +56,7 @@ func SingletonAPICaller() *sacloud.Client {
 	defer accTestMu.Unlock()
 	accTestOnce.Do(func() {
 		if !IsAccTest() {
-			sacloud.DefaultStatePollInterval = 100 * time.Millisecond
+			sacloud.DefaultStatePollingInterval = 100 * time.Millisecond
 			fake.SwitchFactoryFuncToFake()
 		}
 

--- a/utils/setup/retryable_setup.go
+++ b/utils/setup/retryable_setup.go
@@ -43,8 +43,8 @@ var (
 	// DefaultDeleteWaitInterval リソースごとの削除API呼び出しのリトライ間隔
 	DefaultDeleteWaitInterval = 10 * time.Second
 
-	// DefaultPoolInterval ポーリング処理の間隔
-	DefaultPoolInterval = 5 * time.Second
+	// DefaultPollingInterval ポーリング処理の間隔
+	DefaultPollingInterval = 5 * time.Second
 )
 
 // CreateFunc リソース作成関数
@@ -91,7 +91,7 @@ type RetryableSetup struct {
 	// DeleteRetryInterval 削除リトライ間隔
 	DeleteRetryInterval time.Duration
 	// sacloud.StateWaiterによるステート待ちの間隔
-	PollInterval time.Duration
+	PollingInterval time.Duration
 }
 
 // Setup リソースのビルドを行う。必要に応じてリトライ(リソースの削除&再作成)を行う。
@@ -164,8 +164,8 @@ func (r *RetryableSetup) init() {
 	if r.ProvisioningRetryInterval <= 0 {
 		r.ProvisioningRetryInterval = DefaultProvisioningWaitInterval
 	}
-	if r.PollInterval <= 0 {
-		r.PollInterval = DefaultPoolInterval
+	if r.PollingInterval <= 0 {
+		r.PollingInterval = DefaultPollingInterval
 	}
 }
 
@@ -178,7 +178,7 @@ func (r *RetryableSetup) createResource(ctx context.Context, zone string) (acces
 
 func (r *RetryableSetup) waitForCopyWithCleanup(ctx context.Context, zone string, id types.ID) (interface{}, error) {
 
-	waiter := &sacloud.StatePollWaiter{
+	waiter := &sacloud.StatePollingWaiter{
 		ReadFunc: func() (interface{}, error) {
 			return r.Read(ctx, zone, id)
 		},
@@ -193,7 +193,7 @@ func (r *RetryableSetup) waitForCopyWithCleanup(ctx context.Context, zone string
 			types.Availabilities.Transfering,
 			types.Availabilities.Discontinued,
 		},
-		PollInterval: r.PollInterval,
+		PollingInterval: r.PollingInterval,
 	}
 
 	//wait
@@ -257,7 +257,7 @@ func (r *RetryableSetup) provisionBeforeUp(ctx context.Context, zone string, id 
 
 func (r *RetryableSetup) waitForUp(ctx context.Context, zone string, id types.ID, created interface{}) error {
 	if r.IsWaitForUp && created != nil {
-		waiter := &sacloud.StatePollWaiter{
+		waiter := &sacloud.StatePollingWaiter{
 			ReadFunc: func() (interface{}, error) {
 				return r.Read(ctx, zone, id)
 			},
@@ -279,7 +279,7 @@ func (r *RetryableSetup) waitForUp(ctx context.Context, zone string, id types.ID
 				types.ServerInstanceStatuses.Cleaning,
 				types.ServerInstanceStatuses.Down,
 			},
-			PollInterval: r.PollInterval,
+			PollingInterval: r.PollingInterval,
 		}
 		_, err := waiter.WaitForState(ctx)
 		return err

--- a/utils/setup/retryable_setup_test.go
+++ b/utils/setup/retryable_setup_test.go
@@ -66,7 +66,7 @@ func TestRetryableSetup_Setup(t *testing.T) {
 				},
 				ProvisioningRetryInterval: time.Millisecond,
 				DeleteRetryInterval:       time.Millisecond,
-				PollInterval:              time.Millisecond,
+				PollingInterval:           time.Millisecond,
 			}
 			res, err := retryable.Setup(ctx, zone)
 
@@ -86,7 +86,7 @@ func TestRetryableSetup_Setup(t *testing.T) {
 				},
 				ProvisioningRetryInterval: time.Millisecond,
 				DeleteRetryInterval:       time.Millisecond,
-				PollInterval:              time.Millisecond,
+				PollingInterval:           time.Millisecond,
 			}
 			res, err := retryable.Setup(ctx, zone)
 
@@ -114,7 +114,7 @@ func TestRetryableSetup_Setup(t *testing.T) {
 				}, 3),
 				ProvisioningRetryInterval: time.Millisecond,
 				DeleteRetryInterval:       time.Millisecond,
-				PollInterval:              time.Millisecond,
+				PollingInterval:           time.Millisecond,
 			}
 
 			res, err := retryable.Setup(ctx, zone)
@@ -139,7 +139,7 @@ func TestRetryableSetup_Setup(t *testing.T) {
 				}, 5),
 				ProvisioningRetryInterval: time.Millisecond,
 				DeleteRetryInterval:       time.Millisecond,
-				PollInterval:              time.Millisecond,
+				PollingInterval:           time.Millisecond,
 			}
 
 			res, err := retryable.Setup(ctx, zone)

--- a/utils/setup/setup_test.go
+++ b/utils/setup/setup_test.go
@@ -77,7 +77,7 @@ func TestRetryableSetup(t *testing.T) {
 				if !testutil.IsAccTest() {
 					nfsSetup.ProvisioningRetryInterval = time.Millisecond
 					nfsSetup.DeleteRetryInterval = time.Millisecond
-					nfsSetup.PollInterval = time.Millisecond
+					nfsSetup.PollingInterval = time.Millisecond
 				}
 
 				return nfsSetup.Setup(ctx, testZone)

--- a/utils/vpcrouter/builder.go
+++ b/utils/vpcrouter/builder.go
@@ -84,7 +84,7 @@ type RetryableSetupParameter struct {
 	// DeleteRetryInterval 削除リトライ間隔
 	DeleteRetryInterval time.Duration
 	// sacloud.StateWaiterによるステート待ちの間隔
-	PollInterval time.Duration
+	PollingInterval time.Duration
 }
 
 func (b *Builder) init() {
@@ -268,7 +268,7 @@ func (b *Builder) Build(ctx context.Context, client sacloud.VPCRouterAPI, zone s
 		ProvisioningRetryInterval: b.SetupOptions.ProvisioningRetryInterval,
 		DeleteRetryCount:          b.SetupOptions.DeleteRetryCount,
 		DeleteRetryInterval:       b.SetupOptions.DeleteRetryInterval,
-		PollInterval:              b.SetupOptions.PollInterval,
+		PollingInterval:           b.SetupOptions.PollingInterval,
 	}
 
 	result, err := builder.Setup(ctx, zone)

--- a/utils/vpcrouter/builder_test.go
+++ b/utils/vpcrouter/builder_test.go
@@ -30,7 +30,7 @@ func getSetupOption() *RetryableSetupParameter {
 	return &RetryableSetupParameter{
 		DeleteRetryInterval:       10 * time.Millisecond,
 		ProvisioningRetryInterval: 10 * time.Millisecond,
-		PollInterval:              10 * time.Millisecond,
+		PollingInterval:           10 * time.Millisecond,
 		NICUpdateWaitDuration:     10 * time.Millisecond,
 	}
 }


### PR DESCRIPTION
`pool`を`poll`に修正。
また、typoではない`pool`も存在するため`polling`と変更する。