### PR TITLE
Add size pkg

### DIFF
--- a/pkg/size/size.go
+++ b/pkg/size/size.go
@@ -1,0 +1,43 @@
+// Copyright 2016-2019 terraform-provider-sakuracloud authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package size さくらのクラウドでのサイズ(MiB/GiB)
+//
+// MBを起点としてGiBへの変換などを行う
+package size
+
+const (
+	// MiB 1024KiB
+	MiB = 1
+	// GiB 1024MiB
+	GiB = 1024 * MiB
+	// TiB 1024GiB
+	TiB = 1024 * GiB
+	// PiB 1024TiB
+	PiB = 1024 * TiB
+)
+
+// GiBToMiB GiBからMiB
+func GiBToMiB(sizeGiB int) int {
+	return convertUnit(sizeGiB, GiB, MiB)
+}
+
+// MiBToGiB MiBからGiB
+func MiBToGiB(sizeMiB int) int {
+	return convertUnit(sizeMiB, MiB, GiB)
+}
+
+func convertUnit(size int, sourceUnit int64, desiredUnit int64) int {
+	return int(int64(size) * sourceUnit / desiredUnit)
+}

--- a/pkg/size/size_test.go
+++ b/pkg/size/size_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package size
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSizeFunctions(t *testing.T) {
+	cases := []struct {
+		msg string
+		f   func(int) int
+		in  int
+		out int
+	}{
+		{
+			msg: "MiBToGiB",
+			f:   MiBToGiB,
+			in:  1024,
+			out: 1,
+		},
+		{
+			msg: "MiBToGiB",
+			f:   MiBToGiB,
+			in:  51200,
+			out: 50,
+		},
+		{
+			msg: "MiBToGiB",
+			f:   MiBToGiB,
+			in:  102400,
+			out: 100,
+		},
+		{
+			msg: "ToGiB with Zero",
+			f:   MiBToGiB,
+			in:  0,
+			out: 0,
+		},
+		{
+			msg: "GiBToMiB",
+			f:   GiBToMiB,
+			in:  1,
+			out: 1024,
+		},
+		{
+			msg: "GiBToMiB",
+			f:   GiBToMiB,
+			in:  100,
+			out: 102400,
+		},
+		{
+			msg: "GiBToMiB with Zero",
+			f:   GiBToMiB,
+			in:  0,
+			out: 0,
+		},
+	}
+
+	for _, tt := range cases {
+		got := tt.f(tt.in)
+		require.Equal(t, tt.out, got, "%s returns unexpected value: expect: %v actual:", tt.msg, tt.out, got)
+	}
+}

--- a/sacloud/accessor/assigned_memory_mb.go
+++ b/sacloud/accessor/assigned_memory_mb.go
@@ -14,6 +14,8 @@
 
 package accessor
 
+import "github.com/sacloud/libsacloud/v2/pkg/size"
+
 /************************************************
  AssignedMemoryMB - MemoryGB
 ************************************************/
@@ -30,10 +32,10 @@ func GetAssignedMemoryGB(target AssignedMemoryMB) int {
 	if sizeMB == 0 {
 		return 0
 	}
-	return sizeMB / 1024
+	return size.MiBToGiB(sizeMB)
 }
 
 // SetAssignedMemoryGB sets MemoryMB from GB
