### PR TITLE
v2/local router

### DIFF
--- a/internal/define/apis.go
+++ b/internal/define/apis.go
@@ -55,6 +55,7 @@ func init() {
 	APIs.Define(licenseAPI)           // ライセンス
 	APIs.Define(licenseInfoAPI)       // ライセンスプラン
 	APIs.Define(loadBalancerAPI)      // ロードバランサ
+	APIs.Define(localRouterAPI)       // ローカルルータAPI
 	APIs.Define(mobileGatewayAPI)     // モバイルゲートウェイ
 	APIs.Define(nfsAPI)               // NFS
 	APIs.Define(noteAPI)              // スタートアップスクリプト

--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -1435,6 +1435,126 @@ func (f *fieldsDef) ProxyLBTimeout() *dsl.FieldDesc {
 	}
 }
 
+func (f *fieldsDef) LocalRouterSecretKeys() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "SecretKeys",
+		Type: meta.TypeStringSlice,
+		Tags: &dsl.FieldTags{
+			MapConv: "Status.SecretKeys",
+		},
+	}
+}
+
+func (f *fieldsDef) LocalRouterSwitch() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Switch",
+		Type: &dsl.Model{
+			Name: "LocalRouterSwitch",
+			Fields: []*dsl.FieldDesc{
+				{
+					Name: "Code",
+					Type: meta.TypeString,
+				},
+				{
+					Name: "Category",
+					Type: meta.TypeString,
+				},
+				{
+					Name: "ZoneID",
+					Type: meta.TypeString,
+				},
+			},
+		},
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.LocalRouter.Switch,recursive",
+		},
+	}
+}
+
+func (f *fieldsDef) LocalRouterInterface() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Interface",
+		Type: &dsl.Model{
+			Name: "LocalRouterInterface",
+			Fields: []*dsl.FieldDesc{
+				{
+					Name: "VirtualIPAddress",
+					Type: meta.TypeString,
+				},
+				{
+					Name: "IPAddress",
+					Type: meta.TypeStringSlice,
+				},
+				{
+					Name: "NetworkMaskLen",
+					Type: meta.TypeInt,
+				},
+				{
+					Name: "VRID",
+					Type: meta.TypeInt,
+				},
+			},
+		},
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.LocalRouter.Interface,recursive",
+		},
+	}
+}
+
+func (f *fieldsDef) LocalRouterPeers() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Peers",
+		Type: &dsl.Model{
+			Name:    "LocalRouterPeer",
+			IsArray: true,
+			Fields: []*dsl.FieldDesc{
+				{
+					Name: "ID",
+					Type: meta.TypeID,
+				},
+				{
+					Name: "SecretKey",
+					Type: meta.TypeString,
+				},
+				{
+					Name: "Enabled",
+					Type: meta.TypeFlag,
+				},
+				{
+					Name: "Description",
+					Type: meta.TypeString,
+				},
+			},
+		},
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.LocalRouter.[]Peers,recursive",
+		},
+	}
+}
+
+func (f *fieldsDef) LocalRouterStaticRoutes() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "StaticRoutes",
+		Type: &dsl.Model{
+			Name:    "LocalRouterStaticRoute",
+			IsArray: true,
+			Fields: []*dsl.FieldDesc{
+				{
+					Name: "Prefix",
+					Type: meta.TypeString,
+				},
+				{
+					Name: "NextHop",
+					Type: meta.TypeString,
+				},
+			},
+		},
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.LocalRouter.[]StaticRoutes,recursive",
+		},
+	}
+}
+
 func (f *fieldsDef) ContainerRegistrySubDomainLabel() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "SubDomainLabel",
@@ -2348,6 +2468,28 @@ func (f *fieldsDef) MonitorActiveConnections() *dsl.FieldDesc {
 func (f *fieldsDef) MonitorConnectionsPerSec() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "ConnectionsPerSec",
+		Type: meta.TypeFloat64,
+		Tags: &dsl.FieldTags{
+			MapConv: ",omitempty",
+			JSON:    ",omitempty",
+		},
+	}
+}
+
+func (f *fieldsDef) MonitorLocalRouterReceiveBytesPerSec() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "ReceiveBytesPerSec",
+		Type: meta.TypeFloat64,
+		Tags: &dsl.FieldTags{
+			MapConv: ",omitempty",
+			JSON:    ",omitempty",
+		},
+	}
+}
+
+func (f *fieldsDef) MonitorLocalRouterSendBytesPerSec() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "SendBytesPerSec",
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",

--- a/internal/define/local_router.go
+++ b/internal/define/local_router.go
@@ -1,0 +1,168 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package define
+
+import (
+	"github.com/sacloud/libsacloud/v2/internal/define/names"
+	"github.com/sacloud/libsacloud/v2/internal/define/ops"
+	"github.com/sacloud/libsacloud/v2/internal/dsl"
+	"github.com/sacloud/libsacloud/v2/internal/dsl/meta"
+	"github.com/sacloud/libsacloud/v2/sacloud/naked"
+)
+
+const (
+	localRouterAPIName     = "LocalRouter"
+	localRouterAPIPathName = "commonserviceitem"
+)
+
+var localRouterAPI = &dsl.Resource{
+	Name:       localRouterAPIName,
+	PathName:   localRouterAPIPathName,
+	PathSuffix: dsl.CloudAPISuffix,
+	IsGlobal:   true,
+	Operations: dsl.Operations{
+		// find
+		ops.FindCommonServiceItem(localRouterAPIName, localRouterNakedType, findParameter, localRouterView),
+
+		// create
+		ops.CreateCommonServiceItem(localRouterAPIName, localRouterNakedType, localRouterCreateParam, localRouterView),
+
+		// read
+		ops.ReadCommonServiceItem(localRouterAPIName, localRouterNakedType, localRouterView),
+
+		// update
+		ops.UpdateCommonServiceItem(localRouterAPIName, localRouterNakedType, localRouterUpdateParam, localRouterView),
+		// updateSettings
+		ops.UpdateCommonServiceItemSettings(localRouterAPIName, localRouterUpdateSettingsNakedType, localRouterUpdateSettingsParam, localRouterView),
+
+		// delete
+		ops.Delete(localRouterAPIName),
+
+		// Health
+		ops.HealthStatus(localRouterAPIName, meta.Static(naked.LocalRouterHealth{}), localRouterHealth),
+
+		// Monitor
+		ops.MonitorChild(localRouterAPIName, "LocalRouter", "activity/localrouter",
+			monitorParameter, monitors.localRouterModel()),
+	},
+}
+
+var (
+	localRouterNakedType               = meta.Static(naked.LocalRouter{})
+	localRouterUpdateSettingsNakedType = meta.Static(naked.LocalRouterSettingsUpdate{})
+
+	localRouterView = &dsl.Model{
+		Name:      localRouterAPIName,
+		NakedType: localRouterNakedType,
+		Fields: []*dsl.FieldDesc{
+			fields.ID(),
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.Availability(),
+			fields.IconID(),
+			fields.CreatedAt(),
+			fields.ModifiedAt(),
+
+			// settings
+			fields.LocalRouterSwitch(),
+			fields.LocalRouterInterface(),
+			fields.LocalRouterPeers(),
+			fields.LocalRouterStaticRoutes(),
+			fields.SettingsHash(),
+
+			// status
+			fields.LocalRouterSecretKeys(),
+		},
+	}
+
+	localRouterCreateParam = &dsl.Model{
+		Name:      names.CreateParameterName(localRouterAPIName),
+		NakedType: localRouterNakedType,
+		ConstFields: []*dsl.ConstFieldDesc{
+			{
+				Name: "Class",
+				Type: meta.TypeString,
+				Tags: &dsl.FieldTags{
+					MapConv: "Provider.Class",
+				},
+				Value: `"localrouter"`,
+			},
+		},
+		Fields: []*dsl.FieldDesc{
+			// common fields
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.IconID(),
+		},
+	}
+
+	localRouterUpdateParam = &dsl.Model{
+		Name:      names.UpdateParameterName(localRouterAPIName),
+		NakedType: localRouterNakedType,
+		Fields: []*dsl.FieldDesc{
+			// settings
+			fields.LocalRouterSwitch(),
+			fields.LocalRouterInterface(),
+			fields.LocalRouterPeers(),
+			fields.LocalRouterStaticRoutes(),
+			// settings hash
+			fields.SettingsHash(),
+
+			// common fields
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.IconID(),
+		},
+	}
+
+	localRouterUpdateSettingsParam = &dsl.Model{
+		Name:      names.UpdateSettingsParameterName(localRouterAPIName),
+		NakedType: localRouterNakedType,
+		Fields: []*dsl.FieldDesc{
+			// settings
+			fields.LocalRouterSwitch(),
+			fields.LocalRouterInterface(),
+			fields.LocalRouterPeers(),
+			fields.LocalRouterStaticRoutes(),
+			// settings hash
+			fields.SettingsHash(),
+		},
+	}
+
+	localRouterHealth = &dsl.Model{
+		Name: "LocalRouterHealth",
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "Peers",
+				Type: &dsl.Model{
+					Name:    "LocalRouterHealthPeer",
+					IsArray: true,
+					Fields: []*dsl.FieldDesc{
+						fields.Def("ID", meta.TypeID),
+						fields.Def("Status", meta.TypeInstanceStatus),
+						fields.Def("Routes", meta.TypeStringSlice),
+					},
+				},
+				Tags: &dsl.FieldTags{
+					MapConv: "LocalRouter.[]Peers,recursive",
+				},
+			},
+		},
+		NakedType: meta.Static(naked.LocalRouterHealth{}),
+	}
+)

--- a/internal/define/monitors.go
+++ b/internal/define/monitors.go
@@ -253,3 +253,28 @@ func (m *monitorsDef) connectionModel() *dsl.Model {
 		NakedType: meta.Static(naked.MonitorValues{}),
 	}
 }
+
+func (m *monitorsDef) localRouterModel() *dsl.Model {
+	return &dsl.Model{
+		Name: "LocalRouterActivity",
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "Values",
+				Type: &dsl.Model{
+					Name:      "MonitorLocalRouterValue",
+					NakedType: meta.Static(naked.MonitorLocalRouterValue{}),
+					IsArray:   true,
+					Fields: []*dsl.FieldDesc{
+						fields.MonitorTime(),
+						fields.MonitorLocalRouterReceiveBytesPerSec(),
+						fields.MonitorLocalRouterSendBytesPerSec(),
+					},
+				},
+				Tags: &dsl.FieldTags{
+					MapConv: "[]LocalRouter",
+				},
+			},
+		},
+		NakedType: meta.Static(naked.MonitorValues{}),
+	}
+}

