### PR TITLE
Add power management utils

### DIFF
--- a/utils/builder/server/builder.go
+++ b/utils/builder/server/builder.go
@@ -22,10 +22,9 @@ import (
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
-
 	"github.com/sacloud/libsacloud/v2/utils/builder"
 	"github.com/sacloud/libsacloud/v2/utils/builder/disk"
-
+	"github.com/sacloud/libsacloud/v2/utils/power"
 	"github.com/sacloud/libsacloud/v2/utils/query"
 )
 
@@ -152,19 +151,9 @@ func (b *Builder) Build(ctx context.Context, zone string) (*BuildResult, error) 
 
 	// bool
 	if b.BootAfterCreate {
-		if err := b.Client.Server.Boot(ctx, zone, server.ID); err != nil {
+		if err := power.BootServer(ctx, b.Client.Server, zone, server.ID); err != nil {
 			return nil, err
 		}
-		// wait
-		waiter := sacloud.WaiterForUp(func() (interface{}, error) {
-			return b.Client.Server.Read(ctx, zone, server.ID)
-		})
-
-		lastState, err := waiter.WaitForState(ctx)
-		if err != nil {
-			return nil, err
-		}
-		server = lastState.(*sacloud.Server)
 	}
 
 	b.ServerID = result.ServerID
@@ -231,13 +220,7 @@ func (b *Builder) Update(ctx context.Context, zone string) (*BuildResult, error)
 
 	// shutdown
 	if isNeedShutdown && server.InstanceStatus.IsUp() {
-		if err := b.Client.Server.Shutdown(ctx, zone, server.ID, &sacloud.ShutdownOption{Force: b.ForceShutdown}); err != nil {
-			return nil, err
-		}
-		waiter := sacloud.WaiterForDown(func() (interface{}, error) {
-			return b.Client.Server.Read(ctx, zone, server.ID)
-		})
-		if _, err := waiter.WaitForState(ctx); err != nil {
+		if err := power.ShutdownServer(ctx, b.Client.Server, zone, server.ID, b.ForceShutdown); err != nil {
 			return nil, err
 		}
 	}
@@ -294,15 +277,7 @@ func (b *Builder) Update(ctx context.Context, zone string) (*BuildResult, error)
 
 	// bool
 	if isNeedShutdown && server.InstanceStatus.IsDown() {
-		if err := b.Client.Server.Boot(ctx, zone, server.ID); err != nil {
-			return nil, err
-		}
-		// wait
-		waiter := sacloud.WaiterForUp(func() (interface{}, error) {
-			return b.Client.Server.Read(ctx, zone, server.ID)
-		})
-		_, err := waiter.WaitForState(ctx)
-		if err != nil {
+		if err := power.BootServer(ctx, b.Client.Server, zone, server.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/utils/builder/server/builder_test.go
+++ b/utils/builder/server/builder_test.go
@@ -21,14 +21,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sacloud/libsacloud/v2/utils/builder"
-
-	"github.com/sacloud/libsacloud/v2/utils/builder/disk"
-
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/builder"
+	"github.com/sacloud/libsacloud/v2/utils/builder/disk"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/stretchr/testify/require"
@@ -416,8 +415,7 @@ func TestBuilder_Build_BlackBox(t *testing.T) {
 			},
 		},
 		Shutdown: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
-			serverOp := sacloud.NewServerOp(caller)
-			return serverOp.Shutdown(ctx, testZone, ctx.ID, &sacloud.ShutdownOption{Force: true})
+			return power.ShutdownServer(ctx, sacloud.NewServerOp(caller), testZone, ctx.ID, true)
 		},
 		Delete: &testutil.CRUDTestDeleteFunc{
 			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {

--- a/utils/builder/vpcrouter/builder.go
+++ b/utils/builder/vpcrouter/builder.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sacloud/libsacloud/v2/utils/builder"
-
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/accessor"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/builder"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 	"github.com/sacloud/libsacloud/v2/utils/setup"
 )
 
@@ -224,7 +224,7 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.VPCRouter, e
 			}
 
 			if b.SetupOptions.BootAfterBuild {
-				return b.Client.Boot(ctx, zone, id)
+				return power.BootVPCRouter(ctx, b.Client, zone, id)
 			}
 			return nil
 		},
@@ -282,7 +282,7 @@ func (b *Builder) Update(ctx context.Context, zone string, id types.ID) (*saclou
 	isNeedRestart := false
 	if vpcRouter.InstanceStatus.IsUp() && isNeedShutdown {
 		isNeedRestart = true
-		if err := b.shutdownVPCRouter(ctx, zone, id); err != nil {
+		if err := power.ShutdownVPCRouter(ctx, b.Client, zone, id, false); err != nil {
 			return nil, err
 		}
 	}
@@ -351,7 +351,7 @@ func (b *Builder) Update(ctx context.Context, zone string, id types.ID) (*saclou
 	}
 
 	if isNeedRestart {
-		if err := b.bootVPCRouter(ctx, zone, id); err != nil {
+		if err := power.BootVPCRouter(ctx, b.Client, zone, id); err != nil {
 			return nil, err
 		}
 	}
@@ -365,33 +365,6 @@ func (b *Builder) Update(ctx context.Context, zone string, id types.ID) (*saclou
 
 func (b *Builder) isStandardPlan() bool {
 	return b.PlanID != types.VPCRouterPlans.Standard
-}
-
-func (b *Builder) bootVPCRouter(ctx context.Context, zone string, id types.ID) error {
-	if err := b.Client.Boot(ctx, zone, id); err != nil {
-		return err
-	}
-	// wait for down
-	waiter := sacloud.WaiterForUp(func() (state interface{}, err error) {
-		return b.Client.Read(ctx, zone, id)
-	})
-	if _, err := waiter.WaitForState(ctx); err != nil {
-		return err
-	}
-	return nil
-}
-func (b *Builder) shutdownVPCRouter(ctx context.Context, zone string, id types.ID) error {
-	if err := b.Client.Shutdown(ctx, zone, id, &sacloud.ShutdownOption{Force: false}); err != nil {
-		return err
-	}
-	// wait for down
-	waiter := sacloud.WaiterForDown(func() (state interface{}, err error) {
-		return b.Client.Read(ctx, zone, id)
-	})
-	if _, err := waiter.WaitForState(ctx); err != nil {
-		return err
-	}
-	return nil
 }
 
 func (b *Builder) collectUpdateInfo(vpcRouter *sacloud.VPCRouter) (isNeedShutdown bool, err error) {

--- a/utils/cleanup/mobile_gateway.go
+++ b/utils/cleanup/mobile_gateway.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 )
 
 // DeleteMobileGateway 削除
@@ -30,14 +31,7 @@ func DeleteMobileGateway(ctx context.Context, mgwAPI sacloud.MobileGatewayAPI, s
 	}
 
 	if mgw.InstanceStatus.IsUp() {
-		if err := mgwAPI.Shutdown(ctx, zone, id, &sacloud.ShutdownOption{Force: true}); err != nil {
-			return err
-		}
-		// wait for down
-		waiter := sacloud.WaiterForDown(func() (state interface{}, err error) {
-			return mgwAPI.Read(ctx, zone, id)
-		})
-		if _, err := waiter.WaitForState(ctx); err != nil {
+		if err := power.ShutdownMobileGateway(ctx, mgwAPI, zone, id, true); err != nil {
 			return err
 		}
 	}

--- a/utils/power/doc.go
+++ b/utils/power/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package power サーバやアプライアンスの電源操作ユーティリティ
+//
+// BootやShutdownを同期的に処理します。
+// 一定の時間内に起動/シャットダウンが行われない(API呼び出しが無視された)場合にはリトライを行います。
+//
+// ポーリング間隔やタイムアウトはデフォルトのsacloud.StateWaiterの値が利用されます。
+package power

--- a/utils/power/handlers.go
+++ b/utils/power/handlers.go
@@ -1,0 +1,178 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package power
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// ServerAPI APIクライアント
+type ServerAPI interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Server, error)
+	Boot(ctx context.Context, zone string, id types.ID) error
+	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error
+}
+
+type serverHandler struct {
+	ctx    context.Context
+	client ServerAPI
+	zone   string
+	id     types.ID
+}
+
+func (h *serverHandler) boot() error {
+	return h.client.Boot(h.ctx, h.zone, h.id)
+}
+
+func (h *serverHandler) shutdown(force bool) error {
+	return h.client.Shutdown(h.ctx, h.zone, h.id, &sacloud.ShutdownOption{Force: force})
+}
+
+func (h *serverHandler) read() (interface{}, error) {
+	return h.client.Read(h.ctx, h.zone, h.id)
+}
+
+// LoadBalancerAPI APIクライアント
+type LoadBalancerAPI interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.LoadBalancer, error)
+	Boot(ctx context.Context, zone string, id types.ID) error
+	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error
+}
+
+type loadBalancerHandler struct {
+	ctx    context.Context
+	client LoadBalancerAPI
+	zone   string
+	id     types.ID
+}
+
+func (h *loadBalancerHandler) boot() error {
+	return h.client.Boot(h.ctx, h.zone, h.id)
+}
+
+func (h *loadBalancerHandler) shutdown(force bool) error {
+	return h.client.Shutdown(h.ctx, h.zone, h.id, &sacloud.ShutdownOption{Force: force})
+}
+
+func (h *loadBalancerHandler) read() (interface{}, error) {
+	return h.client.Read(h.ctx, h.zone, h.id)
+}
+
+// DatabaseAPI APIクライアント
+type DatabaseAPI interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Database, error)
+	Boot(ctx context.Context, zone string, id types.ID) error
+	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error
+}
+
+type databaseHandler struct {
+	ctx    context.Context
+	client DatabaseAPI
+	zone   string
+	id     types.ID
+}
+
+func (h *databaseHandler) boot() error {
+	return h.client.Boot(h.ctx, h.zone, h.id)
+}
+
+func (h *databaseHandler) shutdown(force bool) error {
+	return h.client.Shutdown(h.ctx, h.zone, h.id, &sacloud.ShutdownOption{Force: force})
+}
+
+func (h *databaseHandler) read() (interface{}, error) {
+	return h.client.Read(h.ctx, h.zone, h.id)
+}
+
+// VPCRouterAPI APIクライアント
+type VPCRouterAPI interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.VPCRouter, error)
+	Boot(ctx context.Context, zone string, id types.ID) error
+	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error
+}
+
+type vpcRouterHandler struct {
+	ctx    context.Context
+	client VPCRouterAPI
+	zone   string
+	id     types.ID
+}
+
+func (h *vpcRouterHandler) boot() error {
+	return h.client.Boot(h.ctx, h.zone, h.id)
+}
+
+func (h *vpcRouterHandler) shutdown(force bool) error {
+	return h.client.Shutdown(h.ctx, h.zone, h.id, &sacloud.ShutdownOption{Force: force})
+}
+
+func (h *vpcRouterHandler) read() (interface{}, error) {
+	return h.client.Read(h.ctx, h.zone, h.id)
+}
+
+// NFSAPI APIクライアント
+type NFSAPI interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.NFS, error)
+	Boot(ctx context.Context, zone string, id types.ID) error
+	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error
+}
+
+type nfsHandler struct {
+	ctx    context.Context
+	client NFSAPI
+	zone   string
+	id     types.ID
+}
+
+func (h *nfsHandler) boot() error {
+	return h.client.Boot(h.ctx, h.zone, h.id)
+}
+
+func (h *nfsHandler) shutdown(force bool) error {
+	return h.client.Shutdown(h.ctx, h.zone, h.id, &sacloud.ShutdownOption{Force: force})
+}
+
+func (h *nfsHandler) read() (interface{}, error) {
+	return h.client.Read(h.ctx, h.zone, h.id)
+}
+
+// MobileGatewayAPI APIクライアント
+type MobileGatewayAPI interface {
+	Read(ctx context.Context, zone string, id types.ID) (*sacloud.MobileGateway, error)
+	Boot(ctx context.Context, zone string, id types.ID) error
+	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error
+}
+
+type mobileGatewayHandler struct {
+	ctx    context.Context
+	client MobileGatewayAPI
+	zone   string
+	id     types.ID
+}
+
+func (h *mobileGatewayHandler) boot() error {
+	return h.client.Boot(h.ctx, h.zone, h.id)
+}
+
+func (h *mobileGatewayHandler) shutdown(force bool) error {
+	return h.client.Shutdown(h.ctx, h.zone, h.id, &sacloud.ShutdownOption{Force: force})
+}
+
+func (h *mobileGatewayHandler) read() (interface{}, error) {
+	return h.client.Read(h.ctx, h.zone, h.id)
+}

