### PR TITLE
Avoid using fsnotify on wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ testacc:
 tools:
 	GO111MODULE=off go get golang.org/x/tools/cmd/goimports
 	GO111MODULE=off go get golang.org/x/tools/cmd/stringer
-	GO111MODULE=off go get github.com/motemen/gobump
 	GO111MODULE=off go get github.com/sacloud/addlicense
 	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.19.1/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.19.1
@@ -75,23 +74,6 @@ godoc:
 .PHONY: lint
 lint:
 	golangci-lint run ./...
-
-.PHONY: bump-patch bump-minor bump-major version
-bump-patch:
-	@gobump patch -w ; echo "next version is v`gobump show -r`"
-
-bump-minor:
-	@gobump minor -w ; echo "next version is v`gobump show -r`"
-
-bump-major:
-	@gobump major -w ; echo "next version is v`gobump show -r`"
-
-version:
-	@gobump show -r
-
-.PHONY: git tag
-git-tag:
-	git tag v`gobump show -r`
 
 .PHONY: set-license
 set-license:

--- a/sacloud/fake/json_file_store_watcher.go
+++ b/sacloud/fake/json_file_store_watcher.go
@@ -1,0 +1,70 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build freebsd openbsd netbsd dragonfly darwin windows
+
+package fake
+
+import (
+	"log"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func (s *JSONFileStore) startWatcher() {
+	ctx := s.Ctx
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("file watch start: %q", s.Path)
+
+	go func() {
+		defer watcher.Close()
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				switch {
+				case event.Op&fsnotify.Write == fsnotify.Write,
+					event.Op&fsnotify.Create == fsnotify.Create,
+					event.Op&fsnotify.Rename == fsnotify.Rename:
+
+					if err := s.load(); err != nil {
+						log.Printf("reloading %q is failed: %s\n", s.Path, err)
+					}
+
+					if event.Op&fsnotify.Rename == fsnotify.Rename {
+						if err := watcher.Add(s.Path); err != nil {
+							panic(err)
+						}
+					}
+					log.Printf("reloaded: %q\n", s.Path)
+				}
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				panic(err)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	if err := watcher.Add(s.Path); err != nil {
+		panic(err)
+	}
+}

--- a/sacloud/fake/json_file_store_watcher_wasm.go
+++ b/sacloud/fake/json_file_store_watcher_wasm.go
@@ -1,0 +1,23 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build wasm
+
+package fake
+
+import "log"
+
+func (s *JSONFileStore) startWatcher() {
+	log.Println("[WARN] fake json file store is not supported fsnotify on wasm")
+}


### PR DESCRIPTION
wasmでfakeドライバーを利用する際にfsnotify周りでビルドエラーとなる問題を修正

wasmでJSONFileStoreを利用する際、外部からstoreの更新があった場合にリロードしなくなるが実用上の問題はないはず。どうしてもリロードしたい場合はJSONFileStoreを新しいインスタンスに差し替えればOK。