-func SetAssignedMemoryGB(target AssignedMemoryMB, size int) {
-	target.SetAssignedMemoryMB(size * 1024)
+func SetAssignedMemoryGB(target AssignedMemoryMB, sizeGB int) {
+	target.SetAssignedMemoryMB(size.GiBToMiB(sizeGB))
 }

--- a/sacloud/accessor/memory_mb.go
+++ b/sacloud/accessor/memory_mb.go
@@ -14,6 +14,8 @@
 
 package accessor
 
+import "github.com/sacloud/libsacloud/v2/pkg/size"
+
 /************************************************
  MemoryMB - MemoryGB
 ************************************************/
@@ -30,10 +32,10 @@ func GetMemoryGB(target MemoryMB) int {
 	if sizeMB == 0 {
 		return 0
 	}
-	return sizeMB / 1024
+	return size.MiBToGiB(sizeMB)
 }
 
 // SetMemoryGB sets MemoryMB from GB
-func SetMemoryGB(target MemoryMB, size int) {
-	target.SetMemoryMB(size * 1024)
+func SetMemoryGB(target MemoryMB, sizeGB int) {
+	target.SetMemoryMB(size.GiBToMiB(sizeGB))
 }

--- a/sacloud/accessor/migrated_mb.go
+++ b/sacloud/accessor/migrated_mb.go
@@ -14,6 +14,8 @@
 
 package accessor
 
+import "github.com/sacloud/libsacloud/v2/pkg/size"
+
 /************************************************
  MigratedMB - MigratedGB
 ************************************************/
@@ -30,10 +32,10 @@ func GetMigratedGB(target MigratedMB) int {
 	if sizeMB == 0 {
 		return 0
 	}
-	return sizeMB / 1024
+	return size.MiBToGiB(sizeMB)
 }
 
 // SetMigratedGB sets MigratedMB from GB
-func SetMigratedGB(target MigratedMB, size int) {
-	target.SetMigratedMB(size * 1024)
+func SetMigratedGB(target MigratedMB, sizeGB int) {
+	target.SetMigratedMB(size.GiBToMiB(sizeGB))
 }

--- a/sacloud/accessor/size_mb.go
+++ b/sacloud/accessor/size_mb.go
@@ -14,6 +14,8 @@
 
 package accessor
 
+import "github.com/sacloud/libsacloud/v2/pkg/size"
+
 /************************************************
  SizeMB - SizeGB
 ************************************************/
@@ -30,10 +32,10 @@ func GetSizeGB(target SizeMB) int {
 	if sizeMB == 0 {
 		return 0
 	}
-	return sizeMB / 1024
+	return size.MiBToGiB(sizeMB)
 }
 
 // SetSizeGB sets SizeMB from GB
-func SetSizeGB(target SizeMB, size int) {
-	target.SetSizeMB(size * 1024)
+func SetSizeGB(target SizeMB, sizeGB int) {
+	target.SetSizeMB(size.GiBToMiB(sizeGB))
 }

--- a/sacloud/accessor/size_mb_test.go
+++ b/sacloud/accessor/size_mb_test.go
@@ -17,6 +17,7 @@ package accessor
 import (
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,11 +44,11 @@ func TestSizeMBAccessor(t *testing.T) {
 		},
 		{
 			input:  1,
-			expect: 1024 * 1,
+			expect: 1 * size.GiB,
 		},
 		{
 			input:  2,
-			expect: 1024 * 2,
+			expect: 2 * size.GiB,
 		},
 	}
 

--- a/sacloud/customize_model_test.go
+++ b/sacloud/customize_model_test.go
@@ -17,6 +17,7 @@ package sacloud
 import (
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/stretchr/testify/require"
 )
@@ -87,7 +88,7 @@ func TestServer_BandWidthAt(t *testing.T) {
 						UpstreamType: types.UpstreamNetworkTypes.Switch,
 					},
 				},
-				MemoryMB: 31 * 1024,
+				MemoryMB: 31 * size.GiB,
 			},
 			expect: 1000,
 		},
@@ -99,7 +100,7 @@ func TestServer_BandWidthAt(t *testing.T) {
 						UpstreamType: types.UpstreamNetworkTypes.Switch,
 					},
 				},
-				MemoryMB: 32 * 1024,
+				MemoryMB: 32 * size.GiB,
 			},
 			expect: 2000,
 		},
@@ -111,7 +112,7 @@ func TestServer_BandWidthAt(t *testing.T) {
 						UpstreamType: types.UpstreamNetworkTypes.Switch,
 					},
 				},
-				MemoryMB: 127 * 1024,
+				MemoryMB: 127 * size.GiB,
 			},
 			expect: 2000,
 		},
@@ -123,7 +124,7 @@ func TestServer_BandWidthAt(t *testing.T) {
 						UpstreamType: types.UpstreamNetworkTypes.Switch,
 					},
 				},
-				MemoryMB: 128 * 1024,
+				MemoryMB: 128 * size.GiB,
 			},
 			expect: 5000,
 		},
@@ -135,7 +136,7 @@ func TestServer_BandWidthAt(t *testing.T) {
 						UpstreamType: types.UpstreamNetworkTypes.Switch,
 					},
 				},
-				MemoryMB: 223 * 1024,
+				MemoryMB: 223 * size.GiB,
 			},
 			expect: 5000,
 		},
@@ -147,7 +148,7 @@ func TestServer_BandWidthAt(t *testing.T) {
 						UpstreamType: types.UpstreamNetworkTypes.Switch,
 					},
 				},
