### PR TITLE
ContainerRegistry: user-level permission/virtual-domain

### DIFF
--- a/internal/define/container_registry.go
+++ b/internal/define/container_registry.go
@@ -145,6 +145,7 @@ var (
 
 			// settings
 			fields.ContainerRegistryAccessLevel(),
+			fields.ContainerRegistryVirtualDomain(),
 			fields.SettingsHash(),
 
 			// status
@@ -175,6 +176,7 @@ var (
 
 			// settings
 			fields.ContainerRegistryAccessLevel(),
+			fields.ContainerRegistryVirtualDomain(),
 			// status
 			fields.ContainerRegistrySubDomainLabel(),
 		},
@@ -192,6 +194,7 @@ var (
 
 			// settings
 			fields.ContainerRegistryAccessLevel(),
+			fields.ContainerRegistryVirtualDomain(),
 			// settings hash
 			fields.SettingsHash(),
 		},
@@ -203,6 +206,7 @@ var (
 		Fields: []*dsl.FieldDesc{
 			// settings
 			fields.ContainerRegistryAccessLevel(),
+			fields.ContainerRegistryVirtualDomain(),
 			// settings hash
 			fields.SettingsHash(),
 		},

--- a/internal/define/container_registry.go
+++ b/internal/define/container_registry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/internal/dsl"
 	"github.com/sacloud/libsacloud/v2/internal/dsl/meta"
 	"github.com/sacloud/libsacloud/v2/sacloud/naked"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
 const (
@@ -219,6 +220,7 @@ var (
 					IsArray:   true,
 					Fields: []*dsl.FieldDesc{
 						fields.Def("UserName", meta.TypeString),
+						fields.Def("Permission", meta.Static(types.EContainerRegistryAccessLevel(""))),
 					},
 				},
 			},
@@ -230,6 +232,7 @@ var (
 		Fields: []*dsl.FieldDesc{
 			fields.Def("UserName", meta.TypeString),
 			fields.Def("Password", meta.TypeString),
+			fields.Def("Permission", meta.Static(types.EContainerRegistryAccessLevel(""))),
 		},
 	}
 	containerRegistryUserUpdateParam = &dsl.Model{
@@ -237,6 +240,7 @@ var (
 		NakedType: meta.Static(naked.ContainerRegistryUser{}),
 		Fields: []*dsl.FieldDesc{
 			fields.Def("Password", meta.TypeString),
+			fields.Def("Permission", meta.Static(types.EContainerRegistryAccessLevel(""))),
 		},
 	}
 )

--- a/internal/define/fields.go
+++ b/internal/define/fields.go
@@ -1595,6 +1595,16 @@ func (f *fieldsDef) ContainerRegistryAccessLevel() *dsl.FieldDesc {
 	}
 }
 
+func (f *fieldsDef) ContainerRegistryVirtualDomain() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "VirtualDomain",
+		Type: meta.TypeString,
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.ContainerRegistry.VirtualDomain",
+		},
+	}
+}
+
 func (f *fieldsDef) SettingsHash() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "SettingsHash",

--- a/sacloud/fake/ops_container_registry.go
+++ b/sacloud/fake/ops_container_registry.go
@@ -126,7 +126,8 @@ func (o *ContainerRegistryOp) AddUser(ctx context.Context, id types.ID, param *s
 		users = v.([]*sacloud.ContainerRegistryUser)
 	}
 	users = append(users, &sacloud.ContainerRegistryUser{
-		UserName: param.UserName,
+		UserName:   param.UserName,
+		Permission: param.Permission,
 	})
 
 	ds().Put(ResourceContainerRegistry+"Users", sacloud.APIDefaultZone, id, users)
@@ -144,6 +145,13 @@ func (o *ContainerRegistryOp) UpdateUser(ctx context.Context, id types.ID, usern
 	if v == nil {
 		return newErrorNotFound(ResourceContainerRegistry+"Users", id)
 	}
+	users := v.([]*sacloud.ContainerRegistryUser)
+	for _, u := range users {
+		if u.UserName == username {
+			u.Permission = param.Permission
+		}
+	}
+	ds().Put(ResourceContainerRegistry+"Users", sacloud.APIDefaultZone, id, users)
 	return nil
 }
 