--- a/pkg/mapconv/mapconv.go
+++ b/pkg/mapconv/mapconv.go
@@ -131,7 +131,7 @@ func ConvertFrom(source interface{}, dest interface{}) error {
 			if err != nil {
 				return err
 			}
-			if value == nil {
+			if value == nil || reflect.ValueOf(value).IsZero() {
 				continue
 			}
 

--- a/sacloud/fake/ops_local_router.go
+++ b/sacloud/fake/ops_local_router.go
@@ -1,0 +1,211 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// Find is fake implementation
+func (o *LocalRouterOp) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LocalRouterFindResult, error) {
+	results, _ := find(o.key, sacloud.APIDefaultZone, conditions)
+	var values []*sacloud.LocalRouter
+	for _, res := range results {
+		dest := &sacloud.LocalRouter{}
+		copySameNameField(res, dest)
+		values = append(values, dest)
+	}
+	return &sacloud.LocalRouterFindResult{
+		Total:        len(results),
+		Count:        len(results),
+		From:         0,
+		LocalRouters: values,
+	}, nil
+}
+
+// Create is fake implementation
+func (o *LocalRouterOp) Create(ctx context.Context, param *sacloud.LocalRouterCreateRequest) (*sacloud.LocalRouter, error) {
+	result := &sacloud.LocalRouter{}
+	copySameNameField(param, result)
+	fill(result, fillID, fillCreatedAt)
+
+	result.Availability = types.Availabilities.Available
+	result.SecretKeys = []string{"dummy"}
+
+	status := &sacloud.LocalRouterHealth{
+		Peers: []*sacloud.LocalRouterHealthPeer{},
+	}
+	ds().Put(ResourceLocalRouter+"Status", sacloud.APIDefaultZone, result.ID, status)
+
+	putLocalRouter(sacloud.APIDefaultZone, result)
+	return result, nil
+}
+
+// Read is fake implementation
+func (o *LocalRouterOp) Read(ctx context.Context, id types.ID) (*sacloud.LocalRouter, error) {
+	value := getLocalRouterByID(sacloud.APIDefaultZone, id)
+	if value == nil {
+		return nil, newErrorNotFound(o.key, id)
+	}
+	dest := &sacloud.LocalRouter{}
+	copySameNameField(value, dest)
+	return dest, nil
+}
+
+// Update is fake implementation
+func (o *LocalRouterOp) Update(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateRequest) (*sacloud.LocalRouter, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	status := &sacloud.LocalRouterHealth{
+		Peers: []*sacloud.LocalRouterHealthPeer{},
+	}
+	for _, peer := range value.Peers {
+		p, err := o.Read(ctx, peer.ID)
+		if err != nil {
+			return nil, err
+		}
+		var routes []string
+		if p.Interface != nil {
+			_, ipNet, err := net.ParseCIDR(fmt.Sprintf("%s/%d", p.Interface.VirtualIPAddress, p.Interface.NetworkMaskLen))
+			if err != nil {
+				return nil, err
+			}
+			if ipNet != nil {
+				routes = append(routes, ipNet.String())
+			}
+
+			for _, sr := range p.StaticRoutes {
+				routes = append(routes, sr.Prefix)
+			}
+		}
+
+		status.Peers = append(status.Peers, &sacloud.LocalRouterHealthPeer{
+			ID:     peer.ID,
+			Status: types.ServerInstanceStatuses.Up,
+			Routes: routes,
+		})
+	}
+
+	ds().Put(ResourceLocalRouter+"Status", sacloud.APIDefaultZone, value.ID, status)
+
+	putLocalRouter(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// UpdateSettings is fake implementation
+func (o *LocalRouterOp) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateSettingsRequest) (*sacloud.LocalRouter, error) {
+	value, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	copySameNameField(param, value)
+	fill(value, fillModifiedAt)
+
+	status := &sacloud.LocalRouterHealth{
+		Peers: []*sacloud.LocalRouterHealthPeer{},
+	}
+	for _, peer := range value.Peers {
+		p, err := o.Read(ctx, peer.ID)
+		if err != nil {
+			return nil, err
+		}
+		var routes []string
+		if p.Interface != nil {
+			_, ipNet, err := net.ParseCIDR(fmt.Sprintf("%s/%d", p.Interface.VirtualIPAddress, p.Interface.NetworkMaskLen))
+			if err != nil {
+				return nil, err
+			}
+			if ipNet != nil {
+				routes = append(routes, ipNet.String())
+			}
+
+			for _, sr := range p.StaticRoutes {
+				routes = append(routes, sr.Prefix)
+			}
+		}
+
+		status.Peers = append(status.Peers, &sacloud.LocalRouterHealthPeer{
+			ID:     peer.ID,
+			Status: types.ServerInstanceStatuses.Up,
+			Routes: routes,
+		})
+	}
+
+	ds().Put(ResourceLocalRouter+"Status", sacloud.APIDefaultZone, value.ID, status)
+
+	putLocalRouter(sacloud.APIDefaultZone, value)
+	return value, nil
+}
+
+// Delete is fake implementation
+func (o *LocalRouterOp) Delete(ctx context.Context, id types.ID) error {
+	_, err := o.Read(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	ds().Delete(o.key, sacloud.APIDefaultZone, id)
+	return nil
+}
+
+// HealthStatus is fake implementation
+func (o *LocalRouterOp) HealthStatus(ctx context.Context, id types.ID) (*sacloud.LocalRouterHealth, error) {
+	_, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	result := ds().Get(ResourceLocalRouter+"Status", sacloud.APIDefaultZone, id)
+	if result == nil {
+		return nil, newErrorNotFound(o.key, id)
+	}
+	return result.(*sacloud.LocalRouterHealth), nil
+}
+
+// MonitorLocalRouter is fake implementation
+func (o *LocalRouterOp) MonitorLocalRouter(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LocalRouterActivity, error) {
+	_, err := o.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().Truncate(time.Second)
+	m := now.Minute() % 5
+	if m != 0 {
+		now.Add(time.Duration(m) * time.Minute)
+	}
+
+	res := &sacloud.LocalRouterActivity{}
+	for i := 0; i < 5; i++ {
+		res.Values = append(res.Values, &sacloud.MonitorLocalRouterValue{
+			Time:               now.Add(time.Duration(i*-5) * time.Minute),
+			ReceiveBytesPerSec: float64(random(1000)),
+			SendBytesPerSec:    float64(random(1000)),
+		})
+	}
+
+	return res, nil
+}

--- a/sacloud/fake/zz_api_ops.go
+++ b/sacloud/fake/zz_api_ops.go
@@ -91,6 +91,9 @@ func SwitchFactoryFuncToFake() {
 	sacloud.SetClientFactoryFunc(ResourceLoadBalancer, func(caller sacloud.APICaller) interface{} {
 		return NewLoadBalancerOp()
 	})
+	sacloud.SetClientFactoryFunc(ResourceLocalRouter, func(caller sacloud.APICaller) interface{} {
+		return NewLocalRouterOp()
+	})
 	sacloud.SetClientFactoryFunc(ResourceMobileGateway, func(caller sacloud.APICaller) interface{} {
 		return NewMobileGatewayOp()
 	})
@@ -515,6 +518,22 @@ type LoadBalancerOp struct {
 func NewLoadBalancerOp() sacloud.LoadBalancerAPI {
 	return &LoadBalancerOp{
 		key: ResourceLoadBalancer,
+	}
+}
+
+/*************************************************
+* LocalRouterOp
+*************************************************/
+
+// LocalRouterOp is fake implementation of LocalRouterAPI interface
+type LocalRouterOp struct {
+	key string
+}
+
+// NewLocalRouterOp creates new LocalRouterOp instance
+func NewLocalRouterOp() sacloud.LocalRouterAPI {
+	return &LocalRouterOp{
+		key: ResourceLocalRouter,
 	}
 }
 

--- a/sacloud/fake/zz_api_ops_test.go
+++ b/sacloud/fake/zz_api_ops_test.go
@@ -116,6 +116,10 @@ func TestResourceOps(t *testing.T) {
 		t.Fatalf("%s is not sacloud.LoadBalancer", op)
 	}
 
+	if op, ok := NewLocalRouterOp().(sacloud.LocalRouterAPI); !ok {
+		t.Fatalf("%s is not sacloud.LocalRouter", op)
+	}
+
 	if op, ok := NewMobileGatewayOp().(sacloud.MobileGatewayAPI); !ok {
 		t.Fatalf("%s is not sacloud.MobileGateway", op)
 	}

--- a/sacloud/fake/zz_resources.go
+++ b/sacloud/fake/zz_resources.go
@@ -63,6 +63,8 @@ const (
 	ResourceLicenseInfo = "LicenseInfo"
 	// ResourceLoadBalancer is resource key of fake store
 	ResourceLoadBalancer = "LoadBalancer"
+	// ResourceLocalRouter is resource key of fake store
+	ResourceLocalRouter = "LocalRouter"
 	// ResourceMobileGateway is resource key of fake store
 	ResourceMobileGateway = "MobileGateway"
 	// ResourceNFS is resource key of fake store

--- a/sacloud/fake/zz_store.go
+++ b/sacloud/fake/zz_store.go
@@ -666,6 +666,34 @@ func putLoadBalancer(zone string, value *sacloud.LoadBalancer) {
 	ds().Put(ResourceLoadBalancer, zone, 0, value)
 }
 
+func getLocalRouter(zone string) []*sacloud.LocalRouter {
+	values := ds().List(ResourceLocalRouter, zone)
+	var ret []*sacloud.LocalRouter
+	for _, v := range values {
+		if v, ok := v.(*sacloud.LocalRouter); ok {
+			ret = append(ret, v)
+		}
+	}
+	return ret
+}
+
+func getLocalRouterByID(zone string, id types.ID) *sacloud.LocalRouter {
+	v := ds().Get(ResourceLocalRouter, zone, id)
+	if v, ok := v.(*sacloud.LocalRouter); ok {
+		return v
+	}
+	return nil
+}
+
+func putLocalRouter(zone string, value *sacloud.LocalRouter) {
+	var v interface{} = value
+	if id, ok := v.(accessor.ID); ok {
+		ds().Put(ResourceLocalRouter, zone, id.GetID(), value)
+		return
+	}
+	ds().Put(ResourceLocalRouter, zone, 0, value)
+}
+
 func getMobileGateway(zone string) []*sacloud.MobileGateway {
 	values := ds().List(ResourceMobileGateway, zone)
 	var ret []*sacloud.MobileGateway

--- a/sacloud/naked/local_router.go
+++ b/sacloud/naked/local_router.go
@@ -1,0 +1,102 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package naked
+
+import (
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// LocalRouter ローカルルータ
+type LocalRouter struct {
+	ID           types.ID             `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
+	Name         string               `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
+	Description  string               `yaml:"description"`
+	Tags         types.Tags           `yaml:"tags"`
+	Icon         *Icon                `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
+	CreatedAt    *time.Time           `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
+	ModifiedAt   *time.Time           `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
+	Availability types.EAvailability  `json:",omitempty" yaml:"availability,omitempty" structs:",omitempty"`
+	Provider     *Provider            `json:",omitempty" yaml:"provider,omitempty" structs:",omitempty"`
+	Settings     *LocalRouterSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string               `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+	Status       *LocalRouterStatus   `json:",omitempty" yaml:"status" structs:",omitempty"`
+	ServiceClass string               `json:",omitempty" yaml:"service_class,omitempty" structs:",omitempty"`
+}
+
+// LocalRouterSettings セッティング
+type LocalRouterSettings struct {
+	LocalRouter *LocalRouterSetting `json:",omitempty" yaml:"local_router,omitempty" structs:",omitempty"`
+}
+
+// LocalRouterSettingsUpdate ローカルルータ セッティング更新
+type LocalRouterSettingsUpdate struct {
+	Settings     *LocalRouterSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`
+	SettingsHash string               `json:",omitempty" yaml:"settings_hash,omitempty" structs:",omitempty"`
+}
+
+// LocalRouterSetting セッティング
+type LocalRouterSetting struct {
+	Switch       *LocalRouterSettingSwitch        `yaml:"switch"`
+	Interface    *LocalRouterSettingInterface     `yaml:"interface"`
+	Peers        []*LocalRouterSettingPeer        `yaml:"peers"`
+	StaticRoutes []*LocalRouterSettingStaticRoute `yaml:"static_routes"`
+}
+
+// LocalRouterSettingSwitch ローカルルータのスイッチ設定
+type LocalRouterSettingSwitch struct {
+	Code     string `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // リソースIDなど
+	Category string `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // cloud/vps/専用サーバなどを表す
+	ZoneID   string `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // クラウドの場合is1aなど Note: VPSの場合は数値型となる
+}
+
+// LocalRouterSettingInterface インターフェース設定
+type LocalRouterSettingInterface struct {
+	VirtualIPAddress string   `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	IPAddress        []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	NetworkMaskLen   int      `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	VRID             int      `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+}
+
+// LocalRouterSettingPeer ピア設定
+type LocalRouterSettingPeer struct {
+	ID          string `yaml:"id"` // 文字列でないとエラーになるためtypes.IDではなくstringとする
+	SecretKey   string `yaml:"secret_key"`
+	Enabled     bool   `yaml:"enabled"`
+	Description string `yaml:"description"`
+}
+
+// LocalRouterSettingStaticRoute スタティックルート
+type LocalRouterSettingStaticRoute struct {
+	Prefix  string `yaml:"prefix"`
+	NextHop string `yaml:"next_hop"`
+}
+
+// LocalRouterStatus ステータス
+type LocalRouterStatus struct {
+	SecretKeys []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+}
+
+// LocalRouterHealth ローカルルータのヘルスチェック結果
+type LocalRouterHealth struct {
+	LocalRouter *struct {
+		Peers []*struct {
+			ID     types.ID
+			Status types.EServerInstanceStatus
+			Routes []string
+		} `yaml:"peers"`
+	}
+}

--- a/sacloud/naked/monitor_test.go
+++ b/sacloud/naked/monitor_test.go
@@ -214,6 +214,26 @@ const (
             "connectionsPerSec": 22.0 
         }
     }`
+
+	testMonitorValuesLocalRouterJSON = `
+    {
+        "1970-01-01T00:00:01Z": {
+            "receiveBytesPerSec": 10.0, 
+            "sendBytesPerSec": 20.0 
+        },
+        "1970-01-01T00:00:02Z": {
+            "receiveBytesPerSec": 11.0, 
+            "sendBytesPerSec": 21.0 
+        },
+        "1970-01-01T00:00:03Z": {
+            "receiveBytesPerSec": null, 
+            "sendBytesPerSec": null 
+        },
+        "1970-01-01T00:00:04Z": {
+            "receiveBytesPerSec": 12.0, 
+            "sendBytesPerSec": 22.0 
+        }
+    }`
 )
 
 func TestMonitorValues_UnmarshalJSON(t *testing.T) {
@@ -424,6 +444,28 @@ func TestMonitorValues_UnmarshalJSON(t *testing.T) {
 						Time:              time.Unix(4, 0).UTC(),
 						ActiveConnections: float64(12.0),
 						ConnectionsPerSec: float64(22.0),
+					},
+				},
+			},
+		},
+		{
+			input: testMonitorValuesLocalRouterJSON,
+			expect: MonitorValues{
+				LocalRouter: MonitorLocalRouterValues{
+					{
+						Time:               time.Unix(1, 0).UTC(),
+						ReceiveBytesPerSec: float64(10.0),
+						SendBytesPerSec:    float64(20.0),
+					},
+					{
+						Time:               time.Unix(2, 0).UTC(),
+						ReceiveBytesPerSec: float64(11.0),
+						SendBytesPerSec:    float64(21.0),
+					},
+					{
+						Time:               time.Unix(4, 0).UTC(),
+						ReceiveBytesPerSec: float64(12.0),
+						SendBytesPerSec:    float64(22.0),
 					},
 				},
 			},

--- a/sacloud/stub/zz_api_stubs.go
+++ b/sacloud/stub/zz_api_stubs.go
@@ -2461,6 +2461,138 @@ func (s *LoadBalancerStub) Status(ctx context.Context, zone string, id types.ID)
 }
 
 /*************************************************
+* LocalRouterStub
+*************************************************/
+
+// LocalRouterFindStubResult is expected values of the Find operation
+type LocalRouterFindStubResult struct {
+	Values *sacloud.LocalRouterFindResult
+	Err    error
+}
+
+// LocalRouterCreateStubResult is expected values of the Create operation
+type LocalRouterCreateStubResult struct {
+	LocalRouter *sacloud.LocalRouter
+	Err         error
+}
+
+// LocalRouterReadStubResult is expected values of the Read operation
+type LocalRouterReadStubResult struct {
+	LocalRouter *sacloud.LocalRouter
+	Err         error
+}
+
+// LocalRouterUpdateStubResult is expected values of the Update operation
+type LocalRouterUpdateStubResult struct {
+	LocalRouter *sacloud.LocalRouter
+	Err         error
+}
+
+// LocalRouterUpdateSettingsStubResult is expected values of the UpdateSettings operation
+type LocalRouterUpdateSettingsStubResult struct {
+	LocalRouter *sacloud.LocalRouter
+	Err         error
+}
+
+// LocalRouterDeleteStubResult is expected values of the Delete operation
+type LocalRouterDeleteStubResult struct {
+	Err error
+}
+
+// LocalRouterHealthStatusStubResult is expected values of the HealthStatus operation
+type LocalRouterHealthStatusStubResult struct {
+	LocalRouterHealth *sacloud.LocalRouterHealth
+	Err               error
+}
+
+// LocalRouterMonitorLocalRouterStubResult is expected values of the MonitorLocalRouter operation
+type LocalRouterMonitorLocalRouterStubResult struct {
+	LocalRouterActivity *sacloud.LocalRouterActivity
+	Err                 error
+}
+
+// LocalRouterStub is for trace LocalRouterOp operations
+type LocalRouterStub struct {
+	FindStubResult               *LocalRouterFindStubResult
+	CreateStubResult             *LocalRouterCreateStubResult
+	ReadStubResult               *LocalRouterReadStubResult
+	UpdateStubResult             *LocalRouterUpdateStubResult
+	UpdateSettingsStubResult     *LocalRouterUpdateSettingsStubResult
+	DeleteStubResult             *LocalRouterDeleteStubResult
+	HealthStatusStubResult       *LocalRouterHealthStatusStubResult
+	MonitorLocalRouterStubResult *LocalRouterMonitorLocalRouterStubResult
+}
+
+// NewLocalRouterStub creates new LocalRouterStub instance
+func NewLocalRouterStub(caller sacloud.APICaller) sacloud.LocalRouterAPI {
+	return &LocalRouterStub{}
+}
+
+// Find is API call with trace log
+func (s *LocalRouterStub) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LocalRouterFindResult, error) {
+	if s.FindStubResult == nil {
+		log.Fatal("LocalRouterStub.FindStubResult is not set")
+	}
+	return s.FindStubResult.Values, s.FindStubResult.Err
+}
+
+// Create is API call with trace log
+func (s *LocalRouterStub) Create(ctx context.Context, param *sacloud.LocalRouterCreateRequest) (*sacloud.LocalRouter, error) {
+	if s.CreateStubResult == nil {
+		log.Fatal("LocalRouterStub.CreateStubResult is not set")
+	}
+	return s.CreateStubResult.LocalRouter, s.CreateStubResult.Err
+}
+
+// Read is API call with trace log
+func (s *LocalRouterStub) Read(ctx context.Context, id types.ID) (*sacloud.LocalRouter, error) {
+	if s.ReadStubResult == nil {
+		log.Fatal("LocalRouterStub.ReadStubResult is not set")
+	}
+	return s.ReadStubResult.LocalRouter, s.ReadStubResult.Err
+}
+
+// Update is API call with trace log
+func (s *LocalRouterStub) Update(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateRequest) (*sacloud.LocalRouter, error) {
+	if s.UpdateStubResult == nil {
+		log.Fatal("LocalRouterStub.UpdateStubResult is not set")
+	}
+	return s.UpdateStubResult.LocalRouter, s.UpdateStubResult.Err
+}
+
+// UpdateSettings is API call with trace log
+func (s *LocalRouterStub) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateSettingsRequest) (*sacloud.LocalRouter, error) {
+	if s.UpdateSettingsStubResult == nil {
+		log.Fatal("LocalRouterStub.UpdateSettingsStubResult is not set")
+	}
+	return s.UpdateSettingsStubResult.LocalRouter, s.UpdateSettingsStubResult.Err
+}
+
+// Delete is API call with trace log
+func (s *LocalRouterStub) Delete(ctx context.Context, id types.ID) error {
+	if s.DeleteStubResult == nil {
+		log.Fatal("LocalRouterStub.DeleteStubResult is not set")
+	}
+	return s.DeleteStubResult.Err
+}
+
+// HealthStatus is API call with trace log
+func (s *LocalRouterStub) HealthStatus(ctx context.Context, id types.ID) (*sacloud.LocalRouterHealth, error) {
+	if s.HealthStatusStubResult == nil {
+		log.Fatal("LocalRouterStub.HealthStatusStubResult is not set")
+	}
+	return s.HealthStatusStubResult.LocalRouterHealth, s.HealthStatusStubResult.Err
+}
+
+// MonitorLocalRouter is API call with trace log
+func (s *LocalRouterStub) MonitorLocalRouter(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LocalRouterActivity, error) {
+	if s.MonitorLocalRouterStubResult == nil {
+		log.Fatal("LocalRouterStub.MonitorLocalRouterStubResult is not set")
+	}
+	return s.MonitorLocalRouterStubResult.LocalRouterActivity, s.MonitorLocalRouterStubResult.Err
+}
+
+/*************************************************
 * MobileGatewayStub
 *************************************************/
 

--- a/sacloud/test/local_router_op_test.go
+++ b/sacloud/test/local_router_op_test.go
@@ -1,0 +1,440 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+func TestLocalRouterOp_CRUD(t *testing.T) {
+	testutil.Run(t, &testutil.CRUDTestCase{
+		Parallel:           true,
+		SetupAPICallerFunc: singletonAPICaller,
+		Setup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+			swOp := sacloud.NewSwitchOp(caller)
+			sw, err := swOp.Create(ctx, testZone, &sacloud.SwitchCreateRequest{
+				Name: testutil.ResourceName("switch-for-local-router"),
+			})
+			if err != nil {
+				return err
+			}
+
+			ctx.Values["localrouter/switch"] = sw.ID
+
+			updateLocalRouterParam.Switch.Code = sw.ID.String()
+			updateLocalRouterParam.Switch.ZoneID = testZone
+			updateLocalRouterExpected.Switch.Code = sw.ID.String()
+			updateLocalRouterExpected.Switch.ZoneID = testZone
+
+			updateLocalRouterSettingsParam.Switch.Code = sw.ID.String()
+			updateLocalRouterSettingsParam.Switch.ZoneID = testZone
+			updateLocalRouterSettingsExpected.Switch.Code = sw.ID.String()
+			updateLocalRouterSettingsExpected.Switch.ZoneID = testZone
+			return nil
+		},
+		Create: &testutil.CRUDTestFunc{
+			Func: testLocalRouterCreate,
+			CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+				ExpectValue:  createLocalRouterExpected,
+				IgnoreFields: ignoreLocalRouterFields,
+			}),
+		},
+
+		Read: &testutil.CRUDTestFunc{
+			Func: testLocalRouterRead,
+			CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+				ExpectValue:  createLocalRouterExpected,
+				IgnoreFields: ignoreLocalRouterFields,
+			}),
+		},
+
+		Updates: []*testutil.CRUDTestFunc{
+			{
+				Func: testLocalRouterUpdate,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateLocalRouterExpected,
+					IgnoreFields: ignoreLocalRouterFields,
+				}),
+			},
+			{
+				Func: testLocalRouterUpdateSettings,
+				CheckFunc: testutil.AssertEqualWithExpected(&testutil.CRUDTestExpect{
+					ExpectValue:  updateLocalRouterSettingsExpected,
+					IgnoreFields: ignoreLocalRouterFields,
+				}),
+			},
+		},
+
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: testLocalRouterDelete,
+		},
+		Cleanup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+			swOp := sacloud.NewSwitchOp(caller)
+			switchID, ok := ctx.Values["localrouter/switch"]
+			if ok {
+				if err := swOp.Delete(ctx, testZone, switchID.(types.ID)); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	})
+}
+
+var (
+	ignoreLocalRouterFields = []string{
+		"ID",
+		"Class",
+		"SettingsHash",
+		"CreatedAt",
+		"ModifiedAt",
+		"SecretKeys",
+	}
+	createLocalRouterParam = &sacloud.LocalRouterCreateRequest{
+		Name:        testutil.ResourceName("container-registry"),
+		Description: "desc",
+		Tags:        []string{"tag1", "tag2"},
+	}
+	createLocalRouterExpected = &sacloud.LocalRouter{
+		Name:         createLocalRouterParam.Name,
+		Description:  createLocalRouterParam.Description,
+		Tags:         createLocalRouterParam.Tags,
+		Availability: types.Availabilities.Available,
+	}
+	updateLocalRouterParam = &sacloud.LocalRouterUpdateRequest{
+		Name:        testutil.ResourceName("container-registry-upd"),
+		Description: "desc-upd",
+		Tags:        []string{"tag1-upd", "tag2-upd"},
+		IconID:      testIconID,
+		Switch: &sacloud.LocalRouterSwitch{
+			Category: "cloud",
+		},
+		Interface: &sacloud.LocalRouterInterface{
+			VirtualIPAddress: "192.168.0.2",
+			IPAddress:        []string{"192.168.0.21", "192.168.0.22"},
+			NetworkMaskLen:   24,
+			VRID:             100,
+		},
+		StaticRoutes: []*sacloud.LocalRouterStaticRoute{
+			{
+				Prefix:  "192.168.1.0/24",
+				NextHop: "192.168.0.201",
+			},
+			{
+				Prefix:  "192.168.2.0/24",
+				NextHop: "192.168.0.202",
+			},
+		},
+	}
+	updateLocalRouterExpected = &sacloud.LocalRouter{
+		Name:         updateLocalRouterParam.Name,
+		Description:  updateLocalRouterParam.Description,
+		Tags:         updateLocalRouterParam.Tags,
+		Availability: types.Availabilities.Available,
+		IconID:       testIconID,
+		Switch:       updateLocalRouterParam.Switch,
+		Interface:    updateLocalRouterParam.Interface,
+		StaticRoutes: updateLocalRouterParam.StaticRoutes,
+	}
+
+	updateLocalRouterSettingsParam = &sacloud.LocalRouterUpdateSettingsRequest{
+		Switch: &sacloud.LocalRouterSwitch{
+			Category: "cloud",
+		},
+		Interface: &sacloud.LocalRouterInterface{
+			VirtualIPAddress: "192.168.0.3",
+			IPAddress:        []string{"192.168.0.31", "192.168.0.32"},
+			NetworkMaskLen:   24,
+			VRID:             100,
+		},
+		StaticRoutes: []*sacloud.LocalRouterStaticRoute{
+			{
+				Prefix:  "192.168.1.0/24",
+				NextHop: "192.168.0.231",
+			},
+			{
+				Prefix:  "192.168.2.0/24",
+				NextHop: "192.168.0.232",
+			},
+		},
+	}
+	updateLocalRouterSettingsExpected = &sacloud.LocalRouter{
+		Name:         updateLocalRouterParam.Name,
+		Description:  updateLocalRouterParam.Description,
+		Tags:         updateLocalRouterParam.Tags,
+		Availability: types.Availabilities.Available,
+		IconID:       testIconID,
+		Switch:       updateLocalRouterSettingsParam.Switch,
+		Interface:    updateLocalRouterSettingsParam.Interface,
+		StaticRoutes: updateLocalRouterSettingsParam.StaticRoutes,
+	}
+)
+
+func testLocalRouterCreate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewLocalRouterOp(caller)
+	return client.Create(ctx, createLocalRouterParam)
+}
+
+func testLocalRouterRead(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewLocalRouterOp(caller)
+	return client.Read(ctx, ctx.ID)
+}
+
+func testLocalRouterUpdate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewLocalRouterOp(caller)
+	return client.Update(ctx, ctx.ID, updateLocalRouterParam)
+}
+
+func testLocalRouterUpdateSettings(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+	client := sacloud.NewLocalRouterOp(caller)
+	return client.UpdateSettings(ctx, ctx.ID, updateLocalRouterSettingsParam)
+}
+
+func testLocalRouterDelete(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+	client := sacloud.NewLocalRouterOp(caller)
+	return client.Delete(ctx, ctx.ID)
+}
+
+func TestLocalRouter_peering(t *testing.T) {
+	var sw1ID, sw2ID types.ID
+	var peerLocalRouter1, peerLocalRouter2 *sacloud.LocalRouter
+
+	testutil.Run(t, &testutil.CRUDTestCase{
+		Parallel:           true,
+		SetupAPICallerFunc: singletonAPICaller,
+		Setup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+			swOp := sacloud.NewSwitchOp(caller)
+			sw, err := swOp.Create(ctx, testZone, &sacloud.SwitchCreateRequest{
+				Name: testutil.ResourceName("switch-for-local-router"),
+			})
+			if err != nil {
+				return err
+			}
+			sw1ID = sw.ID
+
+			sw2, err := swOp.Create(ctx, testZone, &sacloud.SwitchCreateRequest{
+				Name: testutil.ResourceName("switch-for-local-router"),
+			})
+			if err != nil {
+				return err
+			}
+			sw2ID = sw2.ID
+
+			lr, err := sacloud.NewLocalRouterOp(caller).Create(ctx, &sacloud.LocalRouterCreateRequest{
+				Name: testutil.ResourceName("local-router"),
+			})
+			if err != nil {
+				return err
+			}
+			peerLocalRouter1 = lr
+			return nil
+		},
+		Create: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				lrOp := sacloud.NewLocalRouterOp(caller)
+				lr, err := lrOp.Create(ctx, &sacloud.LocalRouterCreateRequest{
+					Name: testutil.ResourceName("local-router"),
+				})
+				if err != nil {
+					return nil, err
+				}
+				peerLocalRouter2 = lr
+				return lr, nil
+			},
+		},
+
+		Read: &testutil.CRUDTestFunc{
+			Func: testLocalRouterRead,
+		},
+
+		Updates: []*testutil.CRUDTestFunc{
+			// connect to switches
+			{
+				Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					lrOp := sacloud.NewLocalRouterOp(caller)
+					lr1, err := lrOp.UpdateSettings(ctx, peerLocalRouter1.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+						Switch: &sacloud.LocalRouterSwitch{
+							Code:     sw1ID.String(),
+							Category: "cloud",
+							ZoneID:   testZone,
+						},
+						Interface: &sacloud.LocalRouterInterface{
+							VirtualIPAddress: "192.168.0.1",
+							IPAddress:        []string{"192.168.0.11", "192.168.0.12"},
+							NetworkMaskLen:   24,
+							VRID:             100,
+						},
+						SettingsHash: peerLocalRouter1.SettingsHash,
+					})
+					if err != nil {
+						return nil, err
+					}
+					peerLocalRouter1 = lr1
+
+					lr2, err := lrOp.UpdateSettings(ctx, peerLocalRouter2.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+						Switch: &sacloud.LocalRouterSwitch{
+							Code:     sw2ID.String(),
+							Category: "cloud",
+							ZoneID:   testZone,
+						},
+						Interface: &sacloud.LocalRouterInterface{
+							VirtualIPAddress: "192.168.1.1",
+							IPAddress:        []string{"192.168.1.11", "192.168.1.12"},
+							NetworkMaskLen:   24,
+							VRID:             100,
+						},
+						SettingsHash: peerLocalRouter2.SettingsHash,
+					})
+					if err != nil {
+						return nil, err
+					}
+					peerLocalRouter2 = lr2
+					return lr2, nil
+				},
+			},
+			// set peer
+			{
+				Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					lrOp := sacloud.NewLocalRouterOp(caller)
+					lr1, err := lrOp.UpdateSettings(ctx, peerLocalRouter1.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+						Switch:    peerLocalRouter1.Switch,
+						Interface: peerLocalRouter1.Interface,
+						Peers: []*sacloud.LocalRouterPeer{
+							{
+								ID:          peerLocalRouter2.ID,
+								SecretKey:   peerLocalRouter2.SecretKeys[0],
+								Enabled:     true,
+								Description: "desc",
+							},
+						},
+						SettingsHash: peerLocalRouter1.SettingsHash,
+					})
+					if err != nil {
+						return nil, err
+					}
+					peerLocalRouter1 = lr1
+
+					lr2, err := lrOp.UpdateSettings(ctx, peerLocalRouter2.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+						Switch:    peerLocalRouter2.Switch,
+						Interface: peerLocalRouter2.Interface,
+						Peers: []*sacloud.LocalRouterPeer{
+							{
+								ID:          peerLocalRouter1.ID,
+								SecretKey:   peerLocalRouter1.SecretKeys[0],
+								Enabled:     true,
+								Description: "desc",
+							},
+						},
+						SettingsHash: peerLocalRouter2.SettingsHash,
+					})
+					if err != nil {
+						return nil, err
+					}
+					peerLocalRouter2 = lr2
+					return lr2, nil
+				},
+				CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, _ interface{}) error {
+					return testutil.DoAsserts(
+						testutil.AssertNotNilFunc(t, peerLocalRouter1.Peers, "LocalRouter1.Peers"),
+						testutil.AssertNotNilFunc(t, peerLocalRouter2.Peers, "LocalRouter2.Peers"),
+						testutil.AssertEqualFunc(t, peerLocalRouter1.Peers[0].ID, peerLocalRouter2.ID, "LocalRouter2.Peers[0].ID"),
+						testutil.AssertEqualFunc(t, peerLocalRouter2.Peers[0].ID, peerLocalRouter1.ID, "LocalRouter2.Peers[0].ID"),
+					)
+				},
+			},
+			// clear peer
+			{
+				Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					lrOp := sacloud.NewLocalRouterOp(caller)
+					lr1, err := lrOp.UpdateSettings(ctx, peerLocalRouter1.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+						Switch:       peerLocalRouter1.Switch,
+						Interface:    peerLocalRouter1.Interface,
+						SettingsHash: peerLocalRouter1.SettingsHash,
+					})
+					if err != nil {
+						return nil, err
+					}
+					peerLocalRouter1 = lr1
+
+					lr2, err := lrOp.UpdateSettings(ctx, peerLocalRouter2.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+						Switch:       peerLocalRouter2.Switch,
+						Interface:    peerLocalRouter2.Interface,
+						SettingsHash: peerLocalRouter2.SettingsHash,
+					})
+					if err != nil {
+						return nil, err
+					}
+					peerLocalRouter2 = lr2
+					return lr2, nil
+				},
+				CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, _ interface{}) error {
+					return testutil.DoAsserts(
+						testutil.AssertNilFunc(t, peerLocalRouter1.Peers, "LocalRouter1.Peers"),
+						testutil.AssertNilFunc(t, peerLocalRouter2.Peers, "LocalRouter2.Peers"),
+					)
+				},
+			},
+			// disconnect from switches
+			{
+				Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+					lrOp := sacloud.NewLocalRouterOp(caller)
+					lr1, err := lrOp.UpdateSettings(ctx, peerLocalRouter1.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+						SettingsHash: peerLocalRouter1.SettingsHash,
+					})
+					if err != nil {
+						return nil, err
+					}
+					peerLocalRouter1 = lr1
+
+					lr2, err := lrOp.UpdateSettings(ctx, peerLocalRouter2.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+						SettingsHash: peerLocalRouter2.SettingsHash,
+					})
+					if err != nil {
+						return nil, err
+					}
+					peerLocalRouter2 = lr2
+					return lr2, nil
+				},
+				CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, _ interface{}) error {
+					return testutil.DoAsserts(
+						testutil.AssertNilFunc(t, peerLocalRouter1.Switch, "LocalRouter1.Switch"),
+						testutil.AssertNilFunc(t, peerLocalRouter2.Switch, "LocalRouter2.Switch"),
+					)
+				},
+			},
+		},
+
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+				lrOp := sacloud.NewLocalRouterOp(caller)
+				ids := []types.ID{peerLocalRouter1.ID, peerLocalRouter2.ID}
+				for _, id := range ids {
+					lrOp.Delete(ctx, id) // nolint
+				}
+
+				swOp := sacloud.NewSwitchOp(caller)
+				ids = []types.ID{sw1ID, sw2ID}
+				for _, id := range ids {
+					swOp.Delete(ctx, testZone, id) // nolint
+				}
+				return nil
+			},
+		},
+	})
+}

