### PR TITLE
ファイルベースの名前付きプロファイル

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.4
 	github.com/huandu/xstrings v1.2.0
 	github.com/leodido/go-urn v1.1.0 // indirect
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/stretchr/testify v1.2.2
 	github.com/uber-go/atomic v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/huandu/xstrings v1.2.0 h1:yPeWdRnmynF7p+lLYz0H2tthW9lqhMJrQV/U7yy4wX0
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/leodido/go-urn v1.1.0 h1:Sm1gr51B1kKyfD2BlRcLSiEkffoG96g6TPv6eRoEiB8=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/sacloud/client.go
+++ b/sacloud/client.go
@@ -33,6 +33,9 @@ import (
 var (
 	// SakuraCloudAPIRoot APIリクエスト送信先ルートURL(末尾にスラッシュを含まない)
 	SakuraCloudAPIRoot = "https://secure.sakura.ad.jp/cloud/zone"
+
+	// SakuraCloudZones 利用可能なゾーンのデフォルト値
+	SakuraCloudZones = []string{"is1a", "is1b", "tk1a", "tk1v"}
 )
 
 var (

--- a/sacloud/profile/profile.go
+++ b/sacloud/profile/profile.go
@@ -1,0 +1,370 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profile
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+const (
+	DirectoryNameEnv    = "SAKURACLOUD_PROFILE_DIR" // プロファイルの格納先を指定する環境変数
+	DirectoryNameEnvOld = "USACLOUD_PROFILE_DIR"    // プロファイルの格納先を指定する環境変数(後方互換)
+	DefaultProfileName  = "default"                 // デフォルトのプロファイル名
+)
+
+var (
+	configDirName   = ".usacloud"
+	configFileName  = "config.json"
+	currentFileName = "current"
+)
+
+func ValidateName(profileName string, invalidRunes ...rune) error {
+	invalids := invalidRunes
+	if len(invalids) == 0 {
+		// validate profileName
+		invalids = []rune{filepath.ListSeparator, filepath.Separator}
+	}
+
+	for _, r := range invalids {
+		if strings.ContainsRune(profileName, r) {
+			return fmt.Errorf("got invalid profile name: %s", profileName)
+		}
+	}
+	return nil
+}
+
+func loadProfileDirFromEnvs() (string, error) {
+	dir, err := loadProfileDirFromEnv(DirectoryNameEnv)
+	if err != nil {
+		return "", err
+	}
+	if dir == "" {
+		// fallback
+		dir, err = loadProfileDirFromEnv(DirectoryNameEnvOld)
+		if err != nil {
+			return "", err
+		}
+	}
+	return dir, nil
+}
+
+func loadProfileDirFromEnv(key string) (string, error) {
+	if path, ok := os.LookupEnv(key); ok {
+		if err := ValidateName(path, filepath.ListSeparator); err != nil {
+			return "", fmt.Errorf("loading ProfileDir from environment variables[%s] is failed: %s", key, err)
+		}
+		return filepath.Clean(path), nil
+	}
+	return "", nil
+}
+
+func baseDir() (string, error) {
+	// from profileDirEnv var
+	path, err := loadProfileDirFromEnvs()
+	if path != "" || err != nil {
+		return path, err
+	}
+
+	// default, use homedir
+	homeDir, err := homedir.Dir()
+	if err != nil {
+		return "", fmt.Errorf("getting user's home dir is failed: %s", err)
+	}
+	return homeDir, nil
+}
+
+func ConfigFilePath(profileName string) (string, error) {
+	if err := ValidateName(profileName); err != nil {
+		return "", err
+	}
+
+	if profileName == "" {
+		profileName = DefaultProfileName
+	}
+	baseDir, err := baseDir()
+	if err != nil {
+		return "", fmt.Errorf("getting profile base dir is failed: %s", err)
+	}
+	return filepath.Clean(filepath.Join(baseDir, configDirName, filepath.Clean(profileName), configFileName)), nil
+}
+
+// ConfigValue プロファイル コンフィグ
+type ConfigValue struct {
+	// AccessToken アクセストークン
+	AccessToken string
+	// AccessTokenSecret アクセスシークレット
+	AccessTokenSecret string
+
+	// DefaultZone デフォルトゾーン
+	DefaultZone string
+	// Zones 利用可能なゾーン
+	Zones []string
+
+	// UserAgent ユーザーエージェント
+	UserAgent string `json:",omitempty"`
+	// AcceptLanguage リクエスト時のAccept-Languageヘッダ
+	AcceptLanguage string `json:",omitempty"`
+
+	// RetryMax 423/503時のリトライ回数
+	RetryMax int `json:",omitempty"`
+	// RetryMin 423/503時のリトライ間隔(最小) 単位:秒
+	RetryWaitMin int `json:",omitempty"`
+	// RetryMax 423/503時のリトライ間隔(最大) 単位:秒
+	RetryWaitMax int `json:",omitempty"`
+
+	// StatePollingTimeout StatePollWaiterでのタイムアウト 単位:秒
+	StatePollingTimeout int `json:",omitempty"`
+	// StatePollingInterval StatePollWaiterでのポーリング間隔 単位:秒
+	StatePollingInterval int `json:",omitempty"`
+
+	// HTTPRequestTimeout APIリクエスト時のHTTPタイムアウト 単位:秒
+	HTTPRequestTimeout int
+	// HTTPRequestRateLimit APIリクエスト時の1秒あたりのリクエスト上限数
+	HTTPRequestRateLimit int
+
+	// APIRootURL APIのルートURL
+	APIRootURL string `json:",omitempty"`
+
+	// TraceMode トレースモード
+	TraceMode string `json:",omitempty"`
+	// FakeMode フェイクモード有効化
+	FakeMode bool `json:",omitempty"`
+	// FakeStorePath フェイクモードでのファイルストアパス
+	FakeStorePath string `json:",omitempty"`
+}
+
+// Save プロファイルコンフィグを保存
+func Save(profileName string, val interface{}) error {
+	if val == nil {
+		return fmt.Errorf("config is required")
+	}
+
+	path, err := ConfigFilePath(profileName)
+	if err != nil {
+		return err
+	}
+
+	// create dir
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); err != nil {
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			return fmt.Errorf("creating profile directory[%q] is failed: %s", dir, err)
+		}
+	}
+
+	rawBody, err := json.MarshalIndent(val, "", "\t")
+	if err != nil {
+		return fmt.Errorf("marshalling config to JSON is failed: %s", err)
+	}
+
+	err = ioutil.WriteFile(path, rawBody, 0600)
+	if err != nil {
+		return fmt.Errorf("writing config to %q is failed: %s", path, err)
+	}
+
+	return nil
+}
+
+// Load 指定のプロファイル名からロードする
+//
+// configValueには*profile.ConfigValue(派生)への参照を渡す
+//
+// 指定したプロファイル名に対応するコンフィグファイルが存在しない場合はエラーを返す
+// ただしデフォルトのプロファイル名の場合はファイルが存在しなくてもエラーにしない
+func Load(profileName string, configValue interface{}) error {
+	filePath, err := ConfigFilePath(profileName)
+	if err != nil {
+		return err
+	}
+
+	// file exists?
+	if _, err := os.Stat(filePath); err == nil {
+		// read file
+		buf, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("loading config from %q is failed: %s", filePath, err)
+		}
+		if err := json.Unmarshal(buf, configValue); err != nil {
+			return fmt.Errorf("parsing config is failed: %s", err)
+		}
+	} else if profileName != DefaultProfileName {
+		return fmt.Errorf("profile %q is not exists", profileName)
+	}
+
+	return nil
+}
+
+// Remove 指定のプロファイルのコンフィグを削除する
+//
+// プロファイルディレクトリが空になる場合はディレクトリも合わせて削除する
+// Currentプロファイルが削除された場合はCurrentをデフォルトに設定する
+func Remove(profileName string) error {
+	path, err := ConfigFilePath(profileName)
+	if err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); err != nil {
+		return fmt.Errorf("removing directory is failed: %q is not exists", dir)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("removing config is failed: %q is not exists", path)
+	}
+
+	// remove file
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("removing config %q is failed: %s", path, err)
+	}
+
+	// remove dir if dir is empty
+	info, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("removing config file is failed: reading %q is failed: %s", dir, err)
+	}
+	if len(info) == 0 {
+		// remove dir
+		if err := os.RemoveAll(dir); err != nil {
+			return fmt.Errorf("removing config dir %q is failed: %s", dir, err)
+		}
+	}
+
+	current, err := CurrentName()
+	if err != nil {
+		return fmt.Errorf("removing config is failed: CurrentName() returns error: %s", err)
+	}
+
+	if current == profileName {
+		if err := SetCurrentName(DefaultProfileName); err != nil {
+			return fmt.Errorf("removing config is failed: SetCurrentName() returns error: %s", err)
+		}
+	}
+	return nil
+}
+
+func CurrentName() (string, error) {
+	baseDir, err := baseDir()
+	if err != nil {
+		return "", err
+	}
+
+	profNameFile := filepath.Join(baseDir, configDirName, currentFileName)
+	if _, err := os.Stat(profNameFile); err == nil {
+		data, err := ioutil.ReadFile(profNameFile)
+		if err != nil {
+			return "", fmt.Errorf("reading current profile is failed: %s", err)
+		}
+		profileName := string(data)
+		if err := ValidateName(profileName); err != nil {
+			return "", err
+		}
+
+		profileName = cleanupProfileName(profileName)
+		if profileName == "" {
+			profileName = DefaultProfileName
+		}
+		return profileName, nil
+	}
+
+	return DefaultProfileName, nil
+}
+
+func cleanupProfileName(profileName string) string {
+	targets := []string{"　", "\t", "\n"}
+	res := profileName
+	for _, s := range targets {
+		res = strings.Replace(res, s, "", -1)
+	}
+	return strings.Trim(res, " ")
+}
+
+func SetCurrentName(profileName string) error {
+	if err := ValidateName(profileName); err != nil {
+		return err
+	}
+
+	profileName = cleanupProfileName(profileName)
+
+	baseDir, err := baseDir()
+	if err != nil {
+		return err
+	}
+
+	configDir := filepath.Join(baseDir, configDirName)
+	if _, err := os.Stat(configDir); err != nil {
+		err := os.MkdirAll(configDir, 0755)
+		if err != nil {
+			return fmt.Errorf("creating config dir %q is failed: %s", configDir, err)
+		}
+	}
+
+	if profileName != DefaultProfileName {
+		profileConfigPath := filepath.Join(configDir, profileName, configFileName)
+		if _, err := os.Stat(profileConfigPath); err != nil {
+			return fmt.Errorf("profile %q is not exists", profileName)
+		}
+	}
+
+	profNameFile := filepath.Join(baseDir, configDirName, currentFileName)
+	if err := ioutil.WriteFile(profNameFile, []byte(profileName), 0600); err != nil {
+		return fmt.Errorf("writing profile to %q is failed: %s", profNameFile, err)
+	}
+
+	return nil
+}
+
+func List() ([]string, error) {
+	res := []string{"default"}
+
+	// get profile dirs under base dir
+	baseDir, err := baseDir()
+	if err != nil {
+		return []string{}, fmt.Errorf("listing profiles is failed: %s", err)
+	}
+	configDirPath := filepath.Join(baseDir, configDirName)
+	if _, err := os.Stat(configDirPath); err != nil {
+		return res, nil
+	}
+	entries, err := ioutil.ReadDir(filepath.Join(baseDir, configDirName))
+	if err != nil {
+		return []string{}, fmt.Errorf("listing profiles is failed: %s", err)
+	}
+
+	// validate each profile dir
+	for _, fi := range entries {
+		if fi.IsDir() {
+			profile := filepath.Base(fi.Name())
+			if profile != DefaultProfileName {
+				if profile != DefaultProfileName {
+					c := &ConfigValue{}
+					if err := Load(profile, c); err == nil {
+						res = append(res, profile)
+					}
+				}
+			}
+		}
+	}
+
+	return res, nil
+}

