### PR TITLE
Fix some wrong behavior at utils/builder/server

### DIFF
--- a/sacloud/fake/ops_server.go
+++ b/sacloud/fake/ops_server.go
@@ -280,6 +280,13 @@ func (o *ServerOp) ChangePlan(ctx context.Context, zone string, id types.ID, pla
 			putDisk(zone, disk)
 		}
 	}
+	for _, nic := range newServer.Interfaces {
+		iface, err := NewInterfaceOp().Read(ctx, zone, nic.ID)
+		if err == nil {
+			iface.ServerID = newServer.ID
+			putInterface(zone, iface)
+		}
+	}
 
 	return newServer, nil
 }

--- a/utils/builder/disk/api_client.go
+++ b/utils/builder/disk/api_client.go
@@ -50,6 +50,7 @@ type CreateDiskHandler interface {
 	Update(ctx context.Context, zone string, id types.ID, updateParam *sacloud.DiskUpdateRequest) (*sacloud.Disk, error)
 	Config(ctx context.Context, zone string, id types.ID, editParam *sacloud.DiskEditRequest) error
 	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Disk, error)
+	ConnectToServer(ctx context.Context, zone string, id types.ID, serverID types.ID) error
 }
 
 // PlanReader ディスクプラン取得のためのインターフェース

--- a/utils/builder/disk/api_client_test.go
+++ b/utils/builder/disk/api_client_test.go
@@ -88,6 +88,21 @@ func (d *dummyDiskHandler) Read(ctx context.Context, zone string, id types.ID) (
 	return d.disk, nil
 }
 
+func (d *dummyDiskHandler) Update(ctx context.Context, zone string, id types.ID, updateParam *sacloud.DiskUpdateRequest) (*sacloud.Disk, error) {
+	if d.err != nil {
+		return nil, d.err
+	}
+	return d.disk, nil
+}
+
+func (d *dummyDiskHandler) Config(ctx context.Context, zone string, id types.ID, editParam *sacloud.DiskEditRequest) error {
+	return d.err
+}
+
+func (d *dummyDiskHandler) ConnectToServer(ctx context.Context, zone string, id types.ID, serverID types.ID) error {
+	return d.err
+}
+
 type dummyDiskPlanReader struct {
 	diskPlan *sacloud.DiskPlan
 	err      error

--- a/utils/builder/server/builder.go
+++ b/utils/builder/server/builder.go
@@ -425,6 +425,7 @@ func (b *Builder) createServer(ctx context.Context, zone string) (*sacloud.Serve
 		Tags:                 b.Tags,
 		IconID:               b.IconID,
 		WaitDiskMigration:    false,
+		PrivateHostID:        b.PrivateHostID,
 		ConnectedSwitches:    []*sacloud.ConnectedSwitch{},
 	}
 	if b.NIC != nil {

--- a/utils/builder/server/builder_test.go
+++ b/utils/builder/server/builder_test.go
@@ -73,10 +73,16 @@ func TestBuilder_Validate(t *testing.T) {
 			err: errors.New("NIC is required when AdditionalNICs is specified"),
 		},
 		{
-			msg: "Additional NICs over 4",
+			msg: "Additional NICs over 9",
 			in: &Builder{
 				NIC: &SharedNICSetting{},
 				AdditionalNICs: []AdditionalNICSettingHolder{
+					&DisconnectedNICSetting{},
+					&DisconnectedNICSetting{},
+					&DisconnectedNICSetting{},
+					&DisconnectedNICSetting{},
+					&DisconnectedNICSetting{},
+					&DisconnectedNICSetting{},
 					&DisconnectedNICSetting{},
 					&DisconnectedNICSetting{},
 					&DisconnectedNICSetting{},
@@ -86,7 +92,7 @@ func TestBuilder_Validate(t *testing.T) {
 					ServerPlan: &dummyPlanFinder{},
 				},
 			},
-			err: errors.New("AdditionalNICs must be less than 4"),
+			err: errors.New("AdditionalNICs must be less than 9"),
 		},
 		{
 			msg: "invalid InterfaceDriver",


### PR DESCRIPTION
follow up #423 

- ConnectedDiskBuilderでディスクの接続APIを呼ぶように修正
- ConnectedDiskBuilderで必要に応じてディスクの修正APIを呼ぶように修正
- fakeドライバーでサーバのプラン変更に伴うID変更をインターフェースに伝搬させるように修正
- ServerBuilderでNICのUpstreamTypeではなくScopeを利用するように修正
- NIC上限数を10に変更
- サーバ作成時にPrivateHostIDを設定するように修正