-				MemoryMB: 224 * 1024,
+				MemoryMB: 224 * size.GiB,
 			},
 			expect: 10000,
 		},

--- a/sacloud/example_test.go
+++ b/sacloud/example_test.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -66,7 +67,7 @@ func Example_serverCRUD() {
 	serverOp := sacloud.NewServerOp(client)
 	server, err := serverOp.Create(ctx, "is1a", &sacloud.ServerCreateRequest{
 		CPU:                  1,
-		MemoryMB:             1024,
+		MemoryMB:             1 * size.GiB,
 		ServerPlanCommitment: types.Commitments.Standard,
 		ServerPlanGeneration: types.PlanGenerations.Default,
 		ConnectedSwitches:    []*sacloud.ConnectedSwitch{{Scope: "shared"}},

--- a/sacloud/fake/init.go
+++ b/sacloud/fake/init.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -339,7 +340,7 @@ func initServerPlan(s Store, p *valuePool) {
 			ID:           p.generateID(),
 			Name:         "プラン/1Core-1GB",
 			CPU:          1,
-			MemoryMB:     1024,
+			MemoryMB:     1 * size.MiB,
 			Commitment:   types.Commitments.Standard,
 			Generation:   100,
 			Availability: types.Availabilities.Available,
@@ -348,7 +349,7 @@ func initServerPlan(s Store, p *valuePool) {
 			ID:           p.generateID(),
 			Name:         "プラン/2Core-4GB",
 			CPU:          2,
-			MemoryMB:     4 * 1024,
+			MemoryMB:     4 * size.MiB,
 			Commitment:   types.Commitments.Standard,
 			Generation:   100,
 			Availability: types.Availabilities.Available,
@@ -396,13 +397,13 @@ func initDiskPlan(s Store, p *valuePool) {
 					Availability:  types.Availabilities.Available,
 					DisplaySize:   20,
 					DisplaySuffix: "GB",
-					SizeMB:        20 * 1024,
+					SizeMB:        20 * size.GiB,
 				},
 				{
 					Availability:  types.Availabilities.Available,
 					DisplaySize:   40,
 					DisplaySuffix: "GB",
-					SizeMB:        40 * 1024,
+					SizeMB:        40 * size.GiB,
 				},
 			},
 		},
@@ -416,13 +417,13 @@ func initDiskPlan(s Store, p *valuePool) {
 					Availability:  types.Availabilities.Available,
 					DisplaySize:   20,
 					DisplaySuffix: "GB",
-					SizeMB:        20 * 1024,
+					SizeMB:        20 * size.GiB,
 				},
 				{
 					Availability:  types.Availabilities.Available,
 					DisplaySize:   40,
 					DisplaySuffix: "GB",
-					SizeMB:        40 * 1024,
+					SizeMB:        40 * size.GiB,
 				},
 			},
 		},

--- a/sacloud/test/archive_op_test.go
+++ b/sacloud/test/archive_op_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -185,7 +186,7 @@ func TestArchiveOp_CreateBlank(t *testing.T) {
 			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 				client := sacloud.NewArchiveOp(singletonAPICaller())
 				archive, ftpServer, err := client.CreateBlank(ctx, testZone, &sacloud.ArchiveCreateBlankRequest{
-					SizeMB: 20 * 1024,
+					SizeMB: 20 * size.GiB,
 					Name:   testutil.ResourceName("archive-blank"),
 				})
 

--- a/sacloud/test/auto_backup_op_test.go
+++ b/sacloud/test/auto_backup_op_test.go
@@ -17,6 +17,7 @@ package test
 import (
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -33,7 +34,7 @@ func TestAutoBackupOpCRUD(t *testing.T) {
 			diskOp := sacloud.NewDiskOp(caller)
 			disk, err := diskOp.Create(ctx, testZone, &sacloud.DiskCreateRequest{
 				Name:       testutil.ResourceName("-disk-for-autobackup"),
-				SizeMB:     20 * 1024,
+				SizeMB:     20 * size.GiB,
 				DiskPlanID: types.DiskPlans.SSD,
 			}, nil)
 			if !assert.NoError(t, err) {

--- a/sacloud/test/disk_op_test.go
+++ b/sacloud/test/disk_op_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/search"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
@@ -96,7 +97,7 @@ var (
 		Name:        testutil.ResourceName("disk"),
 		Description: "desc",
 		Tags:        []string{"tag1", "tag2"},
-		SizeMB:      20 * 1024,
+		SizeMB:      20 * size.GiB,
 	}
 	createDiskExpected = &sacloud.Disk{
 		Name:        createDiskParam.Name,
@@ -183,7 +184,7 @@ func TestDiskOp_Config(t *testing.T) {
 				disk, err := client.Create(ctx, testZone, &sacloud.DiskCreateRequest{
 					Name:            testutil.ResourceName("disk-edit"),
 					DiskPlanID:      types.DiskPlans.SSD,
-					SizeMB:          20 * 1024,
+					SizeMB:          20 * size.GiB,
 					SourceArchiveID: archiveID,
 				}, nil)
 				if err != nil {

--- a/sacloud/test/interface_op_test.go
+++ b/sacloud/test/interface_op_test.go
@@ -17,6 +17,7 @@ package test
 import (
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -34,7 +35,7 @@ func TestInterface_Operations(t *testing.T) {
 			serverClient := sacloud.NewServerOp(caller)
 			server, err := serverClient.Create(ctx, testZone, &sacloud.ServerCreateRequest{
 				CPU:      1,
-				MemoryMB: 1 * 1024,
+				MemoryMB: 1 * size.GiB,
 				//ConnectedSwitches: []*ConnectedSwitch{
 				//	{Scope: types.Scopes.Shared},
 				//},

--- a/sacloud/test/server_op_test.go
+++ b/sacloud/test/server_op_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/search"
 	"github.com/sacloud/libsacloud/v2/sacloud/search/keys"
@@ -171,7 +172,7 @@ var (
 	}
 	createServerParam = &sacloud.ServerCreateRequest{
 		CPU:      1,
-		MemoryMB: 1 * 1024,
+		MemoryMB: 1 * size.GiB,
 		ConnectedSwitches: []*sacloud.ConnectedSwitch{
 			{
 				Scope: types.Scopes.Shared,
@@ -261,7 +262,7 @@ func TestServerOp_ChangePlan(t *testing.T) {
 			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 				return client.Create(ctx, testZone, &sacloud.ServerCreateRequest{
 					CPU:      1,
-					MemoryMB: 1 * 1024,
+					MemoryMB: 1 * size.GiB,
 					ConnectedSwitches: []*sacloud.ConnectedSwitch{
 						{
 							Scope: types.Scopes.Shared,
@@ -295,7 +296,7 @@ func TestServerOp_ChangePlan(t *testing.T) {
 				Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					return client.ChangePlan(ctx, testZone, ctx.ID, &sacloud.ServerChangePlanRequest{
 						CPU:      2,
-						MemoryMB: 4 * 1024,
+						MemoryMB: 4 * size.GiB,
 					})
 				},
 				CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, v interface{}) error {
@@ -340,7 +341,7 @@ func TestServerOp_Interfaces(t *testing.T) {
 				server, err := serverOp.Create(ctx, testZone, &sacloud.ServerCreateRequest{
 					Name:     testutil.ResourceName("server-disconnected-nics"),
 					CPU:      1,
-					MemoryMB: 1024,
+					MemoryMB: 1 * size.GiB,
 					ConnectedSwitches: []*sacloud.ConnectedSwitch{
 						nil,
 						nil,

--- a/utils/builder/disk/builder.go
+++ b/utils/builder/disk/builder.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/utils/builder"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -148,7 +149,7 @@ func (d *FromUnixBuilder) createDiskParameter(ctx context.Context, client *APICl
 
 	createReq := &sacloud.DiskCreateRequest{
 		DiskPlanID:      d.PlanID,
-		SizeMB:          d.SizeGB * 1024,
+		SizeMB:          d.SizeGB * size.GiB,
 		Connection:      d.Connection,
 		SourceArchiveID: archive.ID,
 		ServerID:        serverID,
@@ -254,7 +255,7 @@ func (d *FromFixedArchiveBuilder) createDiskParameter(ctx context.Context, clien
 
 	createReq := &sacloud.DiskCreateRequest{
 		DiskPlanID:      d.PlanID,
-		SizeMB:          d.SizeGB * 1024,
+		SizeMB:          d.SizeGB * size.GiB,
 		Connection:      d.Connection,
 		SourceArchiveID: archive.ID,
 		ServerID:        serverID,
@@ -340,7 +341,7 @@ func (d *FromWindowsBuilder) createDiskParameter(ctx context.Context, client *AP
 
 	createReq := &sacloud.DiskCreateRequest{
 		DiskPlanID:      d.PlanID,
-		SizeMB:          d.SizeGB * 1024,
+		SizeMB:          d.SizeGB * size.GiB,
 		Connection:      d.Connection,
 		SourceArchiveID: archive.ID,
 		ServerID:        serverID,
@@ -462,7 +463,7 @@ func (d *FromDiskOrArchiveBuilder) updateDiskParameter() *sacloud.DiskUpdateRequ
 func (d *FromDiskOrArchiveBuilder) createDiskParameter(ctx context.Context, client *APIClient, zone string, serverID types.ID) (*sacloud.DiskCreateRequest, *sacloud.DiskEditRequest, error) {
 	createReq := &sacloud.DiskCreateRequest{
 		DiskPlanID:      d.PlanID,
-		SizeMB:          d.SizeGB * 1024,
+		SizeMB:          d.SizeGB * size.GiB,
 		Connection:      d.Connection,
 		SourceArchiveID: d.SourceArchiveID,
 		SourceDiskID:    d.SourceDiskID,
@@ -553,7 +554,7 @@ func (d *BlankBuilder) updateDiskParameter() *sacloud.DiskUpdateRequest {
 func (d *BlankBuilder) createDiskParameter(ctx context.Context, client *APIClient, zone string, serverID types.ID) (*sacloud.DiskCreateRequest, *sacloud.DiskEditRequest, error) {
 	createReq := &sacloud.DiskCreateRequest{
 		DiskPlanID:  d.PlanID,
-		SizeMB:      d.SizeGB * 1024,
+		SizeMB:      d.SizeGB * size.GiB,
 		Connection:  d.Connection,
 		ServerID:    serverID,
 		Name:        d.Name,

--- a/utils/builder/disk/builder_test.go
+++ b/utils/builder/disk/builder_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -79,7 +80,7 @@ func TestDiskFromUnixRequest_Validate(t *testing.T) {
 							Size: []*sacloud.DiskPlanSizeInfo{
 								{
 									Availability: types.Availabilities.Available,
-									SizeMB:       1024,
+									SizeMB:       1 * size.GiB,
 								},
 							},
 						},

--- a/utils/builder/server/builder.go
+++ b/utils/builder/server/builder.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/sacloud/libsacloud/v2/utils/builder"
@@ -239,7 +240,7 @@ func (b *Builder) Update(ctx context.Context, zone string) (*BuildResult, error)
 	if b.isPlanChanged(server) {
 		updated, err := b.Client.Server.ChangePlan(ctx, zone, server.ID, &sacloud.ServerChangePlanRequest{
 			CPU:                  b.CPU,
-			MemoryMB:             b.MemoryGB * 1024,
+			MemoryMB:             b.MemoryGB * size.GiB,
 			ServerPlanGeneration: b.Generation,
 			ServerPlanCommitment: b.Commitment,
 		})
@@ -391,7 +392,7 @@ func (b *Builder) currentState(server *sacloud.Server) *serverState {
 func (b *Builder) createServer(ctx context.Context, zone string) (*sacloud.Server, error) {
 	param := &sacloud.ServerCreateRequest{
 		CPU:                  b.CPU,
-		MemoryMB:             b.MemoryGB * 1024,
+		MemoryMB:             b.MemoryGB * size.GiB,
 		ServerPlanCommitment: b.Commitment,
 		ServerPlanGeneration: b.Generation,
 		InterfaceDriver:      b.InterfaceDriver,

--- a/utils/query/server_plan.go
+++ b/utils/query/server_plan.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/search"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -45,7 +46,7 @@ func (f *FindServerPlanRequest) findCondition() *sacloud.FindCondition {
 		cond.Filter[search.Key("CPU")] = f.CPU
 	}
 	if f.MemoryGB > 0 {
-		cond.Filter[search.Key("MemoryMB")] = f.MemoryGB * 1024
+		cond.Filter[search.Key("MemoryMB")] = size.GiBToMiB(f.MemoryGB)
 	}
 	if f.Generation != types.PlanGenerations.Default {
 		cond.Filter[search.Key("Generation")] = f.Generation


### PR DESCRIPTION
MBを起点として扱うことが多いため、専用のパッケージとしておく。

```go
fmt.Print(1 * size.GiB)
// Output: 1024 
```