### PR TITLE
HybridConnection関連フィールドの追加

### DIFF
--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -391,6 +391,16 @@ func (f *fieldsDef) BridgeID() *dsl.FieldDesc {
 	}
 }
 
+func (f *fieldsDef) HybridConnectionID() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "HybridConnectionID",
+		Type: meta.TypeID,
+		Tags: &dsl.FieldTags{
+			MapConv: "HybridConnection.ID,omitempty",
+		},
+	}
+}
+
 func (f *fieldsDef) SwitchID() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "SwitchID",

--- a/internal/define/switch.go
+++ b/internal/define/switch.go
@@ -113,6 +113,7 @@ var (
 				},
 			},
 			fields.BridgeID(),
+			fields.HybridConnectionID(),
 		},
 	}
 

--- a/sacloud/naked/hybrid_connection.go
+++ b/sacloud/naked/hybrid_connection.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package naked
+
+import "github.com/sacloud/libsacloud/v2/sacloud/types"
+
+// HybridConnection ハイブリッドコネクション
+type HybridConnection struct {
+	ID       types.ID
+	Services []*HybridConnectionService
+}
+
+// HybridConnectionService ハイブリッドコネクションにて接続されているサービスの情報
+type HybridConnectionService struct {
+	ServiceCategory string
+	ServiceName     string
+	ServiceCode     string
+	CloudZone       string
+	IsMyself        bool
+}

