### PR TITLE
Add private host class: ms_windows

### DIFF
--- a/sacloud/fake/init.go
+++ b/sacloud/fake/init.go
@@ -319,9 +319,9 @@ func initPrivateHostPlan(s Store, p *valuePool) {
 			Availability: types.Availabilities.Available,
 		},
 		{
-			ID:           112900526366,
-			Name:         "200Core 224GB 標準",
-			Class:        "dynamic",
+			ID:           113102196877,
+			Name:         "200Core 224GB Windows",
+			Class:        "ms_windows",
 			CPU:          200,
 			MemoryMB:     229376,
 			Availability: types.Availabilities.Available,

--- a/sacloud/types/private_host_plan_class.go
+++ b/sacloud/types/private_host_plan_class.go
@@ -1,0 +1,20 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+const (
+	PrivateHostClassDynamic = "dynamic"    // 標準
+	PrivateHostClassWindows = "ms_windows" // Windows
+)


### PR DESCRIPTION
related: #451 

専有ホスト(Windows)に対応する。
Windows専有ホストはプランIDに`Class=ms_windows`で検索した値を指定することで作成する。

このPRでは検索に使用する値の定義 + フェイクデータの登録のみを行う。
プランの検索処理は各クライアント側で実装する。