### PR TITLE
Fix UserIPAddress parameter propagation at utils/server/Builder

### DIFF
--- a/sacloud/fake/ops_disk.go
+++ b/sacloud/fake/ops_disk.go
@@ -113,6 +113,11 @@ func (o *DiskOp) Config(ctx context.Context, zone string, id types.ID, edit *sac
 		return err
 	}
 
+	if edit.HostName != "" {
+		server.HostName = edit.HostName
+		putServer(zone, server)
+	}
+
 	if len(server.Interfaces) > 0 {
 		nic := server.Interfaces[0]
 		if nic.SwitchScope == types.Scopes.Shared {

--- a/sacloud/fake/ops_interface.go
+++ b/sacloud/fake/ops_interface.go
@@ -86,6 +86,19 @@ func (o *InterfaceOp) Update(ctx context.Context, zone string, id types.ID, para
 	copySameNameField(param, value)
 	fill(value, fillModifiedAt)
 
+	serverOp := NewServerOp()
+	searched, err := serverOp.Find(ctx, zone, nil)
+	if err == nil {
+		for _, server := range searched.Servers {
+			for _, iface := range server.Interfaces {
+				if iface.ID == id {
+					iface.UserIPAddress = param.UserIPAddress
+					putServer(zone, server)
+				}
+			}
+		}
+	}
+
 	putInterface(zone, value)
 	return value, nil
 }

--- a/utils/builder/server/builder.go
+++ b/utils/builder/server/builder.go
@@ -437,12 +437,14 @@ func (b *Builder) collectInterfaceParameters() []*updateInterfaceRequest {
 		reqs = append(reqs, &updateInterfaceRequest{
 			index:          0,
 			packetFilterID: b.NIC.GetPacketFilterID(),
+			displayIP:      b.NIC.GetDisplayIPAddress(),
 		})
 	}
 	for i, nic := range b.AdditionalNICs {
 		reqs = append(reqs, &updateInterfaceRequest{
 			index:          i + 1,
 			packetFilterID: nic.GetPacketFilterID(),
+			displayIP:      nic.GetDisplayIPAddress(),
 		})
 	}
 	return reqs

--- a/utils/builder/server/nic.go
+++ b/utils/builder/server/nic.go
@@ -33,6 +33,7 @@ type nicState struct {
 // NICSettingHolder NIC設定を保持するためのインターフェース
 type NICSettingHolder interface {
 	GetConnectedSwitchParam() *sacloud.ConnectedSwitch
+	GetDisplayIPAddress() string
 
 	GetPacketFilterID() types.ID
 	Validate(ctx context.Context, client *APIClient, zone string) error
@@ -74,6 +75,11 @@ func (c *SharedNICSetting) Validate(ctx context.Context, client *APIClient, zone
 		}
 	}
 	return nil
+}
+
+// GetDisplayIPAddress 表示用IPアドレスを返す
+func (c *SharedNICSetting) GetDisplayIPAddress() string {
+	return ""
 }
 
 func (c *SharedNICSetting) state() *nicState {

--- a/utils/query/public_archive_info.go
+++ b/utils/query/public_archive_info.go
@@ -103,11 +103,6 @@ func getPublicArchiveFromAncestors(ctx context.Context, zone string, reader *Arc
 		return nil, nil
 	}
 
-	// vSrXであれば編集不可
-	if archive.HasTag("pkg-vsrx") {
-		return nil, nil
-	}
-
 	// SophosUTMであれば編集不可
 	if archive.HasTag("pkg-sophosutm") || isSophosUTM(archive) {
 		return nil, nil
@@ -118,6 +113,10 @@ func getPublicArchiveFromAncestors(ctx context.Context, zone string, reader *Arc
 	}
 	// Netwiser VEであれば編集不可
 	if archive.HasTag("pkg-netwiserve") {
+		return nil, nil
+	}
+	// Juniper vSRXであれば編集不可
+	if archive.HasTag("pkg-vsrx") {
 		return nil, nil
 	}
 


### PR DESCRIPTION
utils/server.BuilderでのUserIPAddress(フィールド名は`DisplayIPAddress`)がBuilderからAPIクライアントへ正しく伝搬していなかったのを修正。

合わせてFakeドライバーでのディスクの修正API部分も同様の箇所があったため修正。

Note: vSRX関連処理が紛れ込んでいるが、分割が面倒なためこのままマージする。