--- a/sacloud/naked/switch.go
+++ b/sacloud/naked/switch.go
@@ -22,20 +22,21 @@ import (
 
 // Switch スイッチ
 type Switch struct {
-	ID          types.ID     `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
-	Name        string       `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
-	Description string       `yaml:"description"`
-	Tags        types.Tags   `yaml:"tags"`
-	Icon        *Icon        `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
-	CreatedAt   *time.Time   `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
-	ModifiedAt  *time.Time   `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
-	Scope       types.EScope `json:",omitempty" yaml:"scope,omitempty" structs:",omitempty"`
-	Subnet      *Subnet      `json:",omitempty" yaml:"subnet,omitempty" structs:",omitempty"`
-	UserSubnet  *UserSubnet  `json:",omitempty" yaml:"user_subnet,omitempty" structs:",omitempty"`
-	Zone        *Zone        `json:",omitempty" yaml:"zone,omitempty" structs:",omitempty"`
-	Internet    *Internet    `json:",omitempty" yaml:"internet,omitempty" structs:",omitempty"`
-	Subnets     []*Subnet    `json:",omitempty" yaml:"subnets,omitempty" structs:",omitempty"`
-	IPv6Nets    []*IPv6Net   `json:",omitempty" yaml:"ipv6nets,omitempty" structs:",omitempty"`
-	Bridge      *Bridge      `json:",omitempty" yaml:"bridge,omitempty" structs:",omitempty"`
-	ServerCount int          `json:",omitempty" yaml:"server_count,omitempty" structs:",omitempty"`
+	ID               types.ID          `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
+	Name             string            `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
+	Description      string            `yaml:"description"`
+	Tags             types.Tags        `yaml:"tags"`
+	Icon             *Icon             `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
+	CreatedAt        *time.Time        `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
+	ModifiedAt       *time.Time        `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
+	Scope            types.EScope      `json:",omitempty" yaml:"scope,omitempty" structs:",omitempty"`
+	Subnet           *Subnet           `json:",omitempty" yaml:"subnet,omitempty" structs:",omitempty"`
+	UserSubnet       *UserSubnet       `json:",omitempty" yaml:"user_subnet,omitempty" structs:",omitempty"`
+	Zone             *Zone             `json:",omitempty" yaml:"zone,omitempty" structs:",omitempty"`
+	Internet         *Internet         `json:",omitempty" yaml:"internet,omitempty" structs:",omitempty"`
+	Subnets          []*Subnet         `json:",omitempty" yaml:"subnets,omitempty" structs:",omitempty"`
+	IPv6Nets         []*IPv6Net        `json:",omitempty" yaml:"ipv6nets,omitempty" structs:",omitempty"`
+	Bridge           *Bridge           `json:",omitempty" yaml:"bridge,omitempty" structs:",omitempty"`
+	ServerCount      int               `json:",omitempty" yaml:"server_count,omitempty" structs:",omitempty"`
+	HybridConnection *HybridConnection `json:",omitempty" yaml:"hybrid_connection,omitempty" structs:",omitempty"`
 }

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -23922,19 +23922,20 @@ func (o *SubnetIPAddress) SetIPAddress(v string) {
 
 // Switch represents API parameter/response structure
 type Switch struct {
-	ID             types.ID
-	Name           string `validate:"required"`
-	Description    string `validate:"min=0,max=512"`
-	Tags           types.Tags
-	IconID         types.ID `mapconv:"Icon.ID"`
-	CreatedAt      time.Time
-	ModifiedAt     time.Time
-	Scope          types.EScope
-	ServerCount    int
-	NetworkMaskLen int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-	DefaultRoute   string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
-	Subnets        []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
-	BridgeID       types.ID        `mapconv:"Bridge.ID,omitempty"`
+	ID                 types.ID
+	Name               string `validate:"required"`
+	Description        string `validate:"min=0,max=512"`
+	Tags               types.Tags
+	IconID             types.ID `mapconv:"Icon.ID"`
+	CreatedAt          time.Time
+	ModifiedAt         time.Time
+	Scope              types.EScope
+	ServerCount        int
+	NetworkMaskLen     int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
+	DefaultRoute       string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
+	Subnets            []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
+	BridgeID           types.ID        `mapconv:"Bridge.ID,omitempty"`
+	HybridConnectionID types.ID        `mapconv:"HybridConnection.ID,omitempty"`
 }
 
 // Validate validates by field tags
@@ -23945,33 +23946,35 @@ func (o *Switch) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *Switch) setDefaults() interface{} {
 	return &struct {
-		ID             types.ID
-		Name           string `validate:"required"`
-		Description    string `validate:"min=0,max=512"`
-		Tags           types.Tags
-		IconID         types.ID `mapconv:"Icon.ID"`
-		CreatedAt      time.Time
-		ModifiedAt     time.Time
-		Scope          types.EScope
-		ServerCount    int
-		NetworkMaskLen int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-		DefaultRoute   string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
-		Subnets        []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
-		BridgeID       types.ID        `mapconv:"Bridge.ID,omitempty"`
+		ID                 types.ID
+		Name               string `validate:"required"`
+		Description        string `validate:"min=0,max=512"`
+		Tags               types.Tags
+		IconID             types.ID `mapconv:"Icon.ID"`
+		CreatedAt          time.Time
+		ModifiedAt         time.Time
+		Scope              types.EScope
+		ServerCount        int
+		NetworkMaskLen     int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
+		DefaultRoute       string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
+		Subnets            []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
+		BridgeID           types.ID        `mapconv:"Bridge.ID,omitempty"`
+		HybridConnectionID types.ID        `mapconv:"HybridConnection.ID,omitempty"`
 	}{
-		ID:             o.GetID(),
-		Name:           o.GetName(),
-		Description:    o.GetDescription(),
-		Tags:           o.GetTags(),
-		IconID:         o.GetIconID(),
-		CreatedAt:      o.GetCreatedAt(),
-		ModifiedAt:     o.GetModifiedAt(),
-		Scope:          o.GetScope(),
-		ServerCount:    o.GetServerCount(),
-		NetworkMaskLen: o.GetNetworkMaskLen(),
-		DefaultRoute:   o.GetDefaultRoute(),
-		Subnets:        o.GetSubnets(),
-		BridgeID:       o.GetBridgeID(),
+		ID:                 o.GetID(),
+		Name:               o.GetName(),
+		Description:        o.GetDescription(),
+		Tags:               o.GetTags(),
+		IconID:             o.GetIconID(),
+		CreatedAt:          o.GetCreatedAt(),
+		ModifiedAt:         o.GetModifiedAt(),
+		Scope:              o.GetScope(),
+		ServerCount:        o.GetServerCount(),
+		NetworkMaskLen:     o.GetNetworkMaskLen(),
+		DefaultRoute:       o.GetDefaultRoute(),
+		Subnets:            o.GetSubnets(),
+		BridgeID:           o.GetBridgeID(),
+		HybridConnectionID: o.GetHybridConnectionID(),
 	}
 }
 
@@ -24143,6 +24146,16 @@ func (o *Switch) GetBridgeID() types.ID {
 // SetBridgeID sets value to BridgeID
 func (o *Switch) SetBridgeID(v types.ID) {
 	o.BridgeID = v
+}
+
+// GetHybridConnectionID returns value of HybridConnectionID
+func (o *Switch) GetHybridConnectionID() types.ID {
+	return o.HybridConnectionID
+}
+
+// SetHybridConnectionID sets value to HybridConnectionID
+func (o *Switch) SetHybridConnectionID(v types.ID) {
+	o.HybridConnectionID = v
 }
 
 /*************************************************


### PR DESCRIPTION
related: #479

スイッチからハイブリッド接続情報を参照可能にする。
現状はハイブリッド接続有無があれば十分なため、ハイブリッド接続IDのみを参照可能とする。