--- a/utils/power/power.go
+++ b/utils/power/power.go
@@ -1,0 +1,272 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package power
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/accessor"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+var (
+	// BootRetrySpan 起動APIをコールしてからリトライするまでの待機時間
+	BootRetrySpan = 20 * time.Second
+
+	// ShutdownRetrySpan シャットダウンAPIをコールしてからリトライするまでの待機時間
+	ShutdownRetrySpan = 20 * time.Second
+)
+
+/************************************************
+ * Server
+ ***********************************************/
+
+// BootServer 起動
+func BootServer(ctx context.Context, client ServerAPI, zone string, id types.ID) error {
+	return boot(ctx, &serverHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	})
+}
+
+// ShutdownServer シャットダウン
+func ShutdownServer(ctx context.Context, client ServerAPI, zone string, id types.ID, force bool) error {
+	return shutdown(ctx, &serverHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	}, force)
+}
+
+/************************************************
+ * LoadBalancer
+ ***********************************************/
+
+// BootLoadBalancer 起動
+func BootLoadBalancer(ctx context.Context, client LoadBalancerAPI, zone string, id types.ID) error {
+	return boot(ctx, &loadBalancerHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	})
+}
+
+// ShutdownLoadBalancer シャットダウン
+func ShutdownLoadBalancer(ctx context.Context, client LoadBalancerAPI, zone string, id types.ID, force bool) error {
+	return shutdown(ctx, &loadBalancerHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	}, force)
+}
+
+/************************************************
+ * Database
+ ***********************************************/
+
+// BootDatabase 起動
+func BootDatabase(ctx context.Context, client DatabaseAPI, zone string, id types.ID) error {
+	return boot(ctx, &databaseHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	})
+}
+
+// ShutdownDatabase シャットダウン
+func ShutdownDatabase(ctx context.Context, client DatabaseAPI, zone string, id types.ID, force bool) error {
+	return shutdown(ctx, &databaseHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	}, force)
+}
+
+/************************************************
+ * VPCRouter
+ ***********************************************/
+
+// BootVPCRouter 起動
+func BootVPCRouter(ctx context.Context, client VPCRouterAPI, zone string, id types.ID) error {
+	return boot(ctx, &vpcRouterHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	})
+}
+
+// ShutdownVPCRouter シャットダウン
+func ShutdownVPCRouter(ctx context.Context, client VPCRouterAPI, zone string, id types.ID, force bool) error {
+	return shutdown(ctx, &vpcRouterHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	}, force)
+}
+
+/************************************************
+ * NFS
+ ***********************************************/
+
+// BootNFS 起動
+func BootNFS(ctx context.Context, client NFSAPI, zone string, id types.ID) error {
+	return boot(ctx, &nfsHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	})
+}
+
+// ShutdownNFS シャットダウン
+func ShutdownNFS(ctx context.Context, client NFSAPI, zone string, id types.ID, force bool) error {
+	return shutdown(ctx, &nfsHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	}, force)
+}
+
+/************************************************
+ * MobileGateway
+ ***********************************************/
+
+// BootMobileGateway 起動
+func BootMobileGateway(ctx context.Context, client MobileGatewayAPI, zone string, id types.ID) error {
+	return boot(ctx, &mobileGatewayHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	})
+}
+
+// ShutdownMobileGateway シャットダウン
+func ShutdownMobileGateway(ctx context.Context, client MobileGatewayAPI, zone string, id types.ID, force bool) error {
+	return shutdown(ctx, &mobileGatewayHandler{
+		ctx:    ctx,
+		client: client,
+		zone:   zone,
+		id:     id,
+	}, force)
+}
+
+type handler interface {
+	boot() error
+	shutdown(force bool) error
+	read() (interface{}, error)
+}
+
+func boot(ctx context.Context, h handler) error {
+	if err := h.boot(); err != nil {
+		return err
+	}
+
+	retryTimer := time.NewTicker(BootRetrySpan)
+	defer retryTimer.Stop()
+
+	inProcess := false
+
+	waiter := sacloud.WaiterForUp(h.read)
+	compCh, progressCh, errCh := waiter.AsyncWaitForState(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.New("canceled")
+		case <-compCh:
+			return nil
+		case <-progressCh:
+		// noop
+		case <-retryTimer.C:
+			if inProcess {
+				continue
+			}
+			state, err := h.read()
+			if err != nil {
+				return err
+			}
+			if state.(accessor.InstanceStatus).GetInstanceStatus().IsDown() {
+				if err := h.boot(); err != nil {
+					if err, ok := err.(sacloud.APIError); ok {
+						if err.ResponseCode() == http.StatusConflict {
+							inProcess = true
+							continue
+						}
+					}
+					return err
+				}
+			}
+		case err := <-errCh:
+			return err
+		}
+	}
+}
+
+func shutdown(ctx context.Context, h handler, force bool) error {
+	if err := h.shutdown(force); err != nil {
+		return err
+	}
+
+	retryTimer := time.NewTicker(ShutdownRetrySpan)
+	defer retryTimer.Stop()
+
+	inProcess := false
+
+	waiter := sacloud.WaiterForDown(h.read)
+	compCh, progressCh, errCh := waiter.AsyncWaitForState(ctx)
+	for {
+		select {
+		case <-compCh:
+			return nil
+		case <-progressCh:
+		// noop
+		case <-retryTimer.C:
+			if inProcess {
+				continue
+			}
+			state, err := h.read()
+			if err != nil {
+				return err
+			}
+			if state.(accessor.InstanceStatus).GetInstanceStatus().IsUp() {
+				if err := h.shutdown(force); err != nil {
+					if err, ok := err.(sacloud.APIError); ok {
+						if err.ResponseCode() == http.StatusConflict {
+							inProcess = true
+							continue
+						}
+					}
+					return err
+				}
+			}
+		case err := <-errCh:
+			return err
+		}
+	}
+}

--- a/utils/setup/setup_test.go
+++ b/utils/setup/setup_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/accessor"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 	"github.com/sacloud/libsacloud/v2/utils/query"
 )
 
@@ -97,8 +98,7 @@ func TestRetryableSetup(t *testing.T) {
 		},
 
 		Shutdown: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
-			nfsOp := sacloud.NewNFSOp(caller)
-			return nfsOp.Shutdown(ctx, testZone, ctx.ID, &sacloud.ShutdownOption{Force: true})
+			return power.ShutdownNFS(ctx, sacloud.NewNFSOp(caller), testZone, ctx.ID, true)
 		},
 
 		Delete: &testutil.CRUDTestDeleteFunc{


### PR DESCRIPTION
起動/シャットダウン(graceful or force)を同期的に行えるユーテリティを追加する。

- デフォルトの`sacloud.StateWaiter`を用いて実装し、
タイムアウトやポーリング間隔は`sacloud.StateWaiter`のデフォルト値を利用する
- 一定時間たっても起動/シャットダウンが始まらない場合、起動/シャットダウンAPI呼び出しをリトライする