### PR TITLE
OSTypeからディスクの修正APIをサポートしないアーカイブを除去

### DIFF
--- a/sacloud/ostype/archive_ostype.go
+++ b/sacloud/ostype/archive_ostype.go
@@ -51,14 +51,8 @@ const (
 	K3OS
 	// Kusanagi OS種別:Kusanagi(CentOS)
 	Kusanagi
-	// SophosUTM OS種別:Sophos UTM
-	SophosUTM
 	// FreeBSD OS種別:FreeBSD
 	FreeBSD
-	// Netwiser OS種別: Netwiser Virtual Edition
-	Netwiser
-	// OPNsense OS種別: OPNsense
-	OPNsense
 	// Windows2016 OS種別:Windows Server 2016 Datacenter Edition
 	Windows2016
 	// Windows2016RDS OS種別:Windows Server 2016 RDS
@@ -95,10 +89,7 @@ var ArchiveOSTypes = []ArchiveOSType{
 	RancherOS,
 	K3OS,
 	Kusanagi,
-	SophosUTM,
 	FreeBSD,
-	Netwiser,
-	OPNsense,
 	Windows2016,
 	Windows2016RDS,
 	Windows2016RDSOffice,
@@ -115,8 +106,7 @@ var OSTypeShortNames = []string{
 	"centos", "centos8", "centos7", "centos6",
 	"ubuntu", "ubuntu1804", "ubuntu1604",
 	"debian", "debian10", "debian9",
-	"coreos", "rancheros", "k3os", "kusanagi", "sophos-utm", "freebsd",
-	"netwiser", "opnsense",
+	"coreos", "rancheros", "k3os", "kusanagi", "freebsd",
 	"windows2016", "windows2016-rds", "windows2016-rds-office",
 	"windows2016-sql-web", "windows2016-sql-standard", "windows2016-sql-standard-all",
 	"windows2016-sql2017-standard", "windows2016-sql2017-standard-all",
@@ -180,14 +170,8 @@ func StrToOSType(osType string) ArchiveOSType {
 		return K3OS
 	case "kusanagi":
 		return Kusanagi
-	case "sophos-utm":
-		return SophosUTM
 	case "freebsd":
 		return FreeBSD
-	case "netwiser":
-		return Netwiser
-	case "opnsense":
-		return OPNsense
 	case "windows2016":
 		return Windows2016
 	case "windows2016-rds":

--- a/sacloud/ostype/archiveostype_string.go
+++ b/sacloud/ostype/archiveostype_string.go
@@ -37,24 +37,21 @@ func _() {
 	_ = x[RancherOS-12]
 	_ = x[K3OS-13]
 	_ = x[Kusanagi-14]
-	_ = x[SophosUTM-15]
-	_ = x[FreeBSD-16]
-	_ = x[Netwiser-17]
-	_ = x[OPNsense-18]
-	_ = x[Windows2016-19]
-	_ = x[Windows2016RDS-20]
-	_ = x[Windows2016RDSOffice-21]
-	_ = x[Windows2016SQLServerWeb-22]
-	_ = x[Windows2016SQLServerStandard-23]
-	_ = x[Windows2016SQLServer2017Standard-24]
-	_ = x[Windows2016SQLServerStandardAll-25]
-	_ = x[Windows2016SQLServer2017StandardAll-26]
-	_ = x[Windows2019-27]
+	_ = x[FreeBSD-15]
+	_ = x[Windows2016-16]
+	_ = x[Windows2016RDS-17]
+	_ = x[Windows2016RDSOffice-18]
+	_ = x[Windows2016SQLServerWeb-19]
+	_ = x[Windows2016SQLServerStandard-20]
+	_ = x[Windows2016SQLServer2017Standard-21]
+	_ = x[Windows2016SQLServerStandardAll-22]
+	_ = x[Windows2016SQLServer2017StandardAll-23]
+	_ = x[Windows2019-24]
 }
 
-const _ArchiveOSType_name = "CustomCentOSCentOS8CentOS7CentOS6UbuntuUbuntu1804Ubuntu1604DebianDebian10Debian9CoreOSRancherOSK3OSKusanagiSophosUTMFreeBSDNetwiserOPNsenseWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllWindows2019"
+const _ArchiveOSType_name = "CustomCentOSCentOS8CentOS7CentOS6UbuntuUbuntu1804Ubuntu1604DebianDebian10Debian9CoreOSRancherOSK3OSKusanagiFreeBSDWindows2016Windows2016RDSWindows2016RDSOfficeWindows2016SQLServerWebWindows2016SQLServerStandardWindows2016SQLServer2017StandardWindows2016SQLServerStandardAllWindows2016SQLServer2017StandardAllWindows2019"
 
-var _ArchiveOSType_index = [...]uint16{0, 6, 12, 19, 26, 33, 39, 49, 59, 65, 73, 80, 86, 95, 99, 107, 116, 123, 131, 139, 150, 164, 184, 207, 235, 267, 298, 333, 344}
+var _ArchiveOSType_index = [...]uint16{0, 6, 12, 19, 26, 33, 39, 49, 59, 65, 73, 80, 86, 95, 99, 107, 114, 125, 139, 159, 182, 210, 242, 273, 308, 319}
 
 func (i ArchiveOSType) String() string {
 	if i < 0 || i >= ArchiveOSType(len(_ArchiveOSType_index)-1) {

--- a/sacloud/ostype/filter_criteria.go
+++ b/sacloud/ostype/filter_criteria.go
@@ -63,17 +63,8 @@ var ArchiveCriteria = map[ArchiveOSType]search.Filter{
 	Kusanagi: {
 		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "pkg-kusanagi"),
 	},
-	SophosUTM: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "pkg-sophosutm"),
-	},
 	FreeBSD: {
 		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "distro-freebsd"),
-	},
-	Netwiser: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "pkg-netwiserve"),
-	},
-	OPNsense: {
-		search.Key(keys.Tags): search.TagsAndEqual("current-stable", "distro-opnsense"),
 	},
 	Windows2016: {
 		search.Key(keys.Tags): search.TagsAndEqual("os-windows", "distro-ver-2016"),

--- a/utils/builder/disk/director.go
+++ b/utils/builder/disk/director.go
@@ -108,7 +108,7 @@ func (d *Director) Builder() Builder {
 			Client:        d.Client,
 		}
 	default:
-		// ディスクの修正をサポートしないものが指定された場合
+		// 現在はOSTypeにディスクの修正不可のアーカイブはないためここには到達しない
 		return &FromFixedArchiveBuilder{
 			OSType:      d.OSType,
 			Name:        d.Name,

--- a/utils/builder/disk/director_test.go
+++ b/utils/builder/disk/director_test.go
@@ -90,15 +90,6 @@ func TestDiskDirector_Builder(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "other",
-			in: &Director{
-				OSType: ostype.OPNsense,
-			},
-			out: &FromFixedArchiveBuilder{
-				OSType: ostype.OPNsense,
-			},
-		},
 	}
 
 	for _, tt := range cases {

--- a/utils/query/public_archive_info.go
+++ b/utils/query/public_archive_info.go
@@ -103,6 +103,11 @@ func getPublicArchiveFromAncestors(ctx context.Context, zone string, reader *Arc
 		return nil, nil
 	}
 
+	// vSrXであれば編集不可
+	if archive.HasTag("pkg-vsrx") {
+		return nil, nil
+	}
+
 	// SophosUTMであれば編集不可
 	if archive.HasTag("pkg-sophosutm") || isSophosUTM(archive) {
 		return nil, nil


### PR DESCRIPTION
related #454 

OSTypeから以下を除去する。

- SophosUTM
- Netwiser VE
- OPNsense