### PR TITLE
Rename: DefaultZone -> Zone

### DIFF
--- a/sacloud/profile/profile.go
+++ b/sacloud/profile/profile.go
@@ -114,8 +114,8 @@ type ConfigValue struct {
 	// AccessTokenSecret アクセスシークレット
 	AccessTokenSecret string
 
-	// DefaultZone デフォルトゾーン
-	DefaultZone string
+	// Zone デフォルトゾーン
+	Zone string
 	// Zones 利用可能なゾーン
 	Zones []string
 


### PR DESCRIPTION
usacloud v0.x系と互換性を持たせるためにusacloud側とフィールド名を揃える。