### PR TITLE
Call xxxOp.Config() func when creating/updating

### DIFF
--- a/utils/builder/database/builder.go
+++ b/utils/builder/database/builder.go
@@ -104,6 +104,9 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.Database, er
 		Read: func(ctx context.Context, zone string, id types.ID) (interface{}, error) {
 			return b.Client.Database.Read(ctx, zone, id)
 		},
+		ProvisionBeforeUp: func(ctx context.Context, zone string, id types.ID, _ interface{}) error {
+			return b.Client.Database.Config(ctx, zone, id)
+		},
 		IsWaitForCopy:       true,
 		IsWaitForUp:         true,
 		RetryCount:          b.SetupOptions.RetryCount,
@@ -164,6 +167,9 @@ func (b *Builder) Update(ctx context.Context, zone string, id types.ID) (*saclou
 		SettingsHash:       db.SettingsHash,
 	})
 	if err != nil {
+		return nil, err
+	}
+	if err := b.Client.Database.Config(ctx, zone, id); err != nil {
 		return nil, err
 	}
 	if isNeedRestart {

--- a/utils/builder/mobilegateway/builder.go
+++ b/utils/builder/mobilegateway/builder.go
@@ -187,6 +187,10 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.MobileGatewa
 				}
 			}
 
+			if err := b.Client.MobileGateway.Config(ctx, zone, id); err != nil {
+				return err
+			}
+
 			if b.SetupOptions.BootAfterBuild {
 				return power.BootMobileGateway(ctx, b.Client.MobileGateway, zone, id)
 			}
@@ -422,6 +426,10 @@ func (b *Builder) Update(ctx context.Context, zone string, id types.ID) (*saclou
 				return nil, err
 			}
 		}
+	}
+
+	if err := b.Client.MobileGateway.Config(ctx, zone, id); err != nil {
+		return nil, err
 	}
 
 	if isNeedRestart {

--- a/utils/builder/vpcrouter/builder.go
+++ b/utils/builder/vpcrouter/builder.go
@@ -222,6 +222,9 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.VPCRouter, e
 			if err != nil {
 				return err
 			}
+			if err := b.Client.Config(ctx, zone, id); err != nil {
+				return err
+			}
 
 			if b.SetupOptions.BootAfterBuild {
 				return power.BootVPCRouter(ctx, b.Client, zone, id)
@@ -347,6 +350,10 @@ func (b *Builder) Update(ctx context.Context, zone string, id types.ID) (*saclou
 		SettingsHash: vpcRouter.SettingsHash,
 	})
 	if err != nil {
+		return nil, err
+	}
+
+	if err := b.Client.Config(ctx, zone, id); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
アプライアンスの作成/更新時に`xxxOp.Config(ctx, zone, id)`を呼ぶようにする。