### PR TITLE
Allow both of string and number at Appliance.Remark.SourceAppliance.ID/Appliance.Settings.DBConf.Replication.Appliance.ID

### DIFF
--- a/api/database_test.go
+++ b/api/database_test.go
@@ -59,7 +59,6 @@ func TestDatabaseCRUD(t *testing.T) {
 	//newItem.Remark.Zone = &sacloud.Resource{ID: 21001}
 
 	item, err := api.Create(newItem)
-
 	assert.NoError(t, err)
 	assert.NotEmpty(t, item)
 

--- a/sacloud/database.go
+++ b/sacloud/database.go
@@ -36,13 +36,18 @@ type Database struct {
 // DatabaseRemark データベースリマーク
 type DatabaseRemark struct {
 	*ApplianceRemarkBase
-	propPlanID                             // プランID
-	DBConf          *DatabaseCommonRemarks // コンフィグ
-	Network         *DatabaseRemarkNetwork // ネットワーク
-	SourceAppliance *Resource              // クローン元DB
-	Zone            struct {               // ゾーン
+	propPlanID                               // プランID
+	DBConf          *DatabaseCommonRemarks   // コンフィグ
+	Network         *DatabaseRemarkNetwork   // ネットワーク
+	SourceAppliance *DatabaseSourceAppliance `json:",omitempty"` // クローン元DB
+	Zone            struct {                 // ゾーン
 		ID json.Number `json:",omitempty"` // ゾーンID
 	}
+}
+
+// DatabaseSourceAppliance ソースアプライアンス(クローン元DB)
+type DatabaseSourceAppliance struct {
+	ID json.Number `json:",omitempty"`
 }
 
 // DatabaseRemarkNetwork ネットワーク
@@ -195,9 +200,7 @@ type DatabaseReplicationSetting struct {
 	// Model レプリケーションモデル
 	Model DatabaseReplicationModels `json:",omitempty"`
 	// Appliance マスター側アプライアンス
-	Appliance *struct {
-		ID string
-	} `json:",omitempty"`
+	Appliance *DatabaseSourceAppliance `json:",omitempty"`
 	// IPAddress IPアドレス
 	IPAddress string `json:",omitempty"`
 	// Port ポート
@@ -344,8 +347,7 @@ func CreateNewDatabase(values *CreateDatabaseValue) *Database {
 				},
 			},
 			// Plan
-			propPlanID:      propPlanID{Plan: &Resource{ID: int64(values.Plan)}},
-			SourceAppliance: values.SourceAppliance,
+			propPlanID: propPlanID{Plan: &Resource{ID: int64(values.Plan)}},
 		},
 		// Settings
 		Settings: &DatabaseSettings{
@@ -372,6 +374,10 @@ func CreateNewDatabase(values *CreateDatabaseValue) *Database {
 				},
 			},
 		},
+	}
+
+	if values.SourceAppliance.GetStrID() != "" {
+		db.Remark.SourceAppliance = &DatabaseSourceAppliance{ID: json.Number(values.SourceAppliance.GetStrID())}
 	}
 
 	if values.ServicePort > 0 {
@@ -472,7 +478,7 @@ func NewSlaveDatabaseValue(values *SlaveDatabaseValue) *Database {
 				// Replication
 				Replication: &DatabaseReplicationSetting{
 					Model:     DatabaseReplicationModelAsyncReplica,
-					Appliance: &struct{ ID string }{ID: fmt.Sprintf("%d", values.MasterApplianceID)},
+					Appliance: &DatabaseSourceAppliance{ID: json.Number(fmt.Sprintf("%d", values.MasterApplianceID))},
 					IPAddress: values.MasterIPAddress,
 					Port:      values.MasterPort,
 					User:      "replica",


### PR DESCRIPTION
データベースアプライアンスの参照時にjson.Unmarshalエラーとなる場合がある。
これは文字列を期待しているフィールドに対し数値型が返ってくることにより発生している。

対応として、データベースアプライアンスの`Remark.SourceAppliance.ID`で`json.Number`を利用し数値と文字列両方を許容する。
類似箇所である`Settings.DBConf.Replication.Appliance.ID`も同様の対応を行う。

この問題はv1のみで発生しv2では発生しない。