### PR TITLE
Fix some bugs at utils/builder

### DIFF
--- a/utils/builder/disk/builder.go
+++ b/utils/builder/disk/builder.go
@@ -605,6 +605,12 @@ func (d *ConnectedDiskBuilder) Build(ctx context.Context, zone string, serverID 
 		if err := d.Client.Disk.Config(ctx, zone, d.ID, req); err != nil {
 			return nil, err
 		}
+		waiter := sacloud.WaiterForReady(func() (interface{}, error) {
+			return d.Client.Disk.Read(ctx, zone, d.ID)
+		})
+		if _, err := waiter.WaitForState(ctx); err != nil {
+			return nil, err
+		}
 	}
 	return res, nil
 }
@@ -622,6 +628,12 @@ func (d *ConnectedDiskBuilder) Update(ctx context.Context, zone string) (*Update
 			return nil, err
 		}
 		if err := d.Client.Disk.Config(ctx, zone, d.ID, req); err != nil {
+			return nil, err
+		}
+		waiter := sacloud.WaiterForReady(func() (interface{}, error) {
+			return d.Client.Disk.Read(ctx, zone, d.ID)
+		})
+		if _, err := waiter.WaitForState(ctx); err != nil {
 			return nil, err
 		}
 	}

--- a/utils/builder/server/builder.go
+++ b/utils/builder/server/builder.go
@@ -638,8 +638,10 @@ func (b *Builder) reconcileInterfaces(ctx context.Context, zone string, server *
 					return err
 				}
 			}
-			if err := b.Client.Interface.ConnectToPacketFilter(ctx, zone, nic.ID, desired.packetFilterID); err != nil {
-				return err
+			if !desired.packetFilterID.IsEmpty() {
+				if err := b.Client.Interface.ConnectToPacketFilter(ctx, zone, nic.ID, desired.packetFilterID); err != nil {
+					return err
+				}
 			}
 		}
 		if desired.displayIP != nic.UserIPAddress {


### PR DESCRIPTION
(from https://github.com/sacloud/terraform-provider-sakuracloud/pull/567)
follow up #423 

- パケットフィルタ接続時にIDに値があるか確認する
- DiskBuilderで`Disk.Config`を呼んだ後に完了まで待機する