--- a/sacloud/naked/container_registry.go
+++ b/sacloud/naked/container_registry.go
@@ -62,8 +62,9 @@ type ContainerRegistryStatus struct {
 
 // ContainerRegistryUser コンテナレジストリのユーザ
 type ContainerRegistryUser struct {
-	UserName string `json:"username" yaml:"username"`
-	Password string `json:"password,omitempty" yaml:"password,omitempty"`
+	UserName   string                              `json:"username,omitempty" yaml:"username,omitempty"`
+	Password   string                              `json:"password,omitempty" yaml:"password,omitempty"`
+	Permission types.EContainerRegistryAccessLevel `json:"permission" yaml:"permission"`
 }
 
 // ContainerRegistryUsers コンテナレジストリのユーザ

--- a/sacloud/test/container_registry_op_test.go
+++ b/sacloud/test/container_registry_op_test.go
@@ -61,15 +61,17 @@ func TestContainerRegistryOp_CRUD(t *testing.T) {
 				Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					registryOp := sacloud.NewContainerRegistryOp(caller)
 					err := registryOp.AddUser(ctx, ctx.ID, &sacloud.ContainerRegistryUserCreateRequest{
-						UserName: "user1",
-						Password: "password",
+						UserName:   "user1",
+						Password:   "password",
+						Permission: types.ContainerRegistryAccessLevels.ReadWrite,
 					})
 					if err != nil {
 						return nil, err
 					}
 					err = registryOp.AddUser(ctx, ctx.ID, &sacloud.ContainerRegistryUserCreateRequest{
-						UserName: "user2",
-						Password: "password",
+						UserName:   "user2",
+						Password:   "password",
+						Permission: types.ContainerRegistryAccessLevels.ReadOnly,
 					})
 					if err != nil {
 						return nil, err
@@ -81,7 +83,9 @@ func TestContainerRegistryOp_CRUD(t *testing.T) {
 					return testutil.DoAsserts(
 						testutil.AssertLenFunc(t, users, 2, "ContainerRegistry.Users"),
 						testutil.AssertEqualFunc(t, "user1", users[0].UserName, "ContainerRegistry.Users"),
+						testutil.AssertEqualFunc(t, types.ContainerRegistryAccessLevels.ReadWrite, users[0].Permission, "ContainerRegistry.Permission"),
 						testutil.AssertEqualFunc(t, "user2", users[1].UserName, "ContainerRegistry.Users"),
+						testutil.AssertEqualFunc(t, types.ContainerRegistryAccessLevels.ReadOnly, users[1].Permission, "ContainerRegistry.Permission"),
 					)
 				},
 				SkipExtractID: true,

--- a/sacloud/test/container_registry_op_test.go
+++ b/sacloud/test/container_registry_op_test.go
@@ -126,6 +126,7 @@ var (
 		Name:           testutil.ResourceName("container-registry"),
 		Description:    "desc",
 		Tags:           []string{"tag1", "tag2"},
+		VirtualDomain:  "libsacloud-test.usacloud.jp",
 		AccessLevel:    types.ContainerRegistryAccessLevels.ReadWrite,
 		SubDomainLabel: testutil.RandomName(60, testutil.CharSetAlpha),
 	}
@@ -135,15 +136,17 @@ var (
 		Tags:           createContainerRegistryParam.Tags,
 		Availability:   types.Availabilities.Available,
 		AccessLevel:    createContainerRegistryParam.AccessLevel,
+		VirtualDomain:  createContainerRegistryParam.VirtualDomain,
 		SubDomainLabel: createContainerRegistryParam.SubDomainLabel,
 		FQDN:           createContainerRegistryParam.SubDomainLabel + ".sakuracr.jp",
 	}
 	updateContainerRegistryParam = &sacloud.ContainerRegistryUpdateRequest{
-		Name:        testutil.ResourceName("container-registry-upd"),
-		Description: "desc-upd",
-		Tags:        []string{"tag1-upd", "tag2-upd"},
-		IconID:      testIconID,
-		AccessLevel: types.ContainerRegistryAccessLevels.ReadOnly,
+		Name:          testutil.ResourceName("container-registry-upd"),
+		Description:   "desc-upd",
+		Tags:          []string{"tag1-upd", "tag2-upd"},
+		IconID:        testIconID,
+		VirtualDomain: "libsacloud-test-upd.usacloud.jp",
+		AccessLevel:   types.ContainerRegistryAccessLevels.ReadOnly,
 	}
 	updateContainerRegistryExpected = &sacloud.ContainerRegistry{
 		Name:           updateContainerRegistryParam.Name,
@@ -151,6 +154,7 @@ var (
 		Tags:           updateContainerRegistryParam.Tags,
 		Availability:   types.Availabilities.Available,
 		IconID:         testIconID,
+		VirtualDomain:  updateContainerRegistryParam.VirtualDomain,
 		AccessLevel:    updateContainerRegistryParam.AccessLevel,
 		SubDomainLabel: createContainerRegistryParam.SubDomainLabel,
 		FQDN:           createContainerRegistryParam.SubDomainLabel + ".sakuracr.jp",
@@ -165,6 +169,7 @@ var (
 		Tags:           updateContainerRegistryParam.Tags,
 		Availability:   types.Availabilities.Available,
 		IconID:         testIconID,
+		VirtualDomain:  "",
 		AccessLevel:    updateContainerRegistrySettingsParam.AccessLevel,
 		SubDomainLabel: createContainerRegistryParam.SubDomainLabel,
 		FQDN:           createContainerRegistryParam.SubDomainLabel + ".sakuracr.jp",

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -3779,7 +3779,8 @@ func (o *ContainerRegistryUsers) SetUsers(v []*ContainerRegistryUser) {
 
 // ContainerRegistryUser represents API parameter/response structure
 type ContainerRegistryUser struct {
-	UserName string
+	UserName   string
+	Permission types.EContainerRegistryAccessLevel
 }
 
 // Validate validates by field tags
@@ -3790,9 +3791,11 @@ func (o *ContainerRegistryUser) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistryUser) setDefaults() interface{} {
 	return &struct {
-		UserName string
+		UserName   string
+		Permission types.EContainerRegistryAccessLevel
 	}{
-		UserName: o.GetUserName(),
+		UserName:   o.GetUserName(),
+		Permission: o.GetPermission(),
 	}
 }
 
@@ -3806,14 +3809,25 @@ func (o *ContainerRegistryUser) SetUserName(v string) {
 	o.UserName = v
 }
 
+// GetPermission returns value of Permission
+func (o *ContainerRegistryUser) GetPermission() types.EContainerRegistryAccessLevel {
+	return o.Permission
+}
+
+// SetPermission sets value to Permission
+func (o *ContainerRegistryUser) SetPermission(v types.EContainerRegistryAccessLevel) {
+	o.Permission = v
+}
+
 /*************************************************
 * ContainerRegistryUserCreateRequest
 *************************************************/
 
 // ContainerRegistryUserCreateRequest represents API parameter/response structure
 type ContainerRegistryUserCreateRequest struct {
-	UserName string
-	Password string
+	UserName   string
+	Password   string
+	Permission types.EContainerRegistryAccessLevel
 }
 
 // Validate validates by field tags
@@ -3824,11 +3838,13 @@ func (o *ContainerRegistryUserCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistryUserCreateRequest) setDefaults() interface{} {
 	return &struct {
-		UserName string
-		Password string
+		UserName   string
+		Password   string
+		Permission types.EContainerRegistryAccessLevel
 	}{
-		UserName: o.GetUserName(),
-		Password: o.GetPassword(),
+		UserName:   o.GetUserName(),
+		Password:   o.GetPassword(),
+		Permission: o.GetPermission(),
 	}
 }
 
@@ -3852,13 +3868,24 @@ func (o *ContainerRegistryUserCreateRequest) SetPassword(v string) {
 	o.Password = v
 }
 
+// GetPermission returns value of Permission
+func (o *ContainerRegistryUserCreateRequest) GetPermission() types.EContainerRegistryAccessLevel {
+	return o.Permission
+}
+
+// SetPermission sets value to Permission
+func (o *ContainerRegistryUserCreateRequest) SetPermission(v types.EContainerRegistryAccessLevel) {
+	o.Permission = v
+}
+
 /*************************************************
 * ContainerRegistryUserUpdateRequest
 *************************************************/
 
 // ContainerRegistryUserUpdateRequest represents API parameter/response structure
 type ContainerRegistryUserUpdateRequest struct {
-	Password string
+	Password   string
+	Permission types.EContainerRegistryAccessLevel
 }
 
 // Validate validates by field tags
@@ -3869,9 +3896,11 @@ func (o *ContainerRegistryUserUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistryUserUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Password string
+		Password   string
+		Permission types.EContainerRegistryAccessLevel
 	}{
-		Password: o.GetPassword(),
+		Password:   o.GetPassword(),
+		Permission: o.GetPermission(),
 	}
 }
 
@@ -3883,6 +3912,16 @@ func (o *ContainerRegistryUserUpdateRequest) GetPassword() string {
 // SetPassword sets value to Password
 func (o *ContainerRegistryUserUpdateRequest) SetPassword(v string) {
 	o.Password = v
+}
+
+// GetPermission returns value of Permission
+func (o *ContainerRegistryUserUpdateRequest) GetPermission() types.EContainerRegistryAccessLevel {
+	return o.Permission
+}
+
+// SetPermission sets value to Permission
+func (o *ContainerRegistryUserUpdateRequest) SetPermission(v types.EContainerRegistryAccessLevel) {
+	o.Permission = v
 }
 
 /*************************************************

--- a/sacloud/zz_models.go
+++ b/sacloud/zz_models.go
@@ -3255,6 +3255,7 @@ type ContainerRegistry struct {
 	CreatedAt      time.Time
 	ModifiedAt     time.Time
 	AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+	VirtualDomain  string                              `mapconv:"Settings.ContainerRegistry.VirtualDomain"`
 	SettingsHash   string                              `json:",omitempty" mapconv:",omitempty"`
 	SubDomainLabel string                              `mapconv:"Status.RegistryName"`
 	FQDN           string                              `mapconv:"Status.FQDN"`
@@ -3277,6 +3278,7 @@ func (o *ContainerRegistry) setDefaults() interface{} {
 		CreatedAt      time.Time
 		ModifiedAt     time.Time
 		AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+		VirtualDomain  string                              `mapconv:"Settings.ContainerRegistry.VirtualDomain"`
 		SettingsHash   string                              `json:",omitempty" mapconv:",omitempty"`
 		SubDomainLabel string                              `mapconv:"Status.RegistryName"`
 		FQDN           string                              `mapconv:"Status.FQDN"`
@@ -3290,6 +3292,7 @@ func (o *ContainerRegistry) setDefaults() interface{} {
 		CreatedAt:      o.GetCreatedAt(),
 		ModifiedAt:     o.GetModifiedAt(),
 		AccessLevel:    o.GetAccessLevel(),
+		VirtualDomain:  o.GetVirtualDomain(),
 		SettingsHash:   o.GetSettingsHash(),
 		SubDomainLabel: o.GetSubDomainLabel(),
 		FQDN:           o.GetFQDN(),
@@ -3426,6 +3429,16 @@ func (o *ContainerRegistry) SetAccessLevel(v types.EContainerRegistryAccessLevel
 	o.AccessLevel = v
 }
 
+// GetVirtualDomain returns value of VirtualDomain
+func (o *ContainerRegistry) GetVirtualDomain() string {
+	return o.VirtualDomain
+}
+
+// SetVirtualDomain sets value to VirtualDomain
+func (o *ContainerRegistry) SetVirtualDomain(v string) {
+	o.VirtualDomain = v
+}
+
 // GetSettingsHash returns value of SettingsHash
 func (o *ContainerRegistry) GetSettingsHash() string {
 	return o.SettingsHash
@@ -3467,6 +3480,7 @@ type ContainerRegistryCreateRequest struct {
 	Tags           types.Tags
 	IconID         types.ID                            `mapconv:"Icon.ID"`
 	AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+	VirtualDomain  string                              `mapconv:"Settings.ContainerRegistry.VirtualDomain"`
 	SubDomainLabel string                              `mapconv:"Status.RegistryName"`
 }
 
@@ -3483,6 +3497,7 @@ func (o *ContainerRegistryCreateRequest) setDefaults() interface{} {
 		Tags           types.Tags
 		IconID         types.ID                            `mapconv:"Icon.ID"`
 		AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+		VirtualDomain  string                              `mapconv:"Settings.ContainerRegistry.VirtualDomain"`
 		SubDomainLabel string                              `mapconv:"Status.RegistryName"`
 		Class          string                              `mapconv:"Provider.Class"`
 	}{
@@ -3491,6 +3506,7 @@ func (o *ContainerRegistryCreateRequest) setDefaults() interface{} {
 		Tags:           o.GetTags(),
 		IconID:         o.GetIconID(),
 		AccessLevel:    o.GetAccessLevel(),
+		VirtualDomain:  o.GetVirtualDomain(),
 		SubDomainLabel: o.GetSubDomainLabel(),
 		Class:          "containerregistry",
 	}
@@ -3566,6 +3582,16 @@ func (o *ContainerRegistryCreateRequest) SetAccessLevel(v types.EContainerRegist
 	o.AccessLevel = v
 }
 
+// GetVirtualDomain returns value of VirtualDomain
+func (o *ContainerRegistryCreateRequest) GetVirtualDomain() string {
+	return o.VirtualDomain
+}
+
+// SetVirtualDomain sets value to VirtualDomain
+func (o *ContainerRegistryCreateRequest) SetVirtualDomain(v string) {
+	o.VirtualDomain = v
+}
+
 // GetSubDomainLabel returns value of SubDomainLabel
 func (o *ContainerRegistryCreateRequest) GetSubDomainLabel() string {
 	return o.SubDomainLabel
@@ -3582,12 +3608,13 @@ func (o *ContainerRegistryCreateRequest) SetSubDomainLabel(v string) {
 
 // ContainerRegistryUpdateRequest represents API parameter/response structure
 type ContainerRegistryUpdateRequest struct {
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
-	Tags         types.Tags
-	IconID       types.ID                            `mapconv:"Icon.ID"`
-	AccessLevel  types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
-	SettingsHash string                              `json:",omitempty" mapconv:",omitempty"`
+	Name          string `validate:"required"`
+	Description   string `validate:"min=0,max=512"`
+	Tags          types.Tags
+	IconID        types.ID                            `mapconv:"Icon.ID"`
+	AccessLevel   types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+	VirtualDomain string                              `mapconv:"Settings.ContainerRegistry.VirtualDomain"`
+	SettingsHash  string                              `json:",omitempty" mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -3598,19 +3625,21 @@ func (o *ContainerRegistryUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistryUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
-		Tags         types.Tags
-		IconID       types.ID                            `mapconv:"Icon.ID"`
-		AccessLevel  types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
-		SettingsHash string                              `json:",omitempty" mapconv:",omitempty"`
+		Name          string `validate:"required"`
+		Description   string `validate:"min=0,max=512"`
+		Tags          types.Tags
+		IconID        types.ID                            `mapconv:"Icon.ID"`
+		AccessLevel   types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+		VirtualDomain string                              `mapconv:"Settings.ContainerRegistry.VirtualDomain"`
+		SettingsHash  string                              `json:",omitempty" mapconv:",omitempty"`
 	}{
-		Name:         o.GetName(),
-		Description:  o.GetDescription(),
-		Tags:         o.GetTags(),
-		IconID:       o.GetIconID(),
-		AccessLevel:  o.GetAccessLevel(),
-		SettingsHash: o.GetSettingsHash(),
+		Name:          o.GetName(),
+		Description:   o.GetDescription(),
+		Tags:          o.GetTags(),
+		IconID:        o.GetIconID(),
+		AccessLevel:   o.GetAccessLevel(),
+		VirtualDomain: o.GetVirtualDomain(),
+		SettingsHash:  o.GetSettingsHash(),
 	}
 }
 
@@ -3684,6 +3713,16 @@ func (o *ContainerRegistryUpdateRequest) SetAccessLevel(v types.EContainerRegist
 	o.AccessLevel = v
 }
 
+// GetVirtualDomain returns value of VirtualDomain
+func (o *ContainerRegistryUpdateRequest) GetVirtualDomain() string {
+	return o.VirtualDomain
+}
+
+// SetVirtualDomain sets value to VirtualDomain
+func (o *ContainerRegistryUpdateRequest) SetVirtualDomain(v string) {
+	o.VirtualDomain = v
+}
+
 // GetSettingsHash returns value of SettingsHash
 func (o *ContainerRegistryUpdateRequest) GetSettingsHash() string {
 	return o.SettingsHash
@@ -3700,8 +3739,9 @@ func (o *ContainerRegistryUpdateRequest) SetSettingsHash(v string) {
 
 // ContainerRegistryUpdateSettingsRequest represents API parameter/response structure
 type ContainerRegistryUpdateSettingsRequest struct {
-	AccessLevel  types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
-	SettingsHash string                              `json:",omitempty" mapconv:",omitempty"`
+	AccessLevel   types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+	VirtualDomain string                              `mapconv:"Settings.ContainerRegistry.VirtualDomain"`
+	SettingsHash  string                              `json:",omitempty" mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -3712,11 +3752,13 @@ func (o *ContainerRegistryUpdateSettingsRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistryUpdateSettingsRequest) setDefaults() interface{} {
 	return &struct {
-		AccessLevel  types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
-		SettingsHash string                              `json:",omitempty" mapconv:",omitempty"`
+		AccessLevel   types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
+		VirtualDomain string                              `mapconv:"Settings.ContainerRegistry.VirtualDomain"`
+		SettingsHash  string                              `json:",omitempty" mapconv:",omitempty"`
 	}{
-		AccessLevel:  o.GetAccessLevel(),
-		SettingsHash: o.GetSettingsHash(),
+		AccessLevel:   o.GetAccessLevel(),
+		VirtualDomain: o.GetVirtualDomain(),
+		SettingsHash:  o.GetSettingsHash(),
 	}
 }
 
@@ -3728,6 +3770,16 @@ func (o *ContainerRegistryUpdateSettingsRequest) GetAccessLevel() types.EContain
 // SetAccessLevel sets value to AccessLevel
 func (o *ContainerRegistryUpdateSettingsRequest) SetAccessLevel(v types.EContainerRegistryAccessLevel) {
 	o.AccessLevel = v
+}
+
+// GetVirtualDomain returns value of VirtualDomain
+func (o *ContainerRegistryUpdateSettingsRequest) GetVirtualDomain() string {
+	return o.VirtualDomain
+}
+
+// SetVirtualDomain sets value to VirtualDomain
+func (o *ContainerRegistryUpdateSettingsRequest) SetVirtualDomain(v string) {
+	o.VirtualDomain = v
 }
 
 // GetSettingsHash returns value of SettingsHash

--- a/utils/builder/registry/builder.go
+++ b/utils/builder/registry/builder.go
@@ -28,6 +28,7 @@ type Builder struct {
 	Description    string
 	Tags           types.Tags
 	IconID         types.ID
+	VirtualDomain  string
 	AccessLevel    types.EContainerRegistryAccessLevel
 	SubDomainLabel string
 	Users          []*User
@@ -38,8 +39,9 @@ type Builder struct {
 
 // User ユーザー
 type User struct {
-	UserName string
-	Password string
+	UserName   string
+	Password   string
+	Permission types.EContainerRegistryAccessLevel
 }
 
 // Validate 値の検証
@@ -63,6 +65,7 @@ func (b *Builder) Build(ctx context.Context) (*sacloud.ContainerRegistry, error)
 		IconID:         b.IconID,
 		AccessLevel:    b.AccessLevel,
 		SubDomainLabel: b.SubDomainLabel,
+		VirtualDomain:  b.VirtualDomain,
 	})
 	if err != nil {
 		return nil, err
@@ -71,8 +74,9 @@ func (b *Builder) Build(ctx context.Context) (*sacloud.ContainerRegistry, error)
 	// add users
 	for _, user := range b.Users {
 		u := &sacloud.ContainerRegistryUserCreateRequest{
-			UserName: user.UserName,
-			Password: user.Password,
+			UserName:   user.UserName,
+			Password:   user.Password,
+			Permission: user.Permission,
 		}
 		if err := b.Client.ContainerRegistry.AddUser(ctx, reg.ID, u); err != nil {
 			return nil, err
@@ -95,12 +99,13 @@ func (b *Builder) Update(ctx context.Context, id types.ID) (*sacloud.ContainerRe
 	}
 
 	_, err = b.Client.ContainerRegistry.Update(ctx, id, &sacloud.ContainerRegistryUpdateRequest{
-		Name:         b.Name,
-		Description:  b.Description,
-		Tags:         b.Tags,
-		IconID:       b.IconID,
-		AccessLevel:  b.AccessLevel,
-		SettingsHash: b.SettingsHash,
+		Name:          b.Name,
+		Description:   b.Description,
+		Tags:          b.Tags,
+		IconID:        b.IconID,
+		AccessLevel:   b.AccessLevel,
+		VirtualDomain: b.VirtualDomain,
+		SettingsHash:  b.SettingsHash,
 	})
 	if err != nil {
 		return nil, err
@@ -114,8 +119,9 @@ func (b *Builder) Update(ctx context.Context, id types.ID) (*sacloud.ContainerRe
 	// added
 	for _, user := range added {
 		u := &sacloud.ContainerRegistryUserCreateRequest{
-			UserName: user.UserName,
-			Password: user.Password,
+			UserName:   user.UserName,
+			Password:   user.Password,
+			Permission: user.Permission,
 		}
 		if err := b.Client.ContainerRegistry.AddUser(ctx, id, u); err != nil {
 			return nil, err
@@ -124,7 +130,8 @@ func (b *Builder) Update(ctx context.Context, id types.ID) (*sacloud.ContainerRe
 	// updated
 	for _, user := range updated {
 		u := &sacloud.ContainerRegistryUserUpdateRequest{
-			Password: user.Password,
+			Password:   user.Password,
+			Permission: user.Permission,
 		}
 		err := b.Client.ContainerRegistry.UpdateUser(ctx, id, user.UserName, u)
 		if err != nil {

--- a/utils/builder/registry/builder_test.go
+++ b/utils/builder/registry/builder_test.go
@@ -39,12 +39,14 @@ func TestBuilder_Build(t *testing.T) {
 					SubDomainLabel: testutil.RandomName(60, testutil.CharSetAlpha),
 					Users: []*User{
 						{
-							UserName: "user1",
-							Password: "password",
+							UserName:   "user1",
+							Password:   "password",
+							Permission: types.ContainerRegistryAccessLevels.ReadWrite,
 						},
 						{
-							UserName: "user2",
-							Password: "password",
+							UserName:   "user2",
+							Password:   "password",
+							Permission: types.ContainerRegistryAccessLevels.ReadOnly,
 						},
 					},
 					Client: NewAPIClient(caller),


### PR DESCRIPTION
fixes #504 

Note: ユーザーレベルでのパーミッションが必須となったためbreaking-changeラベルを付与