--- a/sacloud/profile/profile_test.go
+++ b/sacloud/profile/profile_test.go
@@ -1,0 +1,687 @@
+// Copyright 2016-2019 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !windows
+
+package profile
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	os.Setenv(DirectoryNameEnv, "/tmp/.usacloud") // nolint
+}
+
+func Test_baseDir(t *testing.T) {
+	os.Unsetenv(DirectoryNameEnv) // nolint
+	defer func() {
+		os.Setenv(DirectoryNameEnv, "/tmp/.usacloud") // nolint
+	}()
+
+	t.Run(fmt.Sprintf("without %s env", DirectoryNameEnv), func(t *testing.T) {
+		homeDir, err := homedir.Dir()
+		require.NoError(t, err)
+
+		baseDir, err := baseDir()
+		require.NoError(t, err)
+
+		require.EqualValues(t, homeDir, baseDir)
+	})
+
+	t.Run(fmt.Sprintf("with %s env", DirectoryNameEnv), func(t *testing.T) {
+		t.Run("valid", func(t *testing.T) {
+			testDir := "/test"
+			err := os.Setenv(DirectoryNameEnv, testDir)
+			require.NoError(t, err)
+
+			baseDir, err := baseDir()
+			require.NoError(t, err)
+
+			require.EqualValues(t, testDir, baseDir)
+		})
+
+		t.Run("redundant path", func(t *testing.T) {
+			testDir := "/test/../test1/../test"
+			expect := "/test"
+
+			err := os.Setenv(DirectoryNameEnv, testDir)
+			require.NoError(t, err)
+
+			baseDir, err := baseDir()
+			require.NoError(t, err)
+
+			require.EqualValues(t, expect, baseDir)
+		})
+		t.Run("Invalid env var", func(t *testing.T) {
+			// - with filepath.ListSeparator
+			testDir := "/test" + string([]rune{filepath.ListSeparator}) + "test"
+			err := os.Setenv(DirectoryNameEnv, testDir)
+			require.NoError(t, err)
+
+			_, err = baseDir()
+			require.Error(t, err)
+		})
+	})
+}
+
+func Test_ConfigFilePath(t *testing.T) {
+	dir := os.Getenv(DirectoryNameEnv)
+
+	expects := []struct {
+		profileName string
+		filePath    string
+	}{
+		{
+			profileName: "default",
+			filePath:    "/.usacloud/default/config.json",
+		},
+		{
+			profileName: "test1",
+			filePath:    "/.usacloud/test1/config.json",
+		},
+		{
+			profileName: "",
+			filePath:    "/.usacloud/default/config.json",
+		},
+	}
+
+	t.Run("Valid profiles", func(t *testing.T) {
+		for _, expect := range expects {
+			path, err := ConfigFilePath(expect.profileName)
+			require.NoError(t, err)
+
+			p := strings.Replace(path, dir, "", 1)
+			require.EqualValues(t, expect.filePath, p)
+		}
+	})
+
+	t.Run("Invalid profiles", func(t *testing.T) {
+		// - with filepath.Separator
+		_, err := ConfigFilePath("test" + string([]rune{filepath.Separator}) + "test")
+		require.Error(t, err)
+		// - with filepath.ListSeparator
+		_, err = ConfigFilePath("test" + string([]rune{filepath.ListSeparator}) + "test")
+		require.Error(t, err)
+	})
+}
+
+type loadConfigExpects struct {
+	profileName string
+	isValid     bool
+	body        string
+}
+
+func testTargetProfiles() []loadConfigExpects {
+	return []loadConfigExpects{
+		{
+			profileName: "default",
+			isValid:     true,
+			body:        fmt.Sprintf(confTemplate, "default", "default"),
+		},
+		{
+			profileName: "for-usacloud-unit-test1",
+			isValid:     true,
+			body:        fmt.Sprintf(confTemplate, "for-usacloud-unit-test1", "for-usacloud-unit-test1"),
+		},
+		{
+			profileName: "for-usacloud-unit-test2",
+			isValid:     true,
+			body:        fmt.Sprintf(confTemplate, "for-usacloud-unit-test2", "for-usacloud-unit-test2"),
+		},
+		{
+			profileName: " for-usacloud-unit-test3\n\n",
+			isValid:     true,
+			body:        fmt.Sprintf(confTemplate, "for-usacloud-unit-test3", "for-usacloud-unit-test3"),
+		},
+		{
+			profileName: "invalid-json",
+			isValid:     false,
+			body:        "{",
+		},
+		{
+			profileName: "empty-body",
+			isValid:     false,
+			body:        "",
+		},
+	}
+}
+
+func Test_Load(t *testing.T) {
+	defer initConfigFiles()()
+
+	t.Run("Valid profiles", func(t *testing.T) {
+		for _, prof := range testTargetProfiles() {
+			conf := &ConfigValue{}
+			err := Load(prof.profileName, conf)
+			if prof.isValid {
+				require.NoError(t, err)
+				pname := cleanupProfileName(prof.profileName)
+				require.EqualValues(t, pname, conf.AccessToken)
+				require.EqualValues(t, pname, conf.AccessTokenSecret)
+			} else {
+				require.Error(t, err)
+			}
+		}
+	})
+
+	t.Run("Not exists profile", func(t *testing.T) {
+		// not exists profile
+		conf := &ConfigValue{}
+		require.Error(t, Load("not-exists-profile-name", conf))
+	})
+
+	t.Run("Invalid profile names", func(t *testing.T) {
+		conf := &ConfigValue{}
+
+		// - with filepath.Separator
+		require.Error(t, Load("test"+string([]rune{filepath.Separator})+"test", conf))
+
+		// - with filepath.ListSeparator
+		require.Error(t, Load("test"+string([]rune{filepath.ListSeparator})+"test", conf))
+	})
+}
+
+func Test_LoadWithExtendedConfig(t *testing.T) {
+	initFunc := func() func() {
+		cleanupAllProfiles()
+		return func() {
+			cleanupAllProfiles()
+		}
+	}
+	defer initFunc()()
+
+	val := &extendedConfigValue{
+		ConfigValue: ConfigValue{
+			AccessToken:       "test-token",
+			AccessTokenSecret: "test-secret",
+		},
+		Added: "added",
+	}
+
+	err := Save("test-profile-extended-config", val)
+	require.NoError(t, err)
+
+	extended := &extendedConfigValue{}
+	err = Load("test-profile-extended-config", extended)
+	require.NoError(t, err)
+	require.Equal(t, "added", extended.Added)
+
+	// load as ConfigValue
+	configValue := &ConfigValue{}
+	err = Load("test-profile-extended-config", configValue)
+	require.NoError(t, err)
+	require.Equal(t, extended.AccessToken, configValue.AccessToken)
+	require.Equal(t, extended.AccessTokenSecret, configValue.AccessTokenSecret)
+}
+
+func initConfigFiles() func() {
+	p := "/tmp/.usacloud"
+	os.MkdirAll(p, 0700)           // nolint
+	os.Setenv(DirectoryNameEnv, p) // nolint
+
+	for _, prof := range testTargetProfiles() {
+		p, _ := ConfigFilePath(prof.profileName)
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			panic(err)
+		}
+		if err := ioutil.WriteFile(p, []byte(prof.body), 0600); err != nil {
+			panic(err)
+		}
+	}
+
+	return func() {
+		for _, prof := range testTargetProfiles() {
+			p, _ := ConfigFilePath(prof.profileName)
+			os.RemoveAll(filepath.Dir(p)) // nolint
+		}
+	}
+}
+
+var confTemplate = `
+{
+        "AccessToken": "%s",
+        "AccessTokenSecret": "%s"
+}`
+
+func Test_CurrentName(t *testing.T) {
+	homeDir, err := baseDir()
+	require.NoError(t, err)
+
+	configDir := filepath.Join(homeDir, configDirName)
+	profNameFile := filepath.Join(homeDir, configDirName, currentFileName)
+
+	os.Mkdir(configDir, 0755) // nolint
+	os.Remove(profNameFile)   // nolint
+	defer func() {
+		os.Remove(profNameFile) // nolint
+	}()
+
+	t.Run("Should use default", func(t *testing.T) {
+		n, err := CurrentName()
+		require.NoError(t, err)
+		require.Equal(t, "default", n)
+	})
+
+	t.Run("Should use profile file", func(t *testing.T) {
+		// create profile name
+		if err := ioutil.WriteFile(profNameFile, []byte("usacloud-unit-test1"), 0600); err != nil {
+			panic(err)
+		}
+		n, err := CurrentName()
+		require.NoError(t, err)
+		require.Equal(t, "usacloud-unit-test1", n)
+	})
+
+	t.Run("Invalid name in profile file", func(t *testing.T) {
+		// - with filepath.Separator
+		if err := ioutil.WriteFile(profNameFile, []byte("test"+string([]rune{filepath.Separator})+"test"), 0600); err != nil {
+			panic(err)
+		}
+		_, err := CurrentName()
+		require.Error(t, err)
+
+		// - with filepath.ListSeparator
+		if err := ioutil.WriteFile(profNameFile, []byte("test"+string([]rune{filepath.ListSeparator})+"test"), 0600); err != nil {
+			panic(err)
+		}
+		_, err = CurrentName()
+		require.Error(t, err)
+	})
+}
+
+func Test_SetCurrentName(t *testing.T) {
+	homeDir, err := baseDir()
+	require.NoError(t, err)
+
+	configDir := filepath.Join(homeDir, configDirName)
+	profNameFile := filepath.Join(homeDir, configDirName, currentFileName)
+
+	os.Mkdir(configDir, 0755) // nolint
+	os.Remove(profNameFile)   // nolint
+	defer func() {
+		os.Remove(profNameFile) // nolint
+	}()
+
+	t.Run("Default profile", func(t *testing.T) {
+		// profile dir isnot exists
+		configFilePath, err := ConfigFilePath("default")
+		require.NoError(t, err)
+		profileDirExists := false
+		if _, err := os.Stat(configFilePath); err == nil {
+			profileDirExists = true
+		}
+		require.False(t, profileDirExists)
+
+		err = SetCurrentName("default")
+		require.NoError(t, err)
+
+		data, err := ioutil.ReadFile(profNameFile)
+		require.NoError(t, err)
+		require.Equal(t, "default", string(data))
+	})
+
+	t.Run("Exists profile", func(t *testing.T) {
+		defer initConfigFiles()()
+
+		err = SetCurrentName("for-usacloud-unit-test1")
+		require.NoError(t, err)
+
+		data, err := ioutil.ReadFile(profNameFile)
+		require.NoError(t, err)
+		require.Equal(t, "for-usacloud-unit-test1", string(data))
+	})
+
+	t.Run("Not exists profile", func(t *testing.T) {
+		defer initConfigFiles()()
+
+		err := SetCurrentName("for-usacloud-unit-test1")
+		require.NoError(t, err)
+
+		err = SetCurrentName("not-exists")
+		require.Error(t, err)
+
+		data, err := ioutil.ReadFile(profNameFile)
+		require.NoError(t, err)
+		require.Equal(t, "for-usacloud-unit-test1", string(data))
+	})
+
+	t.Run("Invalid name ", func(t *testing.T) {
+		// - with filepath.Separator
+		err := SetCurrentName("test" + string([]rune{filepath.Separator}) + "test")
+		require.Error(t, err)
+
+		// - with filepath.ListSeparator
+		err = SetCurrentName("test" + string([]rune{filepath.ListSeparator}) + "test")
+		require.Error(t, err)
+	})
+}
+
+type extendedConfigValue struct {
+	ConfigValue
+	Added string
+}
+
+func Test_Save(t *testing.T) {
+	testProfileName := "for-usacloud-unit-test1"
+	cleanupProfile(testProfileName)
+	defer cleanupProfile(testProfileName)
+
+	fileExists := func(path string) bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}
+
+	t.Run("Valid profile", func(t *testing.T) {
+		defer cleanupProfile(testProfileName)
+
+		val := &ConfigValue{
+			AccessToken:       "test-token",
+			AccessTokenSecret: "test-secret",
+		}
+
+		err := Save(testProfileName, val)
+		require.NoError(t, err)
+
+		path, err := ConfigFilePath(testProfileName)
+		require.NoError(t, err)
+
+		require.True(t, fileExists(filepath.Dir(path)))
+		require.True(t, fileExists(path))
+	})
+	t.Run("Extended config value", func(t *testing.T) {
+		defer cleanupProfile(testProfileName)
+
+		val := &extendedConfigValue{
+			ConfigValue: ConfigValue{
+				AccessToken:       "test-token",
+				AccessTokenSecret: "test-secret",
+			},
+			Added: "added",
+		}
+
+		err := Save(testProfileName, val)
+		require.NoError(t, err)
+
+		path, err := ConfigFilePath(testProfileName)
+		require.NoError(t, err)
+
+		require.True(t, fileExists(filepath.Dir(path)))
+		require.True(t, fileExists(path))
+	})
+	t.Run("Invalid profile name", func(t *testing.T) {
+		defer cleanupProfile(testProfileName)
+
+		val := &ConfigValue{
+			AccessToken:       "test-token",
+			AccessTokenSecret: "test-secret",
+		}
+		// - with filepath.Separator
+		profileName := "test" + string([]rune{filepath.Separator}) + "test"
+
+		err := Save(profileName, val)
+		require.Error(t, err)
+
+		path, err := ConfigFilePath(testProfileName)
+		require.NoError(t, err)
+
+		require.False(t, fileExists(path))
+
+		// - with filepath.ListSeparator
+		profileName = "test" + string([]rune{filepath.ListSeparator}) + "test"
+		err = Save(profileName, val)
+		require.Error(t, err)
+
+		path, err = ConfigFilePath(testProfileName)
+		require.NoError(t, err)
+
+		require.False(t, fileExists(path))
+	})
+}
+
+func Test_Remove(t *testing.T) {
+	testProfileName := "for-usacloud-unit-test1"
+
+	initFunc := func() func() {
+		val := &ConfigValue{
+			AccessToken:       "test-token",
+			AccessTokenSecret: "test-secret",
+		}
+
+		err := Save(testProfileName, val)
+		if err != nil {
+			panic(err)
+		}
+
+		err = SetCurrentName(testProfileName)
+		if err != nil {
+			panic(err)
+		}
+
+		return func() {
+			cleanupProfile(testProfileName)
+		}
+	}
+	fileExists := func(path string) bool {
+		_, err := os.Stat(path)
+		return err == nil
+	}
+	t.Run("Profile exists", func(t *testing.T) {
+		defer initFunc()()
+		err := Remove(testProfileName)
+
+		require.NoError(t, err)
+
+		path, err := ConfigFilePath(testProfileName)
+		require.NoError(t, err)
+
+		require.False(t, fileExists(filepath.Dir(path)))
+		require.False(t, fileExists(path))
+
+		current, err := CurrentName()
+		require.NoError(t, err)
+		require.EqualValues(t, DefaultProfileName, current)
+	})
+	t.Run("Profile exists with other file", func(t *testing.T) {
+		defer initFunc()()
+
+		// create file in ProfileDir
+		path, err := ConfigFilePath(testProfileName)
+		require.NoError(t, err)
+
+		testOtherFile := filepath.Join(filepath.Dir(path), "test")
+		err = ioutil.WriteFile(testOtherFile, []byte{}, 0600)
+		if err != nil {
+			panic(err)
+		}
+
+		err = Remove(testProfileName)
+
+		require.NoError(t, err)
+
+		require.True(t, fileExists(filepath.Dir(path)))
+		require.True(t, fileExists(testOtherFile))
+		require.False(t, fileExists(path))
+	})
+	t.Run("Profile not exists", func(t *testing.T) {
+		defer initFunc()()
+		err := Remove("NotExistsProfileName")
+
+		require.Error(t, err)
+
+		path, err := ConfigFilePath(testProfileName)
+		require.NoError(t, err)
+
+		require.True(t, fileExists(filepath.Dir(path)))
+		require.True(t, fileExists(path))
+
+		current, err := CurrentName()
+		require.NoError(t, err)
+		require.EqualValues(t, testProfileName, current)
+	})
+	t.Run("Invalid profile name", func(t *testing.T) {
+		defer initFunc()()
+
+		// - with filepath.Separator
+		profileName := "test" + string([]rune{filepath.Separator}) + "test"
+
+		err := Remove(profileName)
+		require.Error(t, err)
+
+		path, err := ConfigFilePath(testProfileName)
+		require.NoError(t, err)
+		require.True(t, fileExists(filepath.Dir(path)))
+		require.True(t, fileExists(path))
+
+		current, err := CurrentName()
+		require.NoError(t, err)
+		require.EqualValues(t, testProfileName, current)
+
+		// - with filepath.ListSeparator
+		profileName = "test" + string([]rune{filepath.ListSeparator}) + "test"
+		err = Remove(profileName)
+		require.Error(t, err)
+
+		path, err = ConfigFilePath(testProfileName)
+		require.NoError(t, err)
+		require.True(t, fileExists(filepath.Dir(path)))
+		require.True(t, fileExists(path))
+
+		current, err = CurrentName()
+		require.NoError(t, err)
+		require.EqualValues(t, testProfileName, current)
+	})
+}
+
+func cleanupProfile(profile string) {
+	path, err := ConfigFilePath(profile)
+	if err != nil {
+		panic(err)
+	}
+	os.RemoveAll(filepath.Dir(path))
+}
+
+// cleanupAllProfiles remove all entries under profile-base-dir(includes "current" file)
+func cleanupAllProfiles() {
+	dir, err := baseDir()
+	if err != nil {
+		panic(err)
+	}
+
+	// dir is exists?
+	configDirPath := filepath.Join(dir, configDirName)
+	if _, err := os.Stat(configDirPath); err == nil {
+		err := os.RemoveAll(configDirPath)
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+func TestList(t *testing.T) {
+	initFunc := func() func() {
+		cleanupAllProfiles()
+		return func() {
+			cleanupAllProfiles()
+		}
+	}
+	defer initFunc()()
+
+	t.Run("Default only", func(t *testing.T) {
+		defer initFunc()()
+
+		profiles, err := List()
+		require.NoError(t, err)
+		require.Len(t, profiles, 1)
+		require.EqualValues(t, DefaultProfileName, profiles[0])
+	})
+	t.Run("Multiple profile", func(t *testing.T) {
+		defer initFunc()()
+
+		// create profile
+		testProfileNames := []string{"test2", "test1"}
+		val := &ConfigValue{
+			AccessToken:       "test-token",
+			AccessTokenSecret: "test-secret",
+		}
+		for _, n := range testProfileNames {
+			err := Save(n, val)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		profiles, err := List()
+		require.NoError(t, err)
+		require.Len(t, profiles, 3) // default + test1 + test2
+		require.EqualValues(t, DefaultProfileName, profiles[0])
+		require.EqualValues(t, "test1", profiles[1]) // sorted by name(except "default")
+		require.EqualValues(t, "test2", profiles[2])
+	})
+	t.Run("With invalid profile", func(t *testing.T) {
+		defer initFunc()()
+		defer initConfigFiles()()
+
+		profiles, err := List()
+		require.NoError(t, err)
+
+		targets := testTargetProfiles()
+		validCount := 0
+		for _, p := range targets {
+			if p.isValid {
+				validCount++
+			}
+		}
+
+		require.Len(t, profiles, validCount)
+	})
+	t.Run("With empty dir", func(t *testing.T) {
+		defer initFunc()()
+
+		// create profile
+		testProfileNames := []string{"test2", "test1"}
+		val := &ConfigValue{
+			AccessToken:       "test-token",
+			AccessTokenSecret: "test-secret",
+		}
+		for _, n := range testProfileNames {
+			err := Save(n, val)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		// create empty dir
+		dir, _ := baseDir()
+		err := os.MkdirAll(filepath.Join(dir, configDirName, "test3"), 0755)
+		if err != nil {
+			panic(err)
+		}
+
+		profiles, err := List()
+		require.NoError(t, err)
+		require.Len(t, profiles, 3) // default + test1 + test2 ( without test3 )
+		require.EqualValues(t, DefaultProfileName, profiles[0])
+		require.EqualValues(t, "test1", profiles[1]) // sorted by name(except "default")
+		require.EqualValues(t, "test2", profiles[2])
+	})
+}


### PR DESCRIPTION
fixes #388 

usacloudからファイルベースの名前付きプロファイル機能を移植する。

移植元: https://github.com/sacloud/usacloud/blob/v0.29.1/command/profile/

## 仕様

- デフォルトでは`~/.usacloud`に保存される
- 保存先は環境変数`SAKURACLOUD_PROFIILE_DIR`または`USACLOUD_PROFILE_DIR`で変更可能  
(`SAKURACLOUD_PROFIILE_DIR`が優先される)
- libsacloudでは保存/ロード/一覧などの基本的な機能のみを提供する。  
プロファイルから得た値の扱いは各クライアントに任される
- 各クライアント固有の設定値を合わせて保存可能とする。

## 各クライアントでの拡張

libsacloudでは以下の構造体を基本値として提供する。

```go

// ConfigValue プロファイル コンフィグ
type ConfigValue struct {
	// AccessToken アクセストークン
	AccessToken string
	// AccessTokenSecret アクセスシークレット
	AccessTokenSecret string

	// DefaultZone デフォルトゾーン
	DefaultZone string
	// Zones 利用可能なゾーン
	Zones []string

	// UserAgent ユーザーエージェント
	UserAgent string `json:",omitempty"`
	// AcceptLanguage リクエスト時のAccept-Languageヘッダ
	AcceptLanguage string `json:",omitempty"`

	// RetryMax 423/503時のリトライ回数
	RetryMax int `json:",omitempty"`
	// RetryMin 423/503時のリトライ間隔(最小) 単位:秒
	RetryWaitMin int `json:",omitempty"`
	// RetryMax 423/503時のリトライ間隔(最大) 単位:秒
	RetryWaitMax int `json:",omitempty"`

	// StatePollingTimeout StatePollWaiterでのタイムアウト 単位:秒
	StatePollingTimeout int `json:",omitempty"`
	// StatePollingInterval StatePollWaiterでのポーリング間隔 単位:秒
	StatePollingInterval int `json:",omitempty"`

	// HTTPRequestTimeout APIリクエスト時のHTTPタイムアウト 単位:秒
	HTTPRequestTimeout int
	// HTTPRequestRateLimit APIリクエスト時の1秒あたりのリクエスト上限数
	HTTPRequestRateLimit int

	// APIRootURL APIのルートURL
	APIRootURL string `json:",omitempty"`

	// TraceMode トレースモード
	TraceMode string `json:",omitempty"`
	// FakeMode フェイクモード有効化
	FakeMode bool `json:",omitempty"`
	// FakeStorePath フェイクモードでのファイルストアパス
	FakeStorePath string `json:",omitempty"`
}
```

各クライアントではprofile.ConfigValueを埋め込んだ構造体を用意することで独自項目をプロファイルに格納可能とする。

```go
type UsacloudConfig struct {
	profile.ConfigValue // 埋め込み
	Zone string // 独自項目
}
```