--- a/sacloud/trace/zz_api_tracer.go
+++ b/sacloud/trace/zz_api_tracer.go
@@ -96,6 +96,9 @@ func AddClientFactoryHooks() {
 	sacloud.AddClientFacotyHookFunc("LoadBalancer", func(in interface{}) interface{} {
 		return NewLoadBalancerTracer(in.(sacloud.LoadBalancerAPI))
 	})
+	sacloud.AddClientFacotyHookFunc("LocalRouter", func(in interface{}) interface{} {
+		return NewLocalRouterTracer(in.(sacloud.LocalRouterAPI))
+	})
 	sacloud.AddClientFacotyHookFunc("MobileGateway", func(in interface{}) interface{} {
 		return NewMobileGatewayTracer(in.(sacloud.MobileGatewayAPI))
 	})
@@ -5259,6 +5262,274 @@ func (t *LoadBalancerTracer) Status(ctx context.Context, zone string, id types.I
 	}
 
 	return result, err
+}
+
+/*************************************************
+* LocalRouterTracer
+*************************************************/
+
+// LocalRouterTracer is for trace LocalRouterOp operations
+type LocalRouterTracer struct {
+	Internal sacloud.LocalRouterAPI
+}
+
+// NewLocalRouterTracer creates new LocalRouterTracer instance
+func NewLocalRouterTracer(in sacloud.LocalRouterAPI) sacloud.LocalRouterAPI {
+	return &LocalRouterTracer{
+		Internal: in,
+	}
+}
+
+// Find is API call with trace log
+func (t *LocalRouterTracer) Find(ctx context.Context, conditions *sacloud.FindCondition) (*sacloud.LocalRouterFindResult, error) {
+	log.Println("[TRACE] LocalRouterAPI.Find start")
+	targetArguments := struct {
+		Argconditions *sacloud.FindCondition `json:"conditions"`
+	}{
+		Argconditions: conditions,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Find end")
+	}()
+
+	result, err := t.Internal.Find(ctx, conditions)
+	targetResults := struct {
+		Result *sacloud.LocalRouterFindResult
+		Error  error
+	}{
+		Result: result,
+		Error:  err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return result, err
+}
+
+// Create is API call with trace log
+func (t *LocalRouterTracer) Create(ctx context.Context, param *sacloud.LocalRouterCreateRequest) (*sacloud.LocalRouter, error) {
+	log.Println("[TRACE] LocalRouterAPI.Create start")
+	targetArguments := struct {
+		Argparam *sacloud.LocalRouterCreateRequest `json:"param"`
+	}{
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Create end")
+	}()
+
+	resultLocalRouter, err := t.Internal.Create(ctx, param)
+	targetResults := struct {
+		LocalRouter *sacloud.LocalRouter
+		Error       error
+	}{
+		LocalRouter: resultLocalRouter,
+		Error:       err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouter, err
+}
+
+// Read is API call with trace log
+func (t *LocalRouterTracer) Read(ctx context.Context, id types.ID) (*sacloud.LocalRouter, error) {
+	log.Println("[TRACE] LocalRouterAPI.Read start")
+	targetArguments := struct {
+		Argid types.ID `json:"id"`
+	}{
+		Argid: id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Read end")
+	}()
+
+	resultLocalRouter, err := t.Internal.Read(ctx, id)
+	targetResults := struct {
+		LocalRouter *sacloud.LocalRouter
+		Error       error
+	}{
+		LocalRouter: resultLocalRouter,
+		Error:       err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouter, err
+}
+
+// Update is API call with trace log
+func (t *LocalRouterTracer) Update(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateRequest) (*sacloud.LocalRouter, error) {
+	log.Println("[TRACE] LocalRouterAPI.Update start")
+	targetArguments := struct {
+		Argid    types.ID                          `json:"id"`
+		Argparam *sacloud.LocalRouterUpdateRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Update end")
+	}()
+
+	resultLocalRouter, err := t.Internal.Update(ctx, id, param)
+	targetResults := struct {
+		LocalRouter *sacloud.LocalRouter
+		Error       error
+	}{
+		LocalRouter: resultLocalRouter,
+		Error:       err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouter, err
+}
+
+// UpdateSettings is API call with trace log
+func (t *LocalRouterTracer) UpdateSettings(ctx context.Context, id types.ID, param *sacloud.LocalRouterUpdateSettingsRequest) (*sacloud.LocalRouter, error) {
+	log.Println("[TRACE] LocalRouterAPI.UpdateSettings start")
+	targetArguments := struct {
+		Argid    types.ID                                  `json:"id"`
+		Argparam *sacloud.LocalRouterUpdateSettingsRequest `json:"param"`
+	}{
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.UpdateSettings end")
+	}()
+
+	resultLocalRouter, err := t.Internal.UpdateSettings(ctx, id, param)
+	targetResults := struct {
+		LocalRouter *sacloud.LocalRouter
+		Error       error
+	}{
+		LocalRouter: resultLocalRouter,
+		Error:       err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouter, err
+}
+
+// Delete is API call with trace log
+func (t *LocalRouterTracer) Delete(ctx context.Context, id types.ID) error {
+	log.Println("[TRACE] LocalRouterAPI.Delete start")
+	targetArguments := struct {
+		Argid types.ID `json:"id"`
+	}{
+		Argid: id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.Delete end")
+	}()
+
+	err := t.Internal.Delete(ctx, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
+// HealthStatus is API call with trace log
+func (t *LocalRouterTracer) HealthStatus(ctx context.Context, id types.ID) (*sacloud.LocalRouterHealth, error) {
+	log.Println("[TRACE] LocalRouterAPI.HealthStatus start")
+	targetArguments := struct {
+		Argid types.ID `json:"id"`
+	}{
+		Argid: id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.HealthStatus end")
+	}()
+
+	resultLocalRouterHealth, err := t.Internal.HealthStatus(ctx, id)
+	targetResults := struct {
+		LocalRouterHealth *sacloud.LocalRouterHealth
+		Error             error
+	}{
+		LocalRouterHealth: resultLocalRouterHealth,
+		Error:             err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouterHealth, err
+}
+
+// MonitorLocalRouter is API call with trace log
+func (t *LocalRouterTracer) MonitorLocalRouter(ctx context.Context, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.LocalRouterActivity, error) {
+	log.Println("[TRACE] LocalRouterAPI.MonitorLocalRouter start")
+	targetArguments := struct {
+		Argid        types.ID                  `json:"id"`
+		Argcondition *sacloud.MonitorCondition `json:"condition"`
+	}{
+		Argid:        id,
+		Argcondition: condition,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LocalRouterAPI.MonitorLocalRouter end")
+	}()
+
+	resultLocalRouterActivity, err := t.Internal.MonitorLocalRouter(ctx, id, condition)
+	targetResults := struct {
+		LocalRouterActivity *sacloud.LocalRouterActivity
+		Error               error
+	}{
+		LocalRouterActivity: resultLocalRouterActivity,
+		Error:               err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultLocalRouterActivity, err
 }
 
 /*************************************************

--- a/sacloud/zz_api_ops.go
+++ b/sacloud/zz_api_ops.go
@@ -211,6 +211,14 @@ func init() {
 		}
 	})
 
+	SetClientFactoryFunc("LocalRouter", func(caller APICaller) interface{} {
+		return &LocalRouterOp{
+			Client:     caller,
+			PathSuffix: "api/cloud/1.1",
+			PathName:   "commonserviceitem",
+		}
+	})
+
 	SetClientFactoryFunc("MobileGateway", func(caller APICaller) interface{} {
 		return &MobileGatewayOp{
 			Client:     caller,
@@ -5797,6 +5805,306 @@ func (o *LoadBalancerOp) Status(ctx context.Context, zone string, id types.ID) (
 		return nil, err
 	}
 	return results, err
+}
+
+/*************************************************
+* LocalRouterOp
+*************************************************/
+
+// LocalRouterOp implements LocalRouterAPI interface
+type LocalRouterOp struct {
+	// Client APICaller
+	Client APICaller
+	// PathSuffix is used when building URL
+	PathSuffix string
+	// PathName is used when building URL
+	PathName string
+}
+
+// NewLocalRouterOp creates new LocalRouterOp instance
+func NewLocalRouterOp(caller APICaller) LocalRouterAPI {
+	return GetClientFactoryFunc("LocalRouter")(caller).(LocalRouterAPI)
+}
+
+// Find is API call
+func (o *LocalRouterOp) Find(ctx context.Context, conditions *FindCondition) (*LocalRouterFindResult, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"conditions": conditions,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformFindArgs(conditions)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformFindResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results, err
+}
+
+// Create is API call
+func (o *LocalRouterOp) Create(ctx context.Context, param *LocalRouterCreateRequest) (*LocalRouter, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformCreateArgs(param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformCreateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouter, nil
+}
+
+// Read is API call
+func (o *LocalRouterOp) Read(ctx context.Context, id types.ID) (*LocalRouter, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformReadResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouter, nil
+}
+
+// Update is API call
+func (o *LocalRouterOp) Update(ctx context.Context, id types.ID, param *LocalRouterUpdateRequest) (*LocalRouter, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouter, nil
+}
+
+// UpdateSettings is API call
+func (o *LocalRouterOp) UpdateSettings(ctx context.Context, id types.ID, param *LocalRouterUpdateSettingsRequest) (*LocalRouter, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformUpdateSettingsArgs(id, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformUpdateSettingsResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouter, nil
+}
+
+// Delete is API call
+func (o *LocalRouterOp) Delete(ctx context.Context, id types.ID) error {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	if err != nil {
+		return err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	_, err = o.Client.Do(ctx, "DELETE", url, body)
+	if err != nil {
+		return err
+	}
+
+	// build results
+
+	return nil
+}
+
+// HealthStatus is API call
+func (o *LocalRouterOp) HealthStatus(ctx context.Context, id types.ID) (*LocalRouterHealth, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/health", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformHealthStatusResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouterHealth, nil
+}
+
+// MonitorLocalRouter is API call
+func (o *LocalRouterOp) MonitorLocalRouter(ctx context.Context, id types.ID, condition *MonitorCondition) (*LocalRouterActivity, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       APIDefaultZone,
+		"id":         id,
+		"condition":  condition,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/activity/localrouter/monitor", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformMonitorLocalRouterArgs(id, condition)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformMonitorLocalRouterResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.LocalRouterActivity, nil
 }
 
 /*************************************************

--- a/sacloud/zz_api_transformers.go
+++ b/sacloud/zz_api_transformers.go
@@ -3446,6 +3446,229 @@ func (o *LoadBalancerOp) transformStatusResults(data []byte) (*LoadBalancerStatu
 	return results, nil
 }
 
+func (o *LocalRouterOp) transformFindArgs(conditions *FindCondition) (*localRouterFindRequestEnvelope, error) {
+	if conditions == nil {
+		conditions = &FindCondition{}
+	}
+	var arg0 interface{} = conditions
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+	}
+
+	v := &localRouterFindRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformFindResults(data []byte) (*LocalRouterFindResult, error) {
+	nakedResponse := &localRouterFindResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &LocalRouterFindResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformCreateArgs(param *LocalRouterCreateRequest) (*localRouterCreateRequestEnvelope, error) {
+	if param == nil {
+		param = &LocalRouterCreateRequest{}
+	}
+	var arg0 interface{} = param
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+	}
+
+	v := &localRouterCreateRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformCreateResults(data []byte) (*localRouterCreateResult, error) {
+	nakedResponse := &localRouterCreateResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterCreateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformReadResults(data []byte) (*localRouterReadResult, error) {
+	nakedResponse := &localRouterReadResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterReadResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformUpdateArgs(id types.ID, param *LocalRouterUpdateRequest) (*localRouterUpdateRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &LocalRouterUpdateRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &localRouterUpdateRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformUpdateResults(data []byte) (*localRouterUpdateResult, error) {
+	nakedResponse := &localRouterUpdateResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterUpdateResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformUpdateSettingsArgs(id types.ID, param *LocalRouterUpdateSettingsRequest) (*localRouterUpdateSettingsRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &LocalRouterUpdateSettingsRequest{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"CommonServiceItem,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &localRouterUpdateSettingsRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformUpdateSettingsResults(data []byte) (*localRouterUpdateSettingsResult, error) {
+	nakedResponse := &localRouterUpdateSettingsResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterUpdateSettingsResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformHealthStatusResults(data []byte) (*localRouterHealthStatusResult, error) {
+	nakedResponse := &localRouterHealthStatusResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterHealthStatusResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (o *LocalRouterOp) transformMonitorLocalRouterArgs(id types.ID, condition *MonitorCondition) (*localRouterMonitorLocalRouterRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if condition == nil {
+		condition = &MonitorCondition{}
+	}
+	var arg1 interface{} = condition
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &localRouterMonitorLocalRouterRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LocalRouterOp) transformMonitorLocalRouterResults(data []byte) (*localRouterMonitorLocalRouterResult, error) {
+	nakedResponse := &localRouterMonitorLocalRouterResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &localRouterMonitorLocalRouterResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *MobileGatewayOp) transformFindArgs(conditions *FindCondition) (*mobileGatewayFindRequestEnvelope, error) {
 	if conditions == nil {
 		conditions = &FindCondition{}

--- a/sacloud/zz_apis.go
+++ b/sacloud/zz_apis.go
@@ -352,6 +352,22 @@ type LoadBalancerAPI interface {
 }
 
 /*************************************************
+* LocalRouterAPI
+*************************************************/
+
+// LocalRouterAPI is interface for operate LocalRouter resource
+type LocalRouterAPI interface {
+	Find(ctx context.Context, conditions *FindCondition) (*LocalRouterFindResult, error)
+	Create(ctx context.Context, param *LocalRouterCreateRequest) (*LocalRouter, error)
+	Read(ctx context.Context, id types.ID) (*LocalRouter, error)
+	Update(ctx context.Context, id types.ID, param *LocalRouterUpdateRequest) (*LocalRouter, error)
+	UpdateSettings(ctx context.Context, id types.ID, param *LocalRouterUpdateSettingsRequest) (*LocalRouter, error)
+	Delete(ctx context.Context, id types.ID) error
+	HealthStatus(ctx context.Context, id types.ID) (*LocalRouterHealth, error)
+	MonitorLocalRouter(ctx context.Context, id types.ID, condition *MonitorCondition) (*LocalRouterActivity, error)
+}
+
+/*************************************************
 * MobileGatewayAPI
 *************************************************/
 

--- a/sacloud/zz_envelopes.go
+++ b/sacloud/zz_envelopes.go
@@ -1392,6 +1392,94 @@ type loadBalancerStatusResponseEnvelope struct {
 	LoadBalancer []*naked.LoadBalancerStatus `json:",omitempty"`
 }
 
+// localRouterFindRequestEnvelope is envelop of API request
+type localRouterFindRequestEnvelope struct {
+	Count   int             `mapconv:",omitempty"`
+	From    int             `mapconv:",omitempty"`
+	Sort    search.SortKeys `json:",omitempty" mapconv:",omitempty"`
+	Filter  search.Filter   `json:",omitempty" mapconv:",omitempty"`
+	Include []string        `json:",omitempty" mapconv:",omitempty"`
+	Exclude []string        `json:",omitempty" mapconv:",omitempty"`
+}
+
+// localRouterFindResponseEnvelope is envelop of API response
+type localRouterFindResponseEnvelope struct {
+	Total int `json:",omitempty"` // トータル件数
+	From  int `json:",omitempty"` // ページング開始ページ
+	Count int `json:",omitempty"` // 件数
+
+	CommonServiceItems []*naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterCreateRequestEnvelope is envelop of API request
+type localRouterCreateRequestEnvelope struct {
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterCreateResponseEnvelope is envelop of API response
+type localRouterCreateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterReadResponseEnvelope is envelop of API response
+type localRouterReadResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterUpdateRequestEnvelope is envelop of API request
+type localRouterUpdateRequestEnvelope struct {
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterUpdateResponseEnvelope is envelop of API response
+type localRouterUpdateResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterUpdateSettingsRequestEnvelope is envelop of API request
+type localRouterUpdateSettingsRequestEnvelope struct {
+	CommonServiceItem *naked.LocalRouterSettingsUpdate `json:",omitempty"`
+}
+
+// localRouterUpdateSettingsResponseEnvelope is envelop of API response
+type localRouterUpdateSettingsResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	CommonServiceItem *naked.LocalRouter `json:",omitempty"`
+}
+
+// localRouterHealthStatusResponseEnvelope is envelop of API response
+type localRouterHealthStatusResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	LocalRouter *naked.LocalRouterHealth `json:",omitempty"`
+}
+
+// localRouterMonitorLocalRouterRequestEnvelope is envelop of API request
+type localRouterMonitorLocalRouterRequestEnvelope struct {
+	Start time.Time `json:",omitempty"`
+	End   time.Time `json:",omitempty"`
+}
+
+// localRouterMonitorLocalRouterResponseEnvelope is envelop of API response
+type localRouterMonitorLocalRouterResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Data *naked.MonitorValues `json:",omitempty"`
+}
+
 // mobileGatewayFindRequestEnvelope is envelop of API request
 type mobileGatewayFindRequestEnvelope struct {
 	Count   int             `mapconv:",omitempty"`

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -12551,6 +12551,1017 @@ func (o *LoadBalancerServerStatus) SetCPS(v types.StringNumber) {
 }
 
 /*************************************************
+* LocalRouter
+*************************************************/
+
+// LocalRouter represents API parameter/response structure
+type LocalRouter struct {
+	ID           types.ID
+	Name         string `validate:"required"`
+	Description  string `validate:"min=0,max=512"`
+	Tags         types.Tags
+	Availability types.EAvailability
+	IconID       types.ID `mapconv:"Icon.ID"`
+	CreatedAt    time.Time
+	ModifiedAt   time.Time
+	Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+	Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+	Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+	StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+	SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+	SecretKeys   []string                  `mapconv:"Status.SecretKeys"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouter) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouter) setDefaults() interface{} {
+	return &struct {
+		ID           types.ID
+		Name         string `validate:"required"`
+		Description  string `validate:"min=0,max=512"`
+		Tags         types.Tags
+		Availability types.EAvailability
+		IconID       types.ID `mapconv:"Icon.ID"`
+		CreatedAt    time.Time
+		ModifiedAt   time.Time
+		Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+		Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+		Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+		StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+		SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+		SecretKeys   []string                  `mapconv:"Status.SecretKeys"`
+	}{
+		ID:           o.GetID(),
+		Name:         o.GetName(),
+		Description:  o.GetDescription(),
+		Tags:         o.GetTags(),
+		Availability: o.GetAvailability(),
+		IconID:       o.GetIconID(),
+		CreatedAt:    o.GetCreatedAt(),
+		ModifiedAt:   o.GetModifiedAt(),
+		Switch:       o.GetSwitch(),
+		Interface:    o.GetInterface(),
+		Peers:        o.GetPeers(),
+		StaticRoutes: o.GetStaticRoutes(),
+		SettingsHash: o.GetSettingsHash(),
+		SecretKeys:   o.GetSecretKeys(),
+	}
+}
+
+// GetID returns value of ID
+func (o *LocalRouter) GetID() types.ID {
+	return o.ID
+}
+
+// SetID sets value to ID
+func (o *LocalRouter) SetID(v types.ID) {
+	o.ID = v
+}
+
+// SetStringID .
+func (o *LocalRouter) SetStringID(id string) {
+	accessor.SetStringID(o, id)
+}
+
+// GetStringID .
+func (o *LocalRouter) GetStringID() string {
+	return accessor.GetStringID(o)
+}
+
+// SetInt64ID .
+func (o *LocalRouter) SetInt64ID(id int64) {
+	accessor.SetInt64ID(o, id)
+}
+
+// GetInt64ID .
+func (o *LocalRouter) GetInt64ID() int64 {
+	return accessor.GetInt64ID(o)
+}
+
+// GetName returns value of Name
+func (o *LocalRouter) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *LocalRouter) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *LocalRouter) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *LocalRouter) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *LocalRouter) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *LocalRouter) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *LocalRouter) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *LocalRouter) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *LocalRouter) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *LocalRouter) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetAvailability returns value of Availability
+func (o *LocalRouter) GetAvailability() types.EAvailability {
+	return o.Availability
+}
+
+// SetAvailability sets value to Availability
+func (o *LocalRouter) SetAvailability(v types.EAvailability) {
+	o.Availability = v
+}
+
+// GetIconID returns value of IconID
+func (o *LocalRouter) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *LocalRouter) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetCreatedAt returns value of CreatedAt
+func (o *LocalRouter) GetCreatedAt() time.Time {
+	return o.CreatedAt
+}
+
+// SetCreatedAt sets value to CreatedAt
+func (o *LocalRouter) SetCreatedAt(v time.Time) {
+	o.CreatedAt = v
+}
+
+// GetModifiedAt returns value of ModifiedAt
+func (o *LocalRouter) GetModifiedAt() time.Time {
+	return o.ModifiedAt
+}
+
+// SetModifiedAt sets value to ModifiedAt
+func (o *LocalRouter) SetModifiedAt(v time.Time) {
+	o.ModifiedAt = v
+}
+
+// GetSwitch returns value of Switch
+func (o *LocalRouter) GetSwitch() *LocalRouterSwitch {
+	return o.Switch
+}
+
+// SetSwitch sets value to Switch
+func (o *LocalRouter) SetSwitch(v *LocalRouterSwitch) {
+	o.Switch = v
+}
+
+// GetInterface returns value of Interface
+func (o *LocalRouter) GetInterface() *LocalRouterInterface {
+	return o.Interface
+}
+
+// SetInterface sets value to Interface
+func (o *LocalRouter) SetInterface(v *LocalRouterInterface) {
+	o.Interface = v
+}
+
+// GetPeers returns value of Peers
+func (o *LocalRouter) GetPeers() []*LocalRouterPeer {
+	return o.Peers
+}
+
+// SetPeers sets value to Peers
+func (o *LocalRouter) SetPeers(v []*LocalRouterPeer) {
+	o.Peers = v
+}
+
+// GetStaticRoutes returns value of StaticRoutes
+func (o *LocalRouter) GetStaticRoutes() []*LocalRouterStaticRoute {
+	return o.StaticRoutes
+}
+
+// SetStaticRoutes sets value to StaticRoutes
+func (o *LocalRouter) SetStaticRoutes(v []*LocalRouterStaticRoute) {
+	o.StaticRoutes = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *LocalRouter) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *LocalRouter) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+// GetSecretKeys returns value of SecretKeys
+func (o *LocalRouter) GetSecretKeys() []string {
+	return o.SecretKeys
+}
+
+// SetSecretKeys sets value to SecretKeys
+func (o *LocalRouter) SetSecretKeys(v []string) {
+	o.SecretKeys = v
+}
+
+/*************************************************
+* LocalRouterSwitch
+*************************************************/
+
+// LocalRouterSwitch represents API parameter/response structure
+type LocalRouterSwitch struct {
+	Code     string
+	Category string
+	ZoneID   string
+}
+
+// Validate validates by field tags
+func (o *LocalRouterSwitch) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterSwitch) setDefaults() interface{} {
+	return &struct {
+		Code     string
+		Category string
+		ZoneID   string
+	}{
+		Code:     o.GetCode(),
+		Category: o.GetCategory(),
+		ZoneID:   o.GetZoneID(),
+	}
+}
+
+// GetCode returns value of Code
+func (o *LocalRouterSwitch) GetCode() string {
+	return o.Code
+}
+
+// SetCode sets value to Code
+func (o *LocalRouterSwitch) SetCode(v string) {
+	o.Code = v
+}
+
+// GetCategory returns value of Category
+func (o *LocalRouterSwitch) GetCategory() string {
+	return o.Category
+}
+
+// SetCategory sets value to Category
+func (o *LocalRouterSwitch) SetCategory(v string) {
+	o.Category = v
+}
+
+// GetZoneID returns value of ZoneID
+func (o *LocalRouterSwitch) GetZoneID() string {
+	return o.ZoneID
+}
+
+// SetZoneID sets value to ZoneID
+func (o *LocalRouterSwitch) SetZoneID(v string) {
+	o.ZoneID = v
+}
+
+/*************************************************
+* LocalRouterInterface
+*************************************************/
+
+// LocalRouterInterface represents API parameter/response structure
+type LocalRouterInterface struct {
+	VirtualIPAddress string
+	IPAddress        []string
+	NetworkMaskLen   int
+	VRID             int
+}
+
+// Validate validates by field tags
+func (o *LocalRouterInterface) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterInterface) setDefaults() interface{} {
+	return &struct {
+		VirtualIPAddress string
+		IPAddress        []string
+		NetworkMaskLen   int
+		VRID             int
+	}{
+		VirtualIPAddress: o.GetVirtualIPAddress(),
+		IPAddress:        o.GetIPAddress(),
+		NetworkMaskLen:   o.GetNetworkMaskLen(),
+		VRID:             o.GetVRID(),
+	}
+}
+
+// GetVirtualIPAddress returns value of VirtualIPAddress
+func (o *LocalRouterInterface) GetVirtualIPAddress() string {
+	return o.VirtualIPAddress
+}
+
+// SetVirtualIPAddress sets value to VirtualIPAddress
+func (o *LocalRouterInterface) SetVirtualIPAddress(v string) {
+	o.VirtualIPAddress = v
+}
+
+// GetIPAddress returns value of IPAddress
+func (o *LocalRouterInterface) GetIPAddress() []string {
+	return o.IPAddress
+}
+
+// SetIPAddress sets value to IPAddress
+func (o *LocalRouterInterface) SetIPAddress(v []string) {
+	o.IPAddress = v
+}
+
+// GetNetworkMaskLen returns value of NetworkMaskLen
+func (o *LocalRouterInterface) GetNetworkMaskLen() int {
+	return o.NetworkMaskLen
+}
+
+// SetNetworkMaskLen sets value to NetworkMaskLen
+func (o *LocalRouterInterface) SetNetworkMaskLen(v int) {
+	o.NetworkMaskLen = v
+}
+
+// GetVRID returns value of VRID
+func (o *LocalRouterInterface) GetVRID() int {
+	return o.VRID
+}
+
+// SetVRID sets value to VRID
+func (o *LocalRouterInterface) SetVRID(v int) {
+	o.VRID = v
+}
+
+/*************************************************
+* LocalRouterPeer
+*************************************************/
+
+// LocalRouterPeer represents API parameter/response structure
+type LocalRouterPeer struct {
+	ID          types.ID
+	SecretKey   string
+	Enabled     bool
+	Description string
+}
+
+// Validate validates by field tags
+func (o *LocalRouterPeer) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterPeer) setDefaults() interface{} {
+	return &struct {
+		ID          types.ID
+		SecretKey   string
+		Enabled     bool
+		Description string
+	}{
+		ID:          o.GetID(),
+		SecretKey:   o.GetSecretKey(),
+		Enabled:     o.GetEnabled(),
+		Description: o.GetDescription(),
+	}
+}
+
+// GetID returns value of ID
+func (o *LocalRouterPeer) GetID() types.ID {
+	return o.ID
+}
+
+// SetID sets value to ID
+func (o *LocalRouterPeer) SetID(v types.ID) {
+	o.ID = v
+}
+
+// GetSecretKey returns value of SecretKey
+func (o *LocalRouterPeer) GetSecretKey() string {
+	return o.SecretKey
+}
+
+// SetSecretKey sets value to SecretKey
+func (o *LocalRouterPeer) SetSecretKey(v string) {
+	o.SecretKey = v
+}
+
+// GetEnabled returns value of Enabled
+func (o *LocalRouterPeer) GetEnabled() bool {
+	return o.Enabled
+}
+
+// SetEnabled sets value to Enabled
+func (o *LocalRouterPeer) SetEnabled(v bool) {
+	o.Enabled = v
+}
+
+// GetDescription returns value of Description
+func (o *LocalRouterPeer) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *LocalRouterPeer) SetDescription(v string) {
+	o.Description = v
+}
+
+/*************************************************
+* LocalRouterStaticRoute
+*************************************************/
+
+// LocalRouterStaticRoute represents API parameter/response structure
+type LocalRouterStaticRoute struct {
+	Prefix  string
+	NextHop string
+}
+
+// Validate validates by field tags
+func (o *LocalRouterStaticRoute) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterStaticRoute) setDefaults() interface{} {
+	return &struct {
+		Prefix  string
+		NextHop string
+	}{
+		Prefix:  o.GetPrefix(),
+		NextHop: o.GetNextHop(),
+	}
+}
+
+// GetPrefix returns value of Prefix
+func (o *LocalRouterStaticRoute) GetPrefix() string {
+	return o.Prefix
+}
+
+// SetPrefix sets value to Prefix
+func (o *LocalRouterStaticRoute) SetPrefix(v string) {
+	o.Prefix = v
+}
+
+// GetNextHop returns value of NextHop
+func (o *LocalRouterStaticRoute) GetNextHop() string {
+	return o.NextHop
+}
+
+// SetNextHop sets value to NextHop
+func (o *LocalRouterStaticRoute) SetNextHop(v string) {
+	o.NextHop = v
+}
+
+/*************************************************
+* LocalRouterCreateRequest
+*************************************************/
+
+// LocalRouterCreateRequest represents API parameter/response structure
+type LocalRouterCreateRequest struct {
+	Name        string `validate:"required"`
+	Description string `validate:"min=0,max=512"`
+	Tags        types.Tags
+	IconID      types.ID `mapconv:"Icon.ID"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterCreateRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterCreateRequest) setDefaults() interface{} {
+	return &struct {
+		Name        string `validate:"required"`
+		Description string `validate:"min=0,max=512"`
+		Tags        types.Tags
+		IconID      types.ID `mapconv:"Icon.ID"`
+		Class       string   `mapconv:"Provider.Class"`
+	}{
+		Name:        o.GetName(),
+		Description: o.GetDescription(),
+		Tags:        o.GetTags(),
+		IconID:      o.GetIconID(),
+		Class:       "localrouter",
+	}
+}
+
+// GetName returns value of Name
+func (o *LocalRouterCreateRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *LocalRouterCreateRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *LocalRouterCreateRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *LocalRouterCreateRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *LocalRouterCreateRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *LocalRouterCreateRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *LocalRouterCreateRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *LocalRouterCreateRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *LocalRouterCreateRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *LocalRouterCreateRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetIconID returns value of IconID
+func (o *LocalRouterCreateRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *LocalRouterCreateRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+/*************************************************
+* LocalRouterUpdateRequest
+*************************************************/
+
+// LocalRouterUpdateRequest represents API parameter/response structure
+type LocalRouterUpdateRequest struct {
+	Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+	Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+	Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+	StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+	SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+	Name         string                    `validate:"required"`
+	Description  string                    `validate:"min=0,max=512"`
+	Tags         types.Tags
+	IconID       types.ID `mapconv:"Icon.ID"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterUpdateRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterUpdateRequest) setDefaults() interface{} {
+	return &struct {
+		Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+		Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+		Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+		StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+		SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+		Name         string                    `validate:"required"`
+		Description  string                    `validate:"min=0,max=512"`
+		Tags         types.Tags
+		IconID       types.ID `mapconv:"Icon.ID"`
+	}{
+		Switch:       o.GetSwitch(),
+		Interface:    o.GetInterface(),
+		Peers:        o.GetPeers(),
+		StaticRoutes: o.GetStaticRoutes(),
+		SettingsHash: o.GetSettingsHash(),
+		Name:         o.GetName(),
+		Description:  o.GetDescription(),
+		Tags:         o.GetTags(),
+		IconID:       o.GetIconID(),
+	}
+}
+
+// GetSwitch returns value of Switch
+func (o *LocalRouterUpdateRequest) GetSwitch() *LocalRouterSwitch {
+	return o.Switch
+}
+
+// SetSwitch sets value to Switch
+func (o *LocalRouterUpdateRequest) SetSwitch(v *LocalRouterSwitch) {
+	o.Switch = v
+}
+
+// GetInterface returns value of Interface
+func (o *LocalRouterUpdateRequest) GetInterface() *LocalRouterInterface {
+	return o.Interface
+}
+
+// SetInterface sets value to Interface
+func (o *LocalRouterUpdateRequest) SetInterface(v *LocalRouterInterface) {
+	o.Interface = v
+}
+
+// GetPeers returns value of Peers
+func (o *LocalRouterUpdateRequest) GetPeers() []*LocalRouterPeer {
+	return o.Peers
+}
+
+// SetPeers sets value to Peers
+func (o *LocalRouterUpdateRequest) SetPeers(v []*LocalRouterPeer) {
+	o.Peers = v
+}
+
+// GetStaticRoutes returns value of StaticRoutes
+func (o *LocalRouterUpdateRequest) GetStaticRoutes() []*LocalRouterStaticRoute {
+	return o.StaticRoutes
+}
+
+// SetStaticRoutes sets value to StaticRoutes
+func (o *LocalRouterUpdateRequest) SetStaticRoutes(v []*LocalRouterStaticRoute) {
+	o.StaticRoutes = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *LocalRouterUpdateRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *LocalRouterUpdateRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+// GetName returns value of Name
+func (o *LocalRouterUpdateRequest) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *LocalRouterUpdateRequest) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *LocalRouterUpdateRequest) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *LocalRouterUpdateRequest) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *LocalRouterUpdateRequest) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *LocalRouterUpdateRequest) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *LocalRouterUpdateRequest) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *LocalRouterUpdateRequest) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *LocalRouterUpdateRequest) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *LocalRouterUpdateRequest) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetIconID returns value of IconID
+func (o *LocalRouterUpdateRequest) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *LocalRouterUpdateRequest) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+/*************************************************
+* LocalRouterUpdateSettingsRequest
+*************************************************/
+
+// LocalRouterUpdateSettingsRequest represents API parameter/response structure
+type LocalRouterUpdateSettingsRequest struct {
+	Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+	Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+	Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+	StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+	SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterUpdateSettingsRequest) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterUpdateSettingsRequest) setDefaults() interface{} {
+	return &struct {
+		Switch       *LocalRouterSwitch        `mapconv:"Settings.LocalRouter.Switch,recursive"`
+		Interface    *LocalRouterInterface     `mapconv:"Settings.LocalRouter.Interface,recursive"`
+		Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
+		StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
+		SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Switch:       o.GetSwitch(),
+		Interface:    o.GetInterface(),
+		Peers:        o.GetPeers(),
+		StaticRoutes: o.GetStaticRoutes(),
+		SettingsHash: o.GetSettingsHash(),
+	}
+}
+
+// GetSwitch returns value of Switch
+func (o *LocalRouterUpdateSettingsRequest) GetSwitch() *LocalRouterSwitch {
+	return o.Switch
+}
+
+// SetSwitch sets value to Switch
+func (o *LocalRouterUpdateSettingsRequest) SetSwitch(v *LocalRouterSwitch) {
+	o.Switch = v
+}
+
+// GetInterface returns value of Interface
+func (o *LocalRouterUpdateSettingsRequest) GetInterface() *LocalRouterInterface {
+	return o.Interface
+}
+
+// SetInterface sets value to Interface
+func (o *LocalRouterUpdateSettingsRequest) SetInterface(v *LocalRouterInterface) {
+	o.Interface = v
+}
+
+// GetPeers returns value of Peers
+func (o *LocalRouterUpdateSettingsRequest) GetPeers() []*LocalRouterPeer {
+	return o.Peers
+}
+
+// SetPeers sets value to Peers
+func (o *LocalRouterUpdateSettingsRequest) SetPeers(v []*LocalRouterPeer) {
+	o.Peers = v
+}
+
+// GetStaticRoutes returns value of StaticRoutes
+func (o *LocalRouterUpdateSettingsRequest) GetStaticRoutes() []*LocalRouterStaticRoute {
+	return o.StaticRoutes
+}
+
+// SetStaticRoutes sets value to StaticRoutes
+func (o *LocalRouterUpdateSettingsRequest) SetStaticRoutes(v []*LocalRouterStaticRoute) {
+	o.StaticRoutes = v
+}
+
+// GetSettingsHash returns value of SettingsHash
+func (o *LocalRouterUpdateSettingsRequest) GetSettingsHash() string {
+	return o.SettingsHash
+}
+
+// SetSettingsHash sets value to SettingsHash
+func (o *LocalRouterUpdateSettingsRequest) SetSettingsHash(v string) {
+	o.SettingsHash = v
+}
+
+/*************************************************
+* LocalRouterHealth
+*************************************************/
+
+// LocalRouterHealth represents API parameter/response structure
+type LocalRouterHealth struct {
+	Peers []*LocalRouterHealthPeer `mapconv:"LocalRouter.[]Peers,recursive"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterHealth) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterHealth) setDefaults() interface{} {
+	return &struct {
+		Peers []*LocalRouterHealthPeer `mapconv:"LocalRouter.[]Peers,recursive"`
+	}{
+		Peers: o.GetPeers(),
+	}
+}
+
+// GetPeers returns value of Peers
+func (o *LocalRouterHealth) GetPeers() []*LocalRouterHealthPeer {
+	return o.Peers
+}
+
+// SetPeers sets value to Peers
+func (o *LocalRouterHealth) SetPeers(v []*LocalRouterHealthPeer) {
+	o.Peers = v
+}
+
+/*************************************************
+* LocalRouterHealthPeer
+*************************************************/
+
+// LocalRouterHealthPeer represents API parameter/response structure
+type LocalRouterHealthPeer struct {
+	ID     types.ID
+	Status types.EServerInstanceStatus
+	Routes []string
+}
+
+// Validate validates by field tags
+func (o *LocalRouterHealthPeer) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterHealthPeer) setDefaults() interface{} {
+	return &struct {
+		ID     types.ID
+		Status types.EServerInstanceStatus
+		Routes []string
+	}{
+		ID:     o.GetID(),
+		Status: o.GetStatus(),
+		Routes: o.GetRoutes(),
+	}
+}
+
+// GetID returns value of ID
+func (o *LocalRouterHealthPeer) GetID() types.ID {
+	return o.ID
+}
+
+// SetID sets value to ID
+func (o *LocalRouterHealthPeer) SetID(v types.ID) {
+	o.ID = v
+}
+
+// GetStatus returns value of Status
+func (o *LocalRouterHealthPeer) GetStatus() types.EServerInstanceStatus {
+	return o.Status
+}
+
+// SetStatus sets value to Status
+func (o *LocalRouterHealthPeer) SetStatus(v types.EServerInstanceStatus) {
+	o.Status = v
+}
+
+// GetRoutes returns value of Routes
+func (o *LocalRouterHealthPeer) GetRoutes() []string {
+	return o.Routes
+}
+
+// SetRoutes sets value to Routes
+func (o *LocalRouterHealthPeer) SetRoutes(v []string) {
+	o.Routes = v
+}
+
+/*************************************************
+* LocalRouterActivity
+*************************************************/
+
+// LocalRouterActivity represents API parameter/response structure
+type LocalRouterActivity struct {
+	Values []*MonitorLocalRouterValue `mapconv:"[]LocalRouter"`
+}
+
+// Validate validates by field tags
+func (o *LocalRouterActivity) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *LocalRouterActivity) setDefaults() interface{} {
+	return &struct {
+		Values []*MonitorLocalRouterValue `mapconv:"[]LocalRouter"`
+	}{
+		Values: o.GetValues(),
+	}
+}
+
+// GetValues returns value of Values
+func (o *LocalRouterActivity) GetValues() []*MonitorLocalRouterValue {
+	return o.Values
+}
+
+// SetValues sets value to Values
+func (o *LocalRouterActivity) SetValues(v []*MonitorLocalRouterValue) {
+	o.Values = v
+}
+
+/*************************************************
+* MonitorLocalRouterValue
+*************************************************/
+
+// MonitorLocalRouterValue represents API parameter/response structure
+type MonitorLocalRouterValue struct {
+	Time               time.Time `json:",omitempty" mapconv:",omitempty"`
+	ReceiveBytesPerSec float64   `json:",omitempty" mapconv:",omitempty"`
+	SendBytesPerSec    float64   `json:",omitempty" mapconv:",omitempty"`
+}
+
+// Validate validates by field tags
+func (o *MonitorLocalRouterValue) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *MonitorLocalRouterValue) setDefaults() interface{} {
+	return &struct {
+		Time               time.Time `json:",omitempty" mapconv:",omitempty"`
+		ReceiveBytesPerSec float64   `json:",omitempty" mapconv:",omitempty"`
+		SendBytesPerSec    float64   `json:",omitempty" mapconv:",omitempty"`
+	}{
+		Time:               o.GetTime(),
+		ReceiveBytesPerSec: o.GetReceiveBytesPerSec(),
+		SendBytesPerSec:    o.GetSendBytesPerSec(),
+	}
+}
+
+// GetTime returns value of Time
+func (o *MonitorLocalRouterValue) GetTime() time.Time {
+	return o.Time
+}
+
+// SetTime sets value to Time
+func (o *MonitorLocalRouterValue) SetTime(v time.Time) {
+	o.Time = v
+}
+
+// GetReceiveBytesPerSec returns value of ReceiveBytesPerSec
+func (o *MonitorLocalRouterValue) GetReceiveBytesPerSec() float64 {
+	return o.ReceiveBytesPerSec
+}
+
+// SetReceiveBytesPerSec sets value to ReceiveBytesPerSec
+func (o *MonitorLocalRouterValue) SetReceiveBytesPerSec(v float64) {
+	o.ReceiveBytesPerSec = v
+}
+
+// GetSendBytesPerSec returns value of SendBytesPerSec
+func (o *MonitorLocalRouterValue) GetSendBytesPerSec() float64 {
+	return o.SendBytesPerSec
+}
+
+// SetSendBytesPerSec sets value to SendBytesPerSec
+func (o *MonitorLocalRouterValue) SetSendBytesPerSec(v float64) {
+	o.SendBytesPerSec = v
+}
+
+/*************************************************
 * MobileGateway
 *************************************************/
 

--- a/sacloud/zz_result.go
+++ b/sacloud/zz_result.go
@@ -807,6 +807,57 @@ type LoadBalancerStatusResult struct {
 	Status []*LoadBalancerStatus `json:",omitempty" mapconv:"[]LoadBalancer,omitempty,recursive"`
 }
 
+// LocalRouterFindResult represents the Result of API
+type LocalRouterFindResult struct {
+	Total int `json:",omitempty"` // Total count of target resources
+	From  int `json:",omitempty"` // Current page number
+	Count int `json:",omitempty"` // Count of current page
+
+	LocalRouters []*LocalRouter `json:",omitempty" mapconv:"[]CommonServiceItems,omitempty,recursive"`
+}
+
+// localRouterCreateResult represents the Result of API
+type localRouterCreateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouter *LocalRouter `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// localRouterReadResult represents the Result of API
+type localRouterReadResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouter *LocalRouter `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// localRouterUpdateResult represents the Result of API
+type localRouterUpdateResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouter *LocalRouter `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// localRouterUpdateSettingsResult represents the Result of API
+type localRouterUpdateSettingsResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouter *LocalRouter `json:",omitempty" mapconv:"CommonServiceItem,omitempty,recursive"`
+}
+
+// localRouterHealthStatusResult represents the Result of API
+type localRouterHealthStatusResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouterHealth *LocalRouterHealth `json:",omitempty" mapconv:"LocalRouter,omitempty,recursive"`
+}
+
+// localRouterMonitorLocalRouterResult represents the Result of API
+type localRouterMonitorLocalRouterResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	LocalRouterActivity *LocalRouterActivity `json:",omitempty" mapconv:"Data,omitempty,recursive"`
+}
+
 // MobileGatewayFindResult represents the Result of API
 type MobileGatewayFindResult struct {
 	Total int `json:",omitempty"` // Total count of target resources


### PR DESCRIPTION
ローカルルータAPIを追加する。

- CRUD操作(スイッチへの接続/切断やピアの追加/削除を含む)
- アクティビティモニタ

**注: libsacloud v1では対応せずv2のみの対応とする**

## Note:

#### Create時のパラメータ

- Create時に`Settings`を渡してもエラーとならないが反映されない。

対応として`sacloud.LocalRouterCreateRequest`に`Settings`関連パラメータを含めないようにした

#### Update時のパラメータ

- Update時にスイッチの接続とピアの追加を同時に行おうとすると400エラーとなる

このため適切な順序/パラメータでAPIを呼び出す必要がある。この問題はこのPRでは対応せず、別途`utils/builder`を追加するPRを作成して対応する。

#### Delete時の挙動

- 一度ローカルルータに接続したスイッチを削除しようとするとエラーとなる場合がある

ローカルルータからスイッチを切断してもスイッチ側にハイブリッド接続の情報が残ったままになるケースがあり、この状態でスイッチを削除しようとするとエラーが発生する。
このため`utils/cleanup`を追加しスイッチの切断を行ってからローカルルータの削除を行うようにする。

また、削除できなくなったスイッチも数分〜15分程度待てば削除できるようになったため、クライアント側で待機処理を実装できるようにする。現在はスイッチの`HybridConnection`フィールドはlibsacloudで未対応のため、待機処理のために別途PRで対応する。