### PR TITLE
[Don't merge] Add isZero func instead of reflect.Value.IsZero

### DIFF
--- a/pkg/mapconv/mapconv.go
+++ b/pkg/mapconv/mapconv.go
@@ -16,6 +16,7 @@ package mapconv
 
 import (
 	"errors"
+	"math"
 	"reflect"
 	"strings"
 
@@ -131,7 +132,7 @@ func ConvertFrom(source interface{}, dest interface{}) error {
 			if err != nil {
 				return err
 			}
-			if value == nil || reflect.ValueOf(value).IsZero() {
+			if value == nil || isZero(reflect.ValueOf(value)) {
 				continue
 			}
 
@@ -231,5 +232,47 @@ func ParseMapConvTag(tagBody string) TagInfo {
 		Recursive:    recursive,
 		Squash:       squash,
 		IsSlice:      isSlice,
+	}
+}
+
+// isZero go 1.13 からのポート
+func isZero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return math.Float64bits(v.Float()) == 0
+	case reflect.Complex64, reflect.Complex128:
+		c := v.Complex()
+		return math.Float64bits(real(c)) == 0 && math.Float64bits(imag(c)) == 0
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if !isZero(v.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		return v.IsNil()
+	case reflect.String:
+		return v.Len() == 0
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if !isZero(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		// This should never happens, but will act as a safeguard for
+		// later, as a default value doesn't makes sense here.
+		panic(&reflect.ValueError{
+			Method: "reflect.Value.IsZero",
+			Kind:   v.Kind(),
+		})
 	}
 }


### PR DESCRIPTION
go 1.12向けにreflect.ValueのIsZero()をコピーして実装したもの。

go 1.12でビルドしたい環境(gopherjsやwasmなど)向けのワークアラウンド。