### PR TITLE
Backport types.ID from v2 as sacloud.ID

### DIFF
--- a/api/archive.go
+++ b/api/archive.go
@@ -103,7 +103,7 @@ func NewArchiveAPI(client *Client) *ArchiveAPI {
 }
 
 // OpenFTP FTP接続開始
-func (api *ArchiveAPI) OpenFTP(id int64) (*sacloud.FTPServer, error) {
+func (api *ArchiveAPI) OpenFTP(id sacloud.ID) (*sacloud.FTPServer, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/ftp", api.getResourceURL(), id)
@@ -120,7 +120,7 @@ func (api *ArchiveAPI) OpenFTP(id int64) (*sacloud.FTPServer, error) {
 }
 
 // CloseFTP FTP接続終了
-func (api *ArchiveAPI) CloseFTP(id int64) (bool, error) {
+func (api *ArchiveAPI) CloseFTP(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/ftp", api.getResourceURL(), id)
@@ -130,7 +130,7 @@ func (api *ArchiveAPI) CloseFTP(id int64) (bool, error) {
 }
 
 // SleepWhileCopying コピー終了まで待機
-func (api *ArchiveAPI) SleepWhileCopying(id int64, timeout time.Duration) error {
+func (api *ArchiveAPI) SleepWhileCopying(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, 0)
@@ -138,7 +138,7 @@ func (api *ArchiveAPI) SleepWhileCopying(id int64, timeout time.Duration) error 
 }
 
 // AsyncSleepWhileCopying コピー終了まで待機(非同期)
-func (api *ArchiveAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration) (chan (interface{}), chan (interface{}), chan (error)) {
+func (api *ArchiveAPI) AsyncSleepWhileCopying(id sacloud.ID, timeout time.Duration) (chan (interface{}), chan (interface{}), chan (error)) {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, 0)
@@ -146,7 +146,7 @@ func (api *ArchiveAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration) (
 }
 
 // CanEditDisk ディスクの修正が可能か判定
-func (api *ArchiveAPI) CanEditDisk(id int64) (bool, error) {
+func (api *ArchiveAPI) CanEditDisk(id sacloud.ID) (bool, error) {
 
 	archive, err := api.Read(id)
 	if err != nil {
@@ -199,9 +199,9 @@ func (api *ArchiveAPI) CanEditDisk(id int64) (bool, error) {
 }
 
 // GetPublicArchiveIDFromAncestors 祖先の中からパブリックアーカイブのIDを検索
-func (api *ArchiveAPI) GetPublicArchiveIDFromAncestors(id int64) (int64, bool) {
+func (api *ArchiveAPI) GetPublicArchiveIDFromAncestors(id sacloud.ID) (sacloud.ID, bool) {
 
-	emptyID := int64(0)
+	emptyID := sacloud.EmptyID
 
 	archive, err := api.Read(id)
 	if err != nil {

--- a/api/archive_gen.go
+++ b/api/archive_gen.go
@@ -215,21 +215,21 @@ func (api *ArchiveAPI) Create(value *sacloud.Archive) (*sacloud.Archive, error) 
 }
 
 // Read 読み取り
-func (api *ArchiveAPI) Read(id int64) (*sacloud.Archive, error) {
+func (api *ArchiveAPI) Read(id sacloud.ID) (*sacloud.Archive, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *ArchiveAPI) Update(id int64, value *sacloud.Archive) (*sacloud.Archive, error) {
+func (api *ArchiveAPI) Update(id sacloud.ID, value *sacloud.Archive) (*sacloud.Archive, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *ArchiveAPI) Delete(id int64) (*sacloud.Archive, error) {
+func (api *ArchiveAPI) Delete(id sacloud.ID) (*sacloud.Archive, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/auto_backup.go
+++ b/api/auto_backup.go
@@ -97,7 +97,7 @@ func (api *AutoBackupAPI) createRequest(value *sacloud.AutoBackup) *autoBackupRe
 }
 
 // New 新規作成用パラメーター作成
-func (api *AutoBackupAPI) New(name string, diskID int64) *sacloud.AutoBackup {
+func (api *AutoBackupAPI) New(name string, diskID sacloud.ID) *sacloud.AutoBackup {
 	return sacloud.CreateNewAutoBackup(name, diskID)
 }
 
@@ -109,21 +109,21 @@ func (api *AutoBackupAPI) Create(value *sacloud.AutoBackup) (*sacloud.AutoBackup
 }
 
 // Read 読み取り
-func (api *AutoBackupAPI) Read(id int64) (*sacloud.AutoBackup, error) {
+func (api *AutoBackupAPI) Read(id sacloud.ID) (*sacloud.AutoBackup, error) {
 	return api.request(func(res *autoBackupResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *AutoBackupAPI) Update(id int64, value *sacloud.AutoBackup) (*sacloud.AutoBackup, error) {
+func (api *AutoBackupAPI) Update(id sacloud.ID, value *sacloud.AutoBackup) (*sacloud.AutoBackup, error) {
 	return api.request(func(res *autoBackupResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *AutoBackupAPI) Delete(id int64) (*sacloud.AutoBackup, error) {
+func (api *AutoBackupAPI) Delete(id sacloud.ID) (*sacloud.AutoBackup, error) {
 	return api.request(func(res *autoBackupResponse) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/base_api.go
+++ b/api/base_api.go
@@ -215,7 +215,7 @@ func (api *baseAPI) create(body interface{}, res interface{}) error {
 	return api.request(method, uri, body, res)
 }
 
-func (api *baseAPI) read(id int64, body interface{}, res interface{}) error {
+func (api *baseAPI) read(id sacloud.ID, body interface{}, res interface{}) error {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d", api.getResourceURL(), id)
@@ -224,7 +224,7 @@ func (api *baseAPI) read(id int64, body interface{}, res interface{}) error {
 	return api.request(method, uri, body, res)
 }
 
-func (api *baseAPI) update(id int64, body interface{}, res interface{}) error {
+func (api *baseAPI) update(id sacloud.ID, body interface{}, res interface{}) error {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d", api.getResourceURL(), id)
@@ -232,7 +232,7 @@ func (api *baseAPI) update(id int64, body interface{}, res interface{}) error {
 	return api.request(method, uri, body, res)
 }
 
-func (api *baseAPI) delete(id int64, body interface{}, res interface{}) error {
+func (api *baseAPI) delete(id sacloud.ID, body interface{}, res interface{}) error {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d", api.getResourceURL(), id)
@@ -257,7 +257,7 @@ func (api *baseAPI) action(method string, uri string, body interface{}, res inte
 	return true, nil
 }
 
-func (api *baseAPI) monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *baseAPI) monitor(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/monitor", api.getResourceURL(), id)
@@ -270,7 +270,7 @@ func (api *baseAPI) monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sa
 	return res.Data, nil
 }
 
-func (api *baseAPI) applianceMonitorBy(id int64, target string, nicIndex int, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *baseAPI) applianceMonitorBy(id sacloud.ID, target string, nicIndex int, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/%s/%d/monitor", api.getResourceURL(), id, target, nicIndex)

--- a/api/bill.go
+++ b/api/bill.go
@@ -112,26 +112,26 @@ func (res *BillDetailCSVResponse) buildCSVBody() {
 }
 
 // ByContract アカウントIDごとの請求取得
-func (api *BillAPI) ByContract(accountID int64) (*BillResponse, error) {
+func (api *BillAPI) ByContract(accountID sacloud.ID) (*BillResponse, error) {
 
 	uri := fmt.Sprintf("%s/by-contract/%d", api.getResourceURL(), accountID)
 	return api.getContract(uri)
 }
 
 // ByContractYear 年指定での請求取得
-func (api *BillAPI) ByContractYear(accountID int64, year int) (*BillResponse, error) {
+func (api *BillAPI) ByContractYear(accountID sacloud.ID, year int) (*BillResponse, error) {
 	uri := fmt.Sprintf("%s/by-contract/%d/%d", api.getResourceURL(), accountID, year)
 	return api.getContract(uri)
 }
 
 // ByContractYearMonth 年月指定での請求指定
-func (api *BillAPI) ByContractYearMonth(accountID int64, year int, month int) (*BillResponse, error) {
+func (api *BillAPI) ByContractYearMonth(accountID sacloud.ID, year int, month int) (*BillResponse, error) {
 	uri := fmt.Sprintf("%s/by-contract/%d/%d/%d", api.getResourceURL(), accountID, year, month)
 	return api.getContract(uri)
 }
 
 // Read 読み取り
-func (api *BillAPI) Read(billNo int64) (*BillResponse, error) {
+func (api *BillAPI) Read(billNo sacloud.ID) (*BillResponse, error) {
 	uri := fmt.Sprintf("%s/id/%d/", api.getResourceURL(), billNo)
 	return api.getContract(uri)
 
@@ -152,7 +152,7 @@ func (api *BillAPI) getContract(uri string) (*BillResponse, error) {
 }
 
 // GetDetail 請求明細取得
-func (api *BillAPI) GetDetail(memberCD string, billNo int64) (*BillDetailResponse, error) {
+func (api *BillAPI) GetDetail(memberCD string, billNo sacloud.ID) (*BillDetailResponse, error) {
 
 	oldFunc := api.FuncGetResourceURL
 	defer func() { api.FuncGetResourceURL = oldFunc }()
@@ -174,7 +174,7 @@ func (api *BillAPI) GetDetail(memberCD string, billNo int64) (*BillDetailRespons
 }
 
 // GetDetailCSV 請求明細CSV取得
-func (api *BillAPI) GetDetailCSV(memberCD string, billNo int64) (*BillDetailCSVResponse, error) {
+func (api *BillAPI) GetDetailCSV(memberCD string, billNo sacloud.ID) (*BillDetailCSVResponse, error) {
 
 	oldFunc := api.FuncGetResourceURL
 	defer func() { api.FuncGetResourceURL = oldFunc }()

--- a/api/bridge_gen.go
+++ b/api/bridge_gen.go
@@ -212,21 +212,21 @@ func (api *BridgeAPI) Create(value *sacloud.Bridge) (*sacloud.Bridge, error) {
 }
 
 // Read 読み取り
-func (api *BridgeAPI) Read(id int64) (*sacloud.Bridge, error) {
+func (api *BridgeAPI) Read(id sacloud.ID) (*sacloud.Bridge, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *BridgeAPI) Update(id int64, value *sacloud.Bridge) (*sacloud.Bridge, error) {
+func (api *BridgeAPI) Update(id sacloud.ID, value *sacloud.Bridge) (*sacloud.Bridge, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *BridgeAPI) Delete(id int64) (*sacloud.Bridge, error) {
+func (api *BridgeAPI) Delete(id sacloud.ID) (*sacloud.Bridge, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/cdrom.go
+++ b/api/cdrom.go
@@ -52,7 +52,7 @@ func (api *CDROMAPI) Create(value *sacloud.CDROM) (*sacloud.CDROM, *sacloud.FTPS
 }
 
 // OpenFTP FTP接続開始
-func (api *CDROMAPI) OpenFTP(id int64, reset bool) (*sacloud.FTPServer, error) {
+func (api *CDROMAPI) OpenFTP(id sacloud.ID, reset bool) (*sacloud.FTPServer, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/ftp", api.getResourceURL(), id)
@@ -69,7 +69,7 @@ func (api *CDROMAPI) OpenFTP(id int64, reset bool) (*sacloud.FTPServer, error) {
 }
 
 // CloseFTP FTP接続終了
-func (api *CDROMAPI) CloseFTP(id int64) (bool, error) {
+func (api *CDROMAPI) CloseFTP(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/ftp", api.getResourceURL(), id)
@@ -79,7 +79,7 @@ func (api *CDROMAPI) CloseFTP(id int64) (bool, error) {
 }
 
 // SleepWhileCopying コピー終了まで待機
-func (api *CDROMAPI) SleepWhileCopying(id int64, timeout time.Duration) error {
+func (api *CDROMAPI) SleepWhileCopying(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, 0)
@@ -87,7 +87,7 @@ func (api *CDROMAPI) SleepWhileCopying(id int64, timeout time.Duration) error {
 }
 
 // AsyncSleepWhileCopying コピー終了まで待機(非同期)
-func (api *CDROMAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration) (chan (interface{}), chan (interface{}), chan (error)) {
+func (api *CDROMAPI) AsyncSleepWhileCopying(id sacloud.ID, timeout time.Duration) (chan (interface{}), chan (interface{}), chan (error)) {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, 0)

--- a/api/cdrom_gen.go
+++ b/api/cdrom_gen.go
@@ -219,21 +219,21 @@ func (api *CDROMAPI) New() *sacloud.CDROM {
 //}
 
 // Read 読み取り
-func (api *CDROMAPI) Read(id int64) (*sacloud.CDROM, error) {
+func (api *CDROMAPI) Read(id sacloud.ID) (*sacloud.CDROM, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *CDROMAPI) Update(id int64, value *sacloud.CDROM) (*sacloud.CDROM, error) {
+func (api *CDROMAPI) Update(id sacloud.ID, value *sacloud.CDROM) (*sacloud.CDROM, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *CDROMAPI) Delete(id int64) (*sacloud.CDROM, error) {
+func (api *CDROMAPI) Delete(id sacloud.ID) (*sacloud.CDROM, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/database.go
+++ b/api/database.go
@@ -128,14 +128,14 @@ func (api *DatabaseAPI) Create(value *sacloud.Database) (*sacloud.Database, erro
 }
 
 // Read 読み取り
-func (api *DatabaseAPI) Read(id int64) (*sacloud.Database, error) {
+func (api *DatabaseAPI) Read(id sacloud.ID) (*sacloud.Database, error) {
 	return api.request(func(res *databaseResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Status DBの設定/起動状態の取得
-func (api *DatabaseAPI) Status(id int64) (*sacloud.DatabaseStatus, error) {
+func (api *DatabaseAPI) Status(id sacloud.ID) (*sacloud.DatabaseStatus, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/status", api.getResourceURL(), id)
@@ -150,7 +150,7 @@ func (api *DatabaseAPI) Status(id int64) (*sacloud.DatabaseStatus, error) {
 }
 
 // Backup バックアップ取得
-func (api *DatabaseAPI) Backup(id int64) (string, error) {
+func (api *DatabaseAPI) Backup(id sacloud.ID) (string, error) {
 	var (
 		method = "POST"
 		uri    = fmt.Sprintf("%s/%d/action/history", api.getResourceURL(), id)
@@ -177,7 +177,7 @@ func (api *DatabaseAPI) Backup(id int64) (string, error) {
 }
 
 // DownloadLog ログ取得
-func (api *DatabaseAPI) DownloadLog(id int64, logID string) (string, error) {
+func (api *DatabaseAPI) DownloadLog(id sacloud.ID, logID string) (string, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/download/log/%s", api.getResourceURL(), id, logID)
@@ -192,7 +192,7 @@ func (api *DatabaseAPI) DownloadLog(id int64, logID string) (string, error) {
 }
 
 // Restore バックアップからの復元
-func (api *DatabaseAPI) Restore(id int64, backupID string) (string, error) {
+func (api *DatabaseAPI) Restore(id sacloud.ID, backupID string) (string, error) {
 	var (
 		method = "POST"
 		uri    = fmt.Sprintf("%s/%d/action/history/%s", api.getResourceURL(), id, backupID)
@@ -211,7 +211,7 @@ func (api *DatabaseAPI) Restore(id int64, backupID string) (string, error) {
 }
 
 // DeleteBackup バックアップの削除
-func (api *DatabaseAPI) DeleteBackup(id int64, backupID string) (string, error) {
+func (api *DatabaseAPI) DeleteBackup(id sacloud.ID, backupID string) (string, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/action/history/%s", api.getResourceURL(), id, backupID)
@@ -230,7 +230,7 @@ func (api *DatabaseAPI) DeleteBackup(id int64, backupID string) (string, error) 
 }
 
 // HistoryLock バックアップ削除ロック
-func (api *DatabaseAPI) HistoryLock(id int64, backupID string) (string, error) {
+func (api *DatabaseAPI) HistoryLock(id sacloud.ID, backupID string) (string, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/action/history-lock/%s", api.getResourceURL(), id, backupID)
@@ -249,7 +249,7 @@ func (api *DatabaseAPI) HistoryLock(id int64, backupID string) (string, error) {
 }
 
 // HistoryUnlock バックアップ削除アンロック
-func (api *DatabaseAPI) HistoryUnlock(id int64, backupID string) (string, error) {
+func (api *DatabaseAPI) HistoryUnlock(id sacloud.ID, backupID string) (string, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/action/history-lock/%s", api.getResourceURL(), id, backupID)
@@ -268,14 +268,14 @@ func (api *DatabaseAPI) HistoryUnlock(id int64, backupID string) (string, error)
 }
 
 // Update 更新
-func (api *DatabaseAPI) Update(id int64, value *sacloud.Database) (*sacloud.Database, error) {
+func (api *DatabaseAPI) Update(id sacloud.ID, value *sacloud.Database) (*sacloud.Database, error) {
 	return api.request(func(res *databaseResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // UpdateSetting 設定更新
-func (api *DatabaseAPI) UpdateSetting(id int64, value *sacloud.Database) (*sacloud.Database, error) {
+func (api *DatabaseAPI) UpdateSetting(id sacloud.ID, value *sacloud.Database) (*sacloud.Database, error) {
 	req := &sacloud.Database{
 		// Settings
 		Settings: value.Settings,
@@ -286,14 +286,14 @@ func (api *DatabaseAPI) UpdateSetting(id int64, value *sacloud.Database) (*saclo
 }
 
 // Delete 削除
-func (api *DatabaseAPI) Delete(id int64) (*sacloud.Database, error) {
+func (api *DatabaseAPI) Delete(id sacloud.ID) (*sacloud.Database, error) {
 	return api.request(func(res *databaseResponse) error {
 		return api.delete(id, nil, res)
 	})
 }
 
 // Config 設定変更の反映
-func (api *DatabaseAPI) Config(id int64) (bool, error) {
+func (api *DatabaseAPI) Config(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/config", api.getResourceURL(), id)
@@ -302,7 +302,7 @@ func (api *DatabaseAPI) Config(id int64) (bool, error) {
 }
 
 // IsUp 起動しているか判定
-func (api *DatabaseAPI) IsUp(id int64) (bool, error) {
+func (api *DatabaseAPI) IsUp(id sacloud.ID) (bool, error) {
 	lb, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -311,7 +311,7 @@ func (api *DatabaseAPI) IsUp(id int64) (bool, error) {
 }
 
 // IsDown ダウンしているか判定
-func (api *DatabaseAPI) IsDown(id int64) (bool, error) {
+func (api *DatabaseAPI) IsDown(id sacloud.ID) (bool, error) {
 	lb, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -320,7 +320,7 @@ func (api *DatabaseAPI) IsDown(id int64) (bool, error) {
 }
 
 // IsDatabaseRunning データベースプロセスが起動しているか判定
-func (api *DatabaseAPI) IsDatabaseRunning(id int64) (bool, error) {
+func (api *DatabaseAPI) IsDatabaseRunning(id sacloud.ID) (bool, error) {
 	db, err := api.Status(id)
 	if err != nil {
 		return false, err
@@ -330,7 +330,7 @@ func (api *DatabaseAPI) IsDatabaseRunning(id int64) (bool, error) {
 }
 
 // Boot 起動
-func (api *DatabaseAPI) Boot(id int64) (bool, error) {
+func (api *DatabaseAPI) Boot(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -339,7 +339,7 @@ func (api *DatabaseAPI) Boot(id int64) (bool, error) {
 }
 
 // Shutdown シャットダウン(graceful)
-func (api *DatabaseAPI) Shutdown(id int64) (bool, error) {
+func (api *DatabaseAPI) Shutdown(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -349,7 +349,7 @@ func (api *DatabaseAPI) Shutdown(id int64) (bool, error) {
 }
 
 // Stop シャットダウン(force)
-func (api *DatabaseAPI) Stop(id int64) (bool, error) {
+func (api *DatabaseAPI) Stop(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -359,7 +359,7 @@ func (api *DatabaseAPI) Stop(id int64) (bool, error) {
 }
 
 // RebootForce 再起動
-func (api *DatabaseAPI) RebootForce(id int64) (bool, error) {
+func (api *DatabaseAPI) RebootForce(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -369,7 +369,7 @@ func (api *DatabaseAPI) RebootForce(id int64) (bool, error) {
 }
 
 // ResetForce リセット
-func (api *DatabaseAPI) ResetForce(id int64, recycleProcess bool) (bool, error) {
+func (api *DatabaseAPI) ResetForce(id sacloud.ID, recycleProcess bool) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -379,7 +379,7 @@ func (api *DatabaseAPI) ResetForce(id int64, recycleProcess bool) (bool, error) 
 }
 
 // SleepUntilUp 起動するまで待機
-func (api *DatabaseAPI) SleepUntilUp(id int64, timeout time.Duration) error {
+func (api *DatabaseAPI) SleepUntilUp(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForUpFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -387,7 +387,7 @@ func (api *DatabaseAPI) SleepUntilUp(id int64, timeout time.Duration) error {
 }
 
 // SleepUntilDatabaseRunning 起動するまで待機
-func (api *DatabaseAPI) SleepUntilDatabaseRunning(id int64, timeout time.Duration, maxRetry int) error {
+func (api *DatabaseAPI) SleepUntilDatabaseRunning(id sacloud.ID, timeout time.Duration, maxRetry int) error {
 	handler := waitingForUpFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -395,7 +395,7 @@ func (api *DatabaseAPI) SleepUntilDatabaseRunning(id int64, timeout time.Duratio
 }
 
 // SleepUntilDown ダウンするまで待機
-func (api *DatabaseAPI) SleepUntilDown(id int64, timeout time.Duration) error {
+func (api *DatabaseAPI) SleepUntilDown(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForDownFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -403,7 +403,7 @@ func (api *DatabaseAPI) SleepUntilDown(id int64, timeout time.Duration) error {
 }
 
 // SleepWhileCopying コピー終了まで待機
-func (api *DatabaseAPI) SleepWhileCopying(id int64, timeout time.Duration, maxRetry int) error {
+func (api *DatabaseAPI) SleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) error {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -411,7 +411,7 @@ func (api *DatabaseAPI) SleepWhileCopying(id int64, timeout time.Duration, maxRe
 }
 
 // AsyncSleepWhileCopying コピー終了まで待機(非同期)
-func (api *DatabaseAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
+func (api *DatabaseAPI) AsyncSleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -419,26 +419,26 @@ func (api *DatabaseAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration, 
 }
 
 // MonitorCPU CPUアクティビティーモニター取得
-func (api *DatabaseAPI) MonitorCPU(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *DatabaseAPI) MonitorCPU(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "cpu", 0, body)
 }
 
 // MonitorDatabase データーベース固有項目アクティビティモニター取得
-func (api *DatabaseAPI) MonitorDatabase(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *DatabaseAPI) MonitorDatabase(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "database", 0, body)
 }
 
 // MonitorInterface NICアクティビティーモニター取得
-func (api *DatabaseAPI) MonitorInterface(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *DatabaseAPI) MonitorInterface(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "interface", 0, body)
 }
 
 // MonitorSystemDisk システムディスクアクティビティーモニター取得
-func (api *DatabaseAPI) MonitorSystemDisk(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *DatabaseAPI) MonitorSystemDisk(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "disk", 1, body)
 }
 
 // MonitorBackupDisk バックアップディスクアクティビティーモニター取得
-func (api *DatabaseAPI) MonitorBackupDisk(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *DatabaseAPI) MonitorBackupDisk(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "disk", 2, body)
 }

--- a/api/database_test.go
+++ b/api/database_test.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -49,7 +48,7 @@ func TestDatabaseCRUD(t *testing.T) {
 	v.ServicePort = 54321
 	v.EnableBackup = true
 	v.BackupTime = "00:30"
-	v.SwitchID = fmt.Sprintf("%d", sw.ID)
+	v.SwitchID = sw.ID
 	v.IPAddress1 = "192.168.11.100"
 	v.MaskLen = 24
 	v.DefaultRoute = "192.168.11.1"
@@ -236,7 +235,7 @@ func TestDatabaseMariaDBCRUD(t *testing.T) {
 	v.UserPassword = "defuserPassword01"
 	v.SourceNetwork = []string{"192.168.0.1", "192.168.1.1"}
 	v.ServicePort = 33061
-	v.SwitchID = fmt.Sprintf("%d", sw.ID)
+	v.SwitchID = sw.ID
 	v.IPAddress1 = "192.168.11.100"
 	v.MaskLen = 24
 	v.DefaultRoute = "192.168.11.1"
@@ -324,7 +323,7 @@ func TestDatabaseWaitForCopy(t *testing.T) {
 	v.UserPassword = "defuserPassword01"
 	v.SourceNetwork = []string{"192.168.0.1", "192.168.1.1"}
 	v.ServicePort = 33061
-	v.SwitchID = fmt.Sprintf("%d", sw.ID)
+	v.SwitchID = sw.ID
 	v.IPAddress1 = "192.168.11.100"
 	v.MaskLen = 24
 	v.DefaultRoute = "192.168.11.1"
@@ -397,7 +396,7 @@ func TestDatabaseReplication(t *testing.T) {
 	v.UserPassword = "defuserPassword01"
 	v.SourceNetwork = []string{"192.168.11.1", "192.168.11.101"}
 	v.ServicePort = 54321
-	v.SwitchID = fmt.Sprintf("%d", sw.ID)
+	v.SwitchID = sw.ID
 	v.IPAddress1 = "192.168.11.100"
 	v.MaskLen = 24
 	v.DefaultRoute = "192.168.11.1"

--- a/api/disk.go
+++ b/api/disk.go
@@ -57,7 +57,7 @@ func (api *DiskAPI) SortByConnectionOrder(reverse bool) *DiskAPI {
 }
 
 // WithServerID サーバーID条件
-func (api *DiskAPI) WithServerID(id int64) *DiskAPI {
+func (api *DiskAPI) WithServerID(id sacloud.ID) *DiskAPI {
 	api.FilterBy("Server.ID", id)
 	return api
 }
@@ -76,7 +76,7 @@ func (api *DiskAPI) Create(value *sacloud.Disk) (*sacloud.Disk, error) {
 	rawBody.Disk = value
 	if len(value.DistantFrom) > 0 {
 		rawBody.DistantFrom = value.DistantFrom
-		value.DistantFrom = []int64{}
+		value.DistantFrom = []sacloud.ID{}
 	}
 
 	err := api.create(rawBody, res)
@@ -111,7 +111,7 @@ func (api *DiskAPI) CreateWithConfig(value *sacloud.Disk, config *sacloud.DiskEd
 
 	if len(value.DistantFrom) > 0 {
 		rawBody.DistantFrom = value.DistantFrom
-		value.DistantFrom = []int64{}
+		value.DistantFrom = []sacloud.ID{}
 	}
 
 	err := api.create(rawBody, res)
@@ -127,7 +127,7 @@ func (api *DiskAPI) NewCondig() *sacloud.DiskEditValue {
 }
 
 // Config ディスクの修正
-func (api *DiskAPI) Config(id int64, disk *sacloud.DiskEditValue) (bool, error) {
+func (api *DiskAPI) Config(id sacloud.ID, disk *sacloud.DiskEditValue) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/config", api.getResourceURL(), id)
@@ -145,7 +145,7 @@ func (api *DiskAPI) Config(id int64, disk *sacloud.DiskEditValue) (bool, error) 
 
 }
 
-func (api *DiskAPI) install(id int64, body *sacloud.Disk) (bool, error) {
+func (api *DiskAPI) install(id sacloud.ID, body *sacloud.Disk) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/install", api.getResourceURL(), id)
@@ -161,7 +161,7 @@ func (api *DiskAPI) install(id int64, body *sacloud.Disk) (bool, error) {
 	rawBody.Disk = body
 	if len(body.DistantFrom) > 0 {
 		rawBody.DistantFrom = body.DistantFrom
-		body.DistantFrom = []int64{}
+		body.DistantFrom = []sacloud.ID{}
 	}
 
 	err := api.baseAPI.request(method, uri, rawBody, res)
@@ -172,7 +172,7 @@ func (api *DiskAPI) install(id int64, body *sacloud.Disk) (bool, error) {
 }
 
 // ReinstallFromBlank ブランクディスクから再インストール
-func (api *DiskAPI) ReinstallFromBlank(id int64, sizeMB int) (bool, error) {
+func (api *DiskAPI) ReinstallFromBlank(id sacloud.ID, sizeMB int) (bool, error) {
 	var body = &sacloud.Disk{}
 	body.SetSizeMB(sizeMB)
 
@@ -180,7 +180,7 @@ func (api *DiskAPI) ReinstallFromBlank(id int64, sizeMB int) (bool, error) {
 }
 
 // ReinstallFromArchive アーカイブからの再インストール
-func (api *DiskAPI) ReinstallFromArchive(id int64, archiveID int64, distantFrom ...int64) (bool, error) {
+func (api *DiskAPI) ReinstallFromArchive(id sacloud.ID, archiveID sacloud.ID, distantFrom ...sacloud.ID) (bool, error) {
 	var body = &sacloud.Disk{}
 	body.SetSourceArchive(archiveID)
 	if len(distantFrom) > 0 {
@@ -190,7 +190,7 @@ func (api *DiskAPI) ReinstallFromArchive(id int64, archiveID int64, distantFrom 
 }
 
 // ReinstallFromDisk ディスクからの再インストール
-func (api *DiskAPI) ReinstallFromDisk(id int64, diskID int64, distantFrom ...int64) (bool, error) {
+func (api *DiskAPI) ReinstallFromDisk(id sacloud.ID, diskID sacloud.ID, distantFrom ...sacloud.ID) (bool, error) {
 	var body = &sacloud.Disk{}
 	body.SetSourceDisk(diskID)
 	if len(distantFrom) > 0 {
@@ -200,7 +200,7 @@ func (api *DiskAPI) ReinstallFromDisk(id int64, diskID int64, distantFrom ...int
 }
 
 // ToBlank ディスクを空にする
-func (api *DiskAPI) ToBlank(diskID int64) (bool, error) {
+func (api *DiskAPI) ToBlank(diskID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/to/blank", api.getResourceURL(), diskID)
@@ -209,7 +209,7 @@ func (api *DiskAPI) ToBlank(diskID int64) (bool, error) {
 }
 
 // ResizePartition パーティションのリサイズ
-func (api *DiskAPI) ResizePartition(diskID int64) (bool, error) {
+func (api *DiskAPI) ResizePartition(diskID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/resize-partition", api.getResourceURL(), diskID)
@@ -226,7 +226,7 @@ func (api *DiskAPI) ResizePartition(diskID int64) (bool, error) {
 }
 
 // ResizePartitionBackground パーティションのリサイズ(非同期)
-func (api *DiskAPI) ResizePartitionBackground(diskID int64) (bool, error) {
+func (api *DiskAPI) ResizePartitionBackground(diskID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/resize-partition", api.getResourceURL(), diskID)
@@ -247,7 +247,7 @@ func (api *DiskAPI) ResizePartitionBackground(diskID int64) (bool, error) {
 }
 
 // DisconnectFromServer サーバーとの接続解除
-func (api *DiskAPI) DisconnectFromServer(diskID int64) (bool, error) {
+func (api *DiskAPI) DisconnectFromServer(diskID sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/to/server", api.getResourceURL(), diskID)
@@ -256,7 +256,7 @@ func (api *DiskAPI) DisconnectFromServer(diskID int64) (bool, error) {
 }
 
 // ConnectToServer サーバーとの接続
-func (api *DiskAPI) ConnectToServer(diskID int64, serverID int64) (bool, error) {
+func (api *DiskAPI) ConnectToServer(diskID sacloud.ID, serverID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/to/server/%d", api.getResourceURL(), diskID, serverID)
@@ -265,7 +265,7 @@ func (api *DiskAPI) ConnectToServer(diskID int64, serverID int64) (bool, error) 
 }
 
 // State ディスクの状態を取得し有効な状態か判定
-func (api *DiskAPI) State(diskID int64) (bool, error) {
+func (api *DiskAPI) State(diskID sacloud.ID) (bool, error) {
 	disk, err := api.Read(diskID)
 	if err != nil {
 		return false, err
@@ -274,7 +274,7 @@ func (api *DiskAPI) State(diskID int64) (bool, error) {
 }
 
 // SleepWhileCopying コピー終了まで待機
-func (api *DiskAPI) SleepWhileCopying(id int64, timeout time.Duration) error {
+func (api *DiskAPI) SleepWhileCopying(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, 0)
@@ -282,7 +282,7 @@ func (api *DiskAPI) SleepWhileCopying(id int64, timeout time.Duration) error {
 }
 
 // AsyncSleepWhileCopying コピー終了まで待機(非同期)
-func (api *DiskAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration) (chan (interface{}), chan (interface{}), chan (error)) {
+func (api *DiskAPI) AsyncSleepWhileCopying(id sacloud.ID, timeout time.Duration) (chan (interface{}), chan (interface{}), chan (error)) {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, 0)
@@ -290,12 +290,12 @@ func (api *DiskAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration) (cha
 }
 
 // Monitor アクティビティーモニター取得
-func (api *DiskAPI) Monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *DiskAPI) Monitor(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.monitor(id, body)
 }
 
 // CanEditDisk ディスクの修正が可能か判定
-func (api *DiskAPI) CanEditDisk(id int64) (bool, error) {
+func (api *DiskAPI) CanEditDisk(id sacloud.ID) (bool, error) {
 
 	disk, err := api.Read(id)
 	if err != nil {
@@ -351,9 +351,9 @@ func (api *DiskAPI) CanEditDisk(id int64) (bool, error) {
 }
 
 // GetPublicArchiveIDFromAncestors 祖先の中からパブリックアーカイブのIDを検索
-func (api *DiskAPI) GetPublicArchiveIDFromAncestors(id int64) (int64, bool) {
+func (api *DiskAPI) GetPublicArchiveIDFromAncestors(id sacloud.ID) (sacloud.ID, bool) {
 
-	emptyID := int64(0)
+	emptyID := sacloud.EmptyID
 
 	disk, err := api.Read(id)
 	if err != nil {

--- a/api/disk_gen.go
+++ b/api/disk_gen.go
@@ -197,21 +197,21 @@ func (api *DiskAPI) New() *sacloud.Disk {
 //}
 
 // Read 読み取り
-func (api *DiskAPI) Read(id int64) (*sacloud.Disk, error) {
+func (api *DiskAPI) Read(id sacloud.ID) (*sacloud.Disk, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *DiskAPI) Update(id int64, value *sacloud.Disk) (*sacloud.Disk, error) {
+func (api *DiskAPI) Update(id sacloud.ID, value *sacloud.Disk) (*sacloud.Disk, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *DiskAPI) Delete(id int64) (*sacloud.Disk, error) {
+func (api *DiskAPI) Delete(id sacloud.ID) (*sacloud.Disk, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/disk_test.go
+++ b/api/disk_test.go
@@ -35,7 +35,7 @@ func TestCRUDByDiskAPI(t *testing.T) {
 
 	// HACK 現状ではディスクの存在チェックが行われていないため、ここでテスト可能。
 	// 今後仕様変更などの際は切り出してテストする
-	disk.DistantFrom = []int64{111111111111}
+	disk.DistantFrom = []sacloud.ID{111111111111}
 
 	res, err := diskAPI.Create(disk)
 	assert.NoError(t, err)
@@ -169,7 +169,7 @@ func TestCreateDiskWithConfig(t *testing.T) {
 	err = client.Server.SleepUntilDown(serverID, client.DefaultTimeoutDuration)
 	assert.NoError(t, err)
 
-	_, err = client.Server.DeleteWithDisk(serverID, []int64{diskID})
+	_, err = client.Server.DeleteWithDisk(serverID, []sacloud.ID{diskID})
 	assert.NoError(t, err)
 }
 
@@ -208,7 +208,7 @@ func TestDiskAPI_FindByFilters(t *testing.T) {
 
 	api := client.Disk
 
-	ids := []int64{}
+	ids := []sacloud.ID{}
 	name1 := fmt.Sprintf("libsacloud_test_disk_name%d", 1)
 	name2 := fmt.Sprintf("libsacloud_test_disk_name%d", 2)
 	name3 := fmt.Sprintf("libsacloud_test_disk_name%d", 3)

--- a/api/dns.go
+++ b/api/dns.go
@@ -113,21 +113,21 @@ func (api *DNSAPI) New(zoneName string) *sacloud.DNS {
 }
 
 // Read 読み取り
-func (api *DNSAPI) Read(id int64) (*sacloud.DNS, error) {
+func (api *DNSAPI) Read(id sacloud.ID) (*sacloud.DNS, error) {
 	return api.request(func(res *dnsResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *DNSAPI) Update(id int64, value *sacloud.DNS) (*sacloud.DNS, error) {
+func (api *DNSAPI) Update(id sacloud.ID, value *sacloud.DNS) (*sacloud.DNS, error) {
 	return api.request(func(res *dnsResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *DNSAPI) Delete(id int64) (*sacloud.DNS, error) {
+func (api *DNSAPI) Delete(id sacloud.ID) (*sacloud.DNS, error) {
 	return api.request(func(res *dnsResponse) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/gslb.go
+++ b/api/gslb.go
@@ -112,21 +112,21 @@ func (api *GSLBAPI) Create(value *sacloud.GSLB) (*sacloud.GSLB, error) {
 }
 
 // Read 読み取り
-func (api *GSLBAPI) Read(id int64) (*sacloud.GSLB, error) {
+func (api *GSLBAPI) Read(id sacloud.ID) (*sacloud.GSLB, error) {
 	return api.request(func(res *gslbResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *GSLBAPI) Update(id int64, value *sacloud.GSLB) (*sacloud.GSLB, error) {
+func (api *GSLBAPI) Update(id sacloud.ID, value *sacloud.GSLB) (*sacloud.GSLB, error) {
 	return api.request(func(res *gslbResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *GSLBAPI) Delete(id int64) (*sacloud.GSLB, error) {
+func (api *GSLBAPI) Delete(id sacloud.ID) (*sacloud.GSLB, error) {
 	return api.request(func(res *gslbResponse) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/icon.go
+++ b/api/icon.go
@@ -34,7 +34,7 @@ func NewIconAPI(client *Client) *IconAPI {
 }
 
 // GetImage アイコン画像データ(BASE64文字列)取得
-func (api *IconAPI) GetImage(id int64, size string) (*sacloud.Image, error) {
+func (api *IconAPI) GetImage(id sacloud.ID, size string) (*sacloud.Image, error) {
 
 	res := &sacloud.Response{}
 	err := api.read(id, map[string]string{"Size": size}, res)

--- a/api/icon_gen.go
+++ b/api/icon_gen.go
@@ -216,21 +216,21 @@ func (api *IconAPI) Create(value *sacloud.Icon) (*sacloud.Icon, error) {
 }
 
 // Read 読み取り
-func (api *IconAPI) Read(id int64) (*sacloud.Icon, error) {
+func (api *IconAPI) Read(id sacloud.ID) (*sacloud.Icon, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *IconAPI) Update(id int64, value *sacloud.Icon) (*sacloud.Icon, error) {
+func (api *IconAPI) Update(id sacloud.ID, value *sacloud.Icon) (*sacloud.Icon, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *IconAPI) Delete(id int64) (*sacloud.Icon, error) {
+func (api *IconAPI) Delete(id sacloud.ID) (*sacloud.Icon, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/interface.go
+++ b/api/interface.go
@@ -38,7 +38,7 @@ func NewInterfaceAPI(client *Client) *InterfaceAPI {
 }
 
 // CreateAndConnectToServer 新規作成しサーバーへ接続する
-func (api *InterfaceAPI) CreateAndConnectToServer(serverID int64) (*sacloud.Interface, error) {
+func (api *InterfaceAPI) CreateAndConnectToServer(serverID sacloud.ID) (*sacloud.Interface, error) {
 	iface := api.New()
 	iface.Server = &sacloud.Server{
 		// Resource
@@ -48,7 +48,7 @@ func (api *InterfaceAPI) CreateAndConnectToServer(serverID int64) (*sacloud.Inte
 }
 
 // ConnectToSwitch スイッチへ接続する
-func (api *InterfaceAPI) ConnectToSwitch(interfaceID int64, switchID int64) (bool, error) {
+func (api *InterfaceAPI) ConnectToSwitch(interfaceID sacloud.ID, switchID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/to/switch/%d", api.getResourceURL(), interfaceID, switchID)
@@ -57,7 +57,7 @@ func (api *InterfaceAPI) ConnectToSwitch(interfaceID int64, switchID int64) (boo
 }
 
 // ConnectToSharedSegment 共有セグメントへ接続する
-func (api *InterfaceAPI) ConnectToSharedSegment(interfaceID int64) (bool, error) {
+func (api *InterfaceAPI) ConnectToSharedSegment(interfaceID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/to/switch/shared", api.getResourceURL(), interfaceID)
@@ -66,7 +66,7 @@ func (api *InterfaceAPI) ConnectToSharedSegment(interfaceID int64) (bool, error)
 }
 
 // DisconnectFromSwitch スイッチと切断する
-func (api *InterfaceAPI) DisconnectFromSwitch(interfaceID int64) (bool, error) {
+func (api *InterfaceAPI) DisconnectFromSwitch(interfaceID sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/to/switch", api.getResourceURL(), interfaceID)
@@ -75,12 +75,12 @@ func (api *InterfaceAPI) DisconnectFromSwitch(interfaceID int64) (bool, error) {
 }
 
 // Monitor アクティビティーモニター取得
-func (api *InterfaceAPI) Monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *InterfaceAPI) Monitor(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.monitor(id, body)
 }
 
 // ConnectToPacketFilter パケットフィルター適用
-func (api *InterfaceAPI) ConnectToPacketFilter(interfaceID int64, packetFilterID int64) (bool, error) {
+func (api *InterfaceAPI) ConnectToPacketFilter(interfaceID sacloud.ID, packetFilterID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("/%s/%d/to/packetfilter/%d", api.getResourceURL(), interfaceID, packetFilterID)
@@ -89,7 +89,7 @@ func (api *InterfaceAPI) ConnectToPacketFilter(interfaceID int64, packetFilterID
 }
 
 // DisconnectFromPacketFilter パケットフィルター切断
-func (api *InterfaceAPI) DisconnectFromPacketFilter(interfaceID int64) (bool, error) {
+func (api *InterfaceAPI) DisconnectFromPacketFilter(interfaceID sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("/%s/%d/to/packetfilter", api.getResourceURL(), interfaceID)
@@ -98,7 +98,7 @@ func (api *InterfaceAPI) DisconnectFromPacketFilter(interfaceID int64) (bool, er
 }
 
 // SetDisplayIPAddress 表示用IPアドレス 設定
-func (api *InterfaceAPI) SetDisplayIPAddress(interfaceID int64, ipaddress string) (bool, error) {
+func (api *InterfaceAPI) SetDisplayIPAddress(interfaceID sacloud.ID, ipaddress string) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("/%s/%d", api.getResourceURL(), interfaceID)
@@ -112,7 +112,7 @@ func (api *InterfaceAPI) SetDisplayIPAddress(interfaceID int64, ipaddress string
 }
 
 // DeleteDisplayIPAddress 表示用IPアドレス 削除
-func (api *InterfaceAPI) DeleteDisplayIPAddress(interfaceID int64) (bool, error) {
+func (api *InterfaceAPI) DeleteDisplayIPAddress(interfaceID sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("/%s/%d", api.getResourceURL(), interfaceID)

--- a/api/interface_gen.go
+++ b/api/interface_gen.go
@@ -212,21 +212,21 @@ func (api *InterfaceAPI) Create(value *sacloud.Interface) (*sacloud.Interface, e
 }
 
 // Read 読み取り
-func (api *InterfaceAPI) Read(id int64) (*sacloud.Interface, error) {
+func (api *InterfaceAPI) Read(id sacloud.ID) (*sacloud.Interface, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *InterfaceAPI) Update(id int64, value *sacloud.Interface) (*sacloud.Interface, error) {
+func (api *InterfaceAPI) Update(id sacloud.ID, value *sacloud.Interface) (*sacloud.Interface, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *InterfaceAPI) Delete(id int64) (*sacloud.Interface, error) {
+func (api *InterfaceAPI) Delete(id sacloud.ID) (*sacloud.Interface, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/internet.go
+++ b/api/internet.go
@@ -39,7 +39,7 @@ func NewInternetAPI(client *Client) *InternetAPI {
 }
 
 // UpdateBandWidth 帯域幅更新
-func (api *InternetAPI) UpdateBandWidth(id int64, bandWidth int) (*sacloud.Internet, error) {
+func (api *InternetAPI) UpdateBandWidth(id sacloud.ID, bandWidth int) (*sacloud.Internet, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/bandwidth", api.getResourceURL(), id)
@@ -53,7 +53,7 @@ func (api *InternetAPI) UpdateBandWidth(id int64, bandWidth int) (*sacloud.Inter
 }
 
 // AddSubnet IPアドレスブロックの追加割り当て
-func (api *InternetAPI) AddSubnet(id int64, nwMaskLen int, nextHop string) (*sacloud.Subnet, error) {
+func (api *InternetAPI) AddSubnet(id sacloud.ID, nwMaskLen int, nextHop string) (*sacloud.Subnet, error) {
 	var (
 		method = "POST"
 		uri    = fmt.Sprintf("%s/%d/subnet", api.getResourceURL(), id)
@@ -72,7 +72,7 @@ func (api *InternetAPI) AddSubnet(id int64, nwMaskLen int, nextHop string) (*sac
 }
 
 // UpdateSubnet IPアドレスブロックの更新
-func (api *InternetAPI) UpdateSubnet(id int64, subnetID int64, nextHop string) (*sacloud.Subnet, error) {
+func (api *InternetAPI) UpdateSubnet(id sacloud.ID, subnetID sacloud.ID, nextHop string) (*sacloud.Subnet, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/subnet/%d", api.getResourceURL(), id, subnetID)
@@ -90,7 +90,7 @@ func (api *InternetAPI) UpdateSubnet(id int64, subnetID int64, nextHop string) (
 }
 
 // DeleteSubnet IPアドレスブロックの削除
-func (api *InternetAPI) DeleteSubnet(id int64, subnetID int64) (*sacloud.ResultFlagValue, error) {
+func (api *InternetAPI) DeleteSubnet(id sacloud.ID, subnetID sacloud.ID) (*sacloud.ResultFlagValue, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/subnet/%d", api.getResourceURL(), id, subnetID)
@@ -105,7 +105,7 @@ func (api *InternetAPI) DeleteSubnet(id int64, subnetID int64) (*sacloud.ResultF
 }
 
 // EnableIPv6 IPv6有効化
-func (api *InternetAPI) EnableIPv6(id int64) (*sacloud.IPv6Net, error) {
+func (api *InternetAPI) EnableIPv6(id sacloud.ID) (*sacloud.IPv6Net, error) {
 	var (
 		method = "POST"
 		uri    = fmt.Sprintf("%s/%d/ipv6net", api.getResourceURL(), id)
@@ -120,7 +120,7 @@ func (api *InternetAPI) EnableIPv6(id int64) (*sacloud.IPv6Net, error) {
 }
 
 // DisableIPv6 IPv6無効化
-func (api *InternetAPI) DisableIPv6(id int64, ipv6NetID int64) (bool, error) {
+func (api *InternetAPI) DisableIPv6(id sacloud.ID, ipv6NetID sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/ipv6net/%d", api.getResourceURL(), id, ipv6NetID)
@@ -135,7 +135,7 @@ func (api *InternetAPI) DisableIPv6(id int64, ipv6NetID int64) (bool, error) {
 }
 
 // SleepWhileCreating 作成完了まで待機(リトライ10)
-func (api *InternetAPI) SleepWhileCreating(id int64, timeout time.Duration) error {
+func (api *InternetAPI) SleepWhileCreating(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForReadFunc(func() (interface{}, error) {
 		return api.Read(id)
 	}, 10) // 作成直後はReadが404を返すことがあるためリトライ
@@ -144,7 +144,7 @@ func (api *InternetAPI) SleepWhileCreating(id int64, timeout time.Duration) erro
 }
 
 // RetrySleepWhileCreating 作成完了まで待機 作成直後はReadが404を返すことがあるためmaxRetryまでリトライする
-func (api *InternetAPI) RetrySleepWhileCreating(id int64, timeout time.Duration, maxRetry int) error {
+func (api *InternetAPI) RetrySleepWhileCreating(id sacloud.ID, timeout time.Duration, maxRetry int) error {
 	handler := waitingForReadFunc(func() (interface{}, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -153,6 +153,6 @@ func (api *InternetAPI) RetrySleepWhileCreating(id int64, timeout time.Duration,
 }
 
 // Monitor アクティビティーモニター取得
-func (api *InternetAPI) Monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *InternetAPI) Monitor(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.monitor(id, body)
 }

--- a/api/internet_gen.go
+++ b/api/internet_gen.go
@@ -212,21 +212,21 @@ func (api *InternetAPI) Create(value *sacloud.Internet) (*sacloud.Internet, erro
 }
 
 // Read 読み取り
-func (api *InternetAPI) Read(id int64) (*sacloud.Internet, error) {
+func (api *InternetAPI) Read(id sacloud.ID) (*sacloud.Internet, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *InternetAPI) Update(id int64, value *sacloud.Internet) (*sacloud.Internet, error) {
+func (api *InternetAPI) Update(id sacloud.ID, value *sacloud.Internet) (*sacloud.Internet, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *InternetAPI) Delete(id int64) (*sacloud.Internet, error) {
+func (api *InternetAPI) Delete(id sacloud.ID) (*sacloud.Internet, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/ipaddress_gen.go
+++ b/api/ipaddress_gen.go
@@ -197,19 +197,19 @@ func (api *IPAddressAPI) SetSortBy(key string, reverse bool) {
 //	})
 //}
 
-//func (api *IPAddressAPI) Read(id int64) (*sacloud.IPAddress, error) {
+//func (api *IPAddressAPI) Read(id sacloud.ID) (*sacloud.IPAddress, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.read(id, nil, res)
 //	})
 //}
 
-//func (api *IPAddressAPI) Update(id int64, value *sacloud.IPAddress) (*sacloud.IPAddress, error) {
+//func (api *IPAddressAPI) Update(id sacloud.ID, value *sacloud.IPAddress) (*sacloud.IPAddress, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.update(id, api.createRequest(value), res)
 //	})
 //}
 //
-//func (api *IPAddressAPI) Delete(id int64) (*sacloud.IPAddress, error) {
+//func (api *IPAddressAPI) Delete(id sacloud.ID) (*sacloud.IPAddress, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.delete(id, nil, res)
 //	})

--- a/api/ipv6addr_gen.go
+++ b/api/ipv6addr_gen.go
@@ -197,19 +197,19 @@ func (api *IPv6AddrAPI) SetSortBy(key string, reverse bool) {
 //	})
 //}
 
-//func (api *IPv6AddrAPI) Read(id int64) (*sacloud.IPv6Addr, error) {
+//func (api *IPv6AddrAPI) Read(id sacloud.ID) (*sacloud.IPv6Addr, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.read(id, nil, res)
 //	})
 //}
 
-//func (api *IPv6AddrAPI) Update(id int64, value *sacloud.IPv6Addr) (*sacloud.IPv6Addr, error) {
+//func (api *IPv6AddrAPI) Update(id sacloud.ID, value *sacloud.IPv6Addr) (*sacloud.IPv6Addr, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.update(id, api.createRequest(value), res)
 //	})
 //}
 //
-//func (api *IPv6AddrAPI) Delete(id int64) (*sacloud.IPv6Addr, error) {
+//func (api *IPv6AddrAPI) Delete(id sacloud.ID) (*sacloud.IPv6Addr, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.delete(id, nil, res)
 //	})

--- a/api/ipv6net_gen.go
+++ b/api/ipv6net_gen.go
@@ -200,19 +200,19 @@ func (api *IPv6NetAPI) SetSortBy(key string, reverse bool) {
 //}
 
 // Read 読み取り
-func (api *IPv6NetAPI) Read(id int64) (*sacloud.IPv6Net, error) {
+func (api *IPv6NetAPI) Read(id sacloud.ID) (*sacloud.IPv6Net, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
-//func (api *IPv6NetAPI) Update(id int64, value *sacloud.IPv6Net) (*sacloud.IPv6Net, error) {
+//func (api *IPv6NetAPI) Update(id sacloud.ID, value *sacloud.IPv6Net) (*sacloud.IPv6Net, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.update(id, api.createRequest(value), res)
 //	})
 //}
 //
-//func (api *IPv6NetAPI) Delete(id int64) (*sacloud.IPv6Net, error) {
+//func (api *IPv6NetAPI) Delete(id sacloud.ID) (*sacloud.IPv6Net, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.delete(id, nil, res)
 //	})

--- a/api/license_gen.go
+++ b/api/license_gen.go
@@ -212,21 +212,21 @@ func (api *LicenseAPI) Create(value *sacloud.License) (*sacloud.License, error) 
 }
 
 // Read 読み取り
-func (api *LicenseAPI) Read(id int64) (*sacloud.License, error) {
+func (api *LicenseAPI) Read(id sacloud.ID) (*sacloud.License, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *LicenseAPI) Update(id int64, value *sacloud.License) (*sacloud.License, error) {
+func (api *LicenseAPI) Update(id sacloud.ID, value *sacloud.License) (*sacloud.License, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *LicenseAPI) Delete(id int64) (*sacloud.License, error) {
+func (api *LicenseAPI) Delete(id sacloud.ID) (*sacloud.License, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/load_balancer.go
+++ b/api/load_balancer.go
@@ -119,28 +119,28 @@ func (api *LoadBalancerAPI) Create(value *sacloud.LoadBalancer) (*sacloud.LoadBa
 }
 
 // Read 読み取り
-func (api *LoadBalancerAPI) Read(id int64) (*sacloud.LoadBalancer, error) {
+func (api *LoadBalancerAPI) Read(id sacloud.ID) (*sacloud.LoadBalancer, error) {
 	return api.request(func(res *loadBalancerResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *LoadBalancerAPI) Update(id int64, value *sacloud.LoadBalancer) (*sacloud.LoadBalancer, error) {
+func (api *LoadBalancerAPI) Update(id sacloud.ID, value *sacloud.LoadBalancer) (*sacloud.LoadBalancer, error) {
 	return api.request(func(res *loadBalancerResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *LoadBalancerAPI) Delete(id int64) (*sacloud.LoadBalancer, error) {
+func (api *LoadBalancerAPI) Delete(id sacloud.ID) (*sacloud.LoadBalancer, error) {
 	return api.request(func(res *loadBalancerResponse) error {
 		return api.delete(id, nil, res)
 	})
 }
 
 // Config 設定変更の反映
-func (api *LoadBalancerAPI) Config(id int64) (bool, error) {
+func (api *LoadBalancerAPI) Config(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/config", api.getResourceURL(), id)
@@ -149,7 +149,7 @@ func (api *LoadBalancerAPI) Config(id int64) (bool, error) {
 }
 
 // IsUp 起動しているか判定
-func (api *LoadBalancerAPI) IsUp(id int64) (bool, error) {
+func (api *LoadBalancerAPI) IsUp(id sacloud.ID) (bool, error) {
 	lb, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -158,7 +158,7 @@ func (api *LoadBalancerAPI) IsUp(id int64) (bool, error) {
 }
 
 // IsDown ダウンしているか判定
-func (api *LoadBalancerAPI) IsDown(id int64) (bool, error) {
+func (api *LoadBalancerAPI) IsDown(id sacloud.ID) (bool, error) {
 	lb, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -167,7 +167,7 @@ func (api *LoadBalancerAPI) IsDown(id int64) (bool, error) {
 }
 
 // Boot 起動
-func (api *LoadBalancerAPI) Boot(id int64) (bool, error) {
+func (api *LoadBalancerAPI) Boot(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -176,7 +176,7 @@ func (api *LoadBalancerAPI) Boot(id int64) (bool, error) {
 }
 
 // Shutdown シャットダウン(graceful)
-func (api *LoadBalancerAPI) Shutdown(id int64) (bool, error) {
+func (api *LoadBalancerAPI) Shutdown(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -186,7 +186,7 @@ func (api *LoadBalancerAPI) Shutdown(id int64) (bool, error) {
 }
 
 // Stop シャットダウン(force)
-func (api *LoadBalancerAPI) Stop(id int64) (bool, error) {
+func (api *LoadBalancerAPI) Stop(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -196,7 +196,7 @@ func (api *LoadBalancerAPI) Stop(id int64) (bool, error) {
 }
 
 // RebootForce 再起動
-func (api *LoadBalancerAPI) RebootForce(id int64) (bool, error) {
+func (api *LoadBalancerAPI) RebootForce(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -206,7 +206,7 @@ func (api *LoadBalancerAPI) RebootForce(id int64) (bool, error) {
 }
 
 // ResetForce リセット
-func (api *LoadBalancerAPI) ResetForce(id int64, recycleProcess bool) (bool, error) {
+func (api *LoadBalancerAPI) ResetForce(id sacloud.ID, recycleProcess bool) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -216,7 +216,7 @@ func (api *LoadBalancerAPI) ResetForce(id int64, recycleProcess bool) (bool, err
 }
 
 // SleepUntilUp 起動するまで待機
-func (api *LoadBalancerAPI) SleepUntilUp(id int64, timeout time.Duration) error {
+func (api *LoadBalancerAPI) SleepUntilUp(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForUpFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -224,7 +224,7 @@ func (api *LoadBalancerAPI) SleepUntilUp(id int64, timeout time.Duration) error 
 }
 
 // SleepUntilDown ダウンするまで待機
-func (api *LoadBalancerAPI) SleepUntilDown(id int64, timeout time.Duration) error {
+func (api *LoadBalancerAPI) SleepUntilDown(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForDownFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -232,7 +232,7 @@ func (api *LoadBalancerAPI) SleepUntilDown(id int64, timeout time.Duration) erro
 }
 
 // SleepWhileCopying コピー終了まで待機
-func (api *LoadBalancerAPI) SleepWhileCopying(id int64, timeout time.Duration, maxRetry int) error {
+func (api *LoadBalancerAPI) SleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) error {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -240,7 +240,7 @@ func (api *LoadBalancerAPI) SleepWhileCopying(id int64, timeout time.Duration, m
 }
 
 // AsyncSleepWhileCopying コピー終了まで待機(非同期)
-func (api *LoadBalancerAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
+func (api *LoadBalancerAPI) AsyncSleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -248,12 +248,12 @@ func (api *LoadBalancerAPI) AsyncSleepWhileCopying(id int64, timeout time.Durati
 }
 
 // Monitor アクティビティーモニター取得
-func (api *LoadBalancerAPI) Monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *LoadBalancerAPI) Monitor(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "interface", 0, body)
 }
 
 // Status ステータス取得
-func (api *LoadBalancerAPI) Status(id int64) (*sacloud.LoadBalancerStatusResult, error) {
+func (api *LoadBalancerAPI) Status(id sacloud.ID) (*sacloud.LoadBalancerStatusResult, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/status", api.getResourceURL(), id)

--- a/api/load_balancer_test.go
+++ b/api/load_balancer_test.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/sacloud/libsacloud/sacloud"
@@ -79,7 +78,7 @@ func TestLoadBalancerCRUD(t *testing.T) {
 	assert.NotEmpty(t, sw)
 
 	//CREATE
-	createLoadBalancerValues.SwitchID = fmt.Sprintf("%d", sw.ID)
+	createLoadBalancerValues.SwitchID = sw.ID
 	newItem, err := sacloud.CreateNewLoadBalancerSingle(createLoadBalancerValues, loadBalancerSettings)
 	assert.NoError(t, err)
 
@@ -143,7 +142,7 @@ func _TestLoadBalancerCRUDWithoutVIP(t *testing.T) {
 	assert.NotEmpty(t, sw)
 
 	//CREATE
-	createLoadBalancerValues.SwitchID = fmt.Sprintf("%d", sw.ID)
+	createLoadBalancerValues.SwitchID = sw.ID
 	newItem, err := sacloud.CreateNewLoadBalancerSingle(createLoadBalancerValues, nil)
 	assert.NoError(t, err)
 

--- a/api/mobile_gateway.go
+++ b/api/mobile_gateway.go
@@ -120,21 +120,21 @@ func (api *MobileGatewayAPI) Create(value *sacloud.MobileGateway) (*sacloud.Mobi
 }
 
 // Read 読み取り
-func (api *MobileGatewayAPI) Read(id int64) (*sacloud.MobileGateway, error) {
+func (api *MobileGatewayAPI) Read(id sacloud.ID) (*sacloud.MobileGateway, error) {
 	return api.request(func(res *mobileGatewayResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *MobileGatewayAPI) Update(id int64, value *sacloud.MobileGateway) (*sacloud.MobileGateway, error) {
+func (api *MobileGatewayAPI) Update(id sacloud.ID, value *sacloud.MobileGateway) (*sacloud.MobileGateway, error) {
 	return api.request(func(res *mobileGatewayResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // UpdateSetting 設定更新
-func (api *MobileGatewayAPI) UpdateSetting(id int64, value *sacloud.MobileGateway) (*sacloud.MobileGateway, error) {
+func (api *MobileGatewayAPI) UpdateSetting(id sacloud.ID, value *sacloud.MobileGateway) (*sacloud.MobileGateway, error) {
 	req := &sacloud.MobileGateway{
 		// Settings
 		Settings: value.Settings,
@@ -145,14 +145,14 @@ func (api *MobileGatewayAPI) UpdateSetting(id int64, value *sacloud.MobileGatewa
 }
 
 // Delete 削除
-func (api *MobileGatewayAPI) Delete(id int64) (*sacloud.MobileGateway, error) {
+func (api *MobileGatewayAPI) Delete(id sacloud.ID) (*sacloud.MobileGateway, error) {
 	return api.request(func(res *mobileGatewayResponse) error {
 		return api.delete(id, nil, res)
 	})
 }
 
 // Config 設定変更の反映
-func (api *MobileGatewayAPI) Config(id int64) (bool, error) {
+func (api *MobileGatewayAPI) Config(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/config", api.getResourceURL(), id)
@@ -161,7 +161,7 @@ func (api *MobileGatewayAPI) Config(id int64) (bool, error) {
 }
 
 // IsUp 起動しているか判定
-func (api *MobileGatewayAPI) IsUp(id int64) (bool, error) {
+func (api *MobileGatewayAPI) IsUp(id sacloud.ID) (bool, error) {
 	lb, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -170,7 +170,7 @@ func (api *MobileGatewayAPI) IsUp(id int64) (bool, error) {
 }
 
 // IsDown ダウンしているか判定
-func (api *MobileGatewayAPI) IsDown(id int64) (bool, error) {
+func (api *MobileGatewayAPI) IsDown(id sacloud.ID) (bool, error) {
 	lb, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -179,7 +179,7 @@ func (api *MobileGatewayAPI) IsDown(id int64) (bool, error) {
 }
 
 // Boot 起動
-func (api *MobileGatewayAPI) Boot(id int64) (bool, error) {
+func (api *MobileGatewayAPI) Boot(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -188,7 +188,7 @@ func (api *MobileGatewayAPI) Boot(id int64) (bool, error) {
 }
 
 // Shutdown シャットダウン(graceful)
-func (api *MobileGatewayAPI) Shutdown(id int64) (bool, error) {
+func (api *MobileGatewayAPI) Shutdown(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -198,7 +198,7 @@ func (api *MobileGatewayAPI) Shutdown(id int64) (bool, error) {
 }
 
 // Stop シャットダウン(force)
-func (api *MobileGatewayAPI) Stop(id int64) (bool, error) {
+func (api *MobileGatewayAPI) Stop(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -208,7 +208,7 @@ func (api *MobileGatewayAPI) Stop(id int64) (bool, error) {
 }
 
 // RebootForce 再起動
-func (api *MobileGatewayAPI) RebootForce(id int64) (bool, error) {
+func (api *MobileGatewayAPI) RebootForce(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -218,7 +218,7 @@ func (api *MobileGatewayAPI) RebootForce(id int64) (bool, error) {
 }
 
 // ResetForce リセット
-func (api *MobileGatewayAPI) ResetForce(id int64, recycleProcess bool) (bool, error) {
+func (api *MobileGatewayAPI) ResetForce(id sacloud.ID, recycleProcess bool) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -228,7 +228,7 @@ func (api *MobileGatewayAPI) ResetForce(id int64, recycleProcess bool) (bool, er
 }
 
 // SleepUntilUp 起動するまで待機
-func (api *MobileGatewayAPI) SleepUntilUp(id int64, timeout time.Duration) error {
+func (api *MobileGatewayAPI) SleepUntilUp(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForUpFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -236,7 +236,7 @@ func (api *MobileGatewayAPI) SleepUntilUp(id int64, timeout time.Duration) error
 }
 
 // SleepUntilDown ダウンするまで待機
-func (api *MobileGatewayAPI) SleepUntilDown(id int64, timeout time.Duration) error {
+func (api *MobileGatewayAPI) SleepUntilDown(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForDownFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -244,7 +244,7 @@ func (api *MobileGatewayAPI) SleepUntilDown(id int64, timeout time.Duration) err
 }
 
 // SleepWhileCopying コピー終了まで待機
-func (api *MobileGatewayAPI) SleepWhileCopying(id int64, timeout time.Duration, maxRetry int) error {
+func (api *MobileGatewayAPI) SleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) error {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -252,7 +252,7 @@ func (api *MobileGatewayAPI) SleepWhileCopying(id int64, timeout time.Duration, 
 }
 
 // AsyncSleepWhileCopying コピー終了まで待機(非同期)
-func (api *MobileGatewayAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
+func (api *MobileGatewayAPI) AsyncSleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -260,7 +260,7 @@ func (api *MobileGatewayAPI) AsyncSleepWhileCopying(id int64, timeout time.Durat
 }
 
 // ConnectToSwitch 指定のインデックス位置のNICをスイッチへ接続
-func (api *MobileGatewayAPI) ConnectToSwitch(id int64, switchID int64) (bool, error) {
+func (api *MobileGatewayAPI) ConnectToSwitch(id sacloud.ID, switchID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/interface/%d/to/switch/%d", api.getResourceURL(), id, 1, switchID)
@@ -269,7 +269,7 @@ func (api *MobileGatewayAPI) ConnectToSwitch(id int64, switchID int64) (bool, er
 }
 
 // DisconnectFromSwitch 指定のインデックス位置のNICをスイッチから切断
-func (api *MobileGatewayAPI) DisconnectFromSwitch(id int64) (bool, error) {
+func (api *MobileGatewayAPI) DisconnectFromSwitch(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/interface/%d/to/switch", api.getResourceURL(), id, 1)
@@ -278,7 +278,7 @@ func (api *MobileGatewayAPI) DisconnectFromSwitch(id int64) (bool, error) {
 }
 
 // GetDNS DNSサーバ設定 取得
-func (api *MobileGatewayAPI) GetDNS(id int64) (*sacloud.MobileGatewayResolver, error) {
+func (api *MobileGatewayAPI) GetDNS(id sacloud.ID) (*sacloud.MobileGatewayResolver, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/dnsresolver", api.getResourceURL(), id)
@@ -296,7 +296,7 @@ func (api *MobileGatewayAPI) GetDNS(id int64) (*sacloud.MobileGatewayResolver, e
 }
 
 // SetDNS DNSサーバ設定
-func (api *MobileGatewayAPI) SetDNS(id int64, dns *sacloud.MobileGatewayResolver) (bool, error) {
+func (api *MobileGatewayAPI) SetDNS(id sacloud.ID, dns *sacloud.MobileGatewayResolver) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/dnsresolver", api.getResourceURL(), id)
@@ -306,7 +306,7 @@ func (api *MobileGatewayAPI) SetDNS(id int64, dns *sacloud.MobileGatewayResolver
 }
 
 // GetSIMRoutes SIMルート 取得
-func (api *MobileGatewayAPI) GetSIMRoutes(id int64) ([]*sacloud.MobileGatewaySIMRoute, error) {
+func (api *MobileGatewayAPI) GetSIMRoutes(id sacloud.ID) ([]*sacloud.MobileGatewaySIMRoute, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/simroutes", api.getResourceURL(), id)
@@ -325,7 +325,7 @@ func (api *MobileGatewayAPI) GetSIMRoutes(id int64) ([]*sacloud.MobileGatewaySIM
 }
 
 // SetSIMRoutes SIMルート 設定
-func (api *MobileGatewayAPI) SetSIMRoutes(id int64, simRoutes *sacloud.MobileGatewaySIMRoutes) (bool, error) {
+func (api *MobileGatewayAPI) SetSIMRoutes(id sacloud.ID, simRoutes *sacloud.MobileGatewaySIMRoutes) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/simroutes", api.getResourceURL(), id)
@@ -335,7 +335,7 @@ func (api *MobileGatewayAPI) SetSIMRoutes(id int64, simRoutes *sacloud.MobileGat
 }
 
 // AddSIMRoute SIMルート 個別追加
-func (api *MobileGatewayAPI) AddSIMRoute(id int64, simID int64, prefix string) (bool, error) {
+func (api *MobileGatewayAPI) AddSIMRoute(id sacloud.ID, simID sacloud.ID, prefix string) (bool, error) {
 
 	routes, err := api.GetSIMRoutes(id)
 	if err != nil {
@@ -354,7 +354,7 @@ func (api *MobileGatewayAPI) AddSIMRoute(id int64, simID int64, prefix string) (
 }
 
 // DeleteSIMRoute SIMルート 個別削除
-func (api *MobileGatewayAPI) DeleteSIMRoute(id int64, simID int64, prefix string) (bool, error) {
+func (api *MobileGatewayAPI) DeleteSIMRoute(id sacloud.ID, simID sacloud.ID, prefix string) (bool, error) {
 
 	routes, err := api.GetSIMRoutes(id)
 	if err != nil {
@@ -374,14 +374,14 @@ func (api *MobileGatewayAPI) DeleteSIMRoute(id int64, simID int64, prefix string
 }
 
 // DeleteSIMRoutes SIMルート 全件削除
-func (api *MobileGatewayAPI) DeleteSIMRoutes(id int64) (bool, error) {
+func (api *MobileGatewayAPI) DeleteSIMRoutes(id sacloud.ID) (bool, error) {
 	return api.SetSIMRoutes(id, &sacloud.MobileGatewaySIMRoutes{
 		SIMRoutes: []*sacloud.MobileGatewaySIMRoute{},
 	})
 }
 
 // ListSIM SIM一覧取得
-func (api *MobileGatewayAPI) ListSIM(id int64, req *MobileGatewaySIMRequest) ([]sacloud.SIMInfo, error) {
+func (api *MobileGatewayAPI) ListSIM(id sacloud.ID, req *MobileGatewaySIMRequest) ([]sacloud.SIMInfo, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/sims", api.getResourceURL(), id)
@@ -399,7 +399,7 @@ func (api *MobileGatewayAPI) ListSIM(id int64, req *MobileGatewaySIMRequest) ([]
 }
 
 // AddSIM SIM登録
-func (api *MobileGatewayAPI) AddSIM(id int64, simID int64) (bool, error) {
+func (api *MobileGatewayAPI) AddSIM(id sacloud.ID, simID sacloud.ID) (bool, error) {
 	var (
 		method = "POST"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/sims", api.getResourceURL(), id)
@@ -413,7 +413,7 @@ func (api *MobileGatewayAPI) AddSIM(id int64, simID int64) (bool, error) {
 }
 
 // DeleteSIM SIM登録
-func (api *MobileGatewayAPI) DeleteSIM(id int64, simID int64) (bool, error) {
+func (api *MobileGatewayAPI) DeleteSIM(id sacloud.ID, simID sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/sims/%d", api.getResourceURL(), id, simID)
@@ -422,7 +422,7 @@ func (api *MobileGatewayAPI) DeleteSIM(id int64, simID int64) (bool, error) {
 }
 
 // Logs セッションログ取得(複数SIM)
-func (api *MobileGatewayAPI) Logs(id int64, body interface{}) ([]sacloud.SIMLog, error) {
+func (api *MobileGatewayAPI) Logs(id sacloud.ID, body interface{}) ([]sacloud.SIMLog, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/sessionlog", api.getResourceURL(), id)
@@ -437,7 +437,7 @@ func (api *MobileGatewayAPI) Logs(id int64, body interface{}) ([]sacloud.SIMLog,
 }
 
 // GetTrafficMonitoringConfig トラフィックコントロール 取得
-func (api *MobileGatewayAPI) GetTrafficMonitoringConfig(id int64) (*sacloud.TrafficMonitoringConfig, error) {
+func (api *MobileGatewayAPI) GetTrafficMonitoringConfig(id sacloud.ID) (*sacloud.TrafficMonitoringConfig, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/traffic_monitoring", api.getResourceURL(), id)
@@ -452,7 +452,7 @@ func (api *MobileGatewayAPI) GetTrafficMonitoringConfig(id int64) (*sacloud.Traf
 }
 
 // SetTrafficMonitoringConfig トラフィックコントロール 設定
-func (api *MobileGatewayAPI) SetTrafficMonitoringConfig(id int64, trafficMonConfig *sacloud.TrafficMonitoringConfig) (bool, error) {
+func (api *MobileGatewayAPI) SetTrafficMonitoringConfig(id sacloud.ID, trafficMonConfig *sacloud.TrafficMonitoringConfig) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/traffic_monitoring", api.getResourceURL(), id)
@@ -465,7 +465,7 @@ func (api *MobileGatewayAPI) SetTrafficMonitoringConfig(id int64, trafficMonConf
 }
 
 // DisableTrafficMonitoringConfig トラフィックコントロール 解除
-func (api *MobileGatewayAPI) DisableTrafficMonitoringConfig(id int64) (bool, error) {
+func (api *MobileGatewayAPI) DisableTrafficMonitoringConfig(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/traffic_monitoring", api.getResourceURL(), id)
@@ -474,7 +474,7 @@ func (api *MobileGatewayAPI) DisableTrafficMonitoringConfig(id int64) (bool, err
 }
 
 // GetTrafficStatus 当月通信量 取得
-func (api *MobileGatewayAPI) GetTrafficStatus(id int64) (*sacloud.TrafficStatus, error) {
+func (api *MobileGatewayAPI) GetTrafficStatus(id sacloud.ID) (*sacloud.TrafficStatus, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/mobilegateway/traffic_status", api.getResourceURL(), id)
@@ -489,6 +489,6 @@ func (api *MobileGatewayAPI) GetTrafficStatus(id int64) (*sacloud.TrafficStatus,
 }
 
 // MonitorBy 指定位置のインターフェースのアクティビティーモニター取得
-func (api *MobileGatewayAPI) MonitorBy(id int64, nicIndex int, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *MobileGatewayAPI) MonitorBy(id sacloud.ID, nicIndex int, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "interface", nicIndex, body)
 }

--- a/api/nfs.go
+++ b/api/nfs.go
@@ -163,28 +163,28 @@ func (api *NFSAPI) GetNFSPlans() (*sacloud.NFSPlans, error) {
 }
 
 // Read 読み取り
-func (api *NFSAPI) Read(id int64) (*sacloud.NFS, error) {
+func (api *NFSAPI) Read(id sacloud.ID) (*sacloud.NFS, error) {
 	return api.request(func(res *nfsResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *NFSAPI) Update(id int64, value *sacloud.NFS) (*sacloud.NFS, error) {
+func (api *NFSAPI) Update(id sacloud.ID, value *sacloud.NFS) (*sacloud.NFS, error) {
 	return api.request(func(res *nfsResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *NFSAPI) Delete(id int64) (*sacloud.NFS, error) {
+func (api *NFSAPI) Delete(id sacloud.ID) (*sacloud.NFS, error) {
 	return api.request(func(res *nfsResponse) error {
 		return api.delete(id, nil, res)
 	})
 }
 
 // Config 設定変更の反映
-func (api *NFSAPI) Config(id int64) (bool, error) {
+func (api *NFSAPI) Config(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/config", api.getResourceURL(), id)
@@ -193,7 +193,7 @@ func (api *NFSAPI) Config(id int64) (bool, error) {
 }
 
 // IsUp 起動しているか判定
-func (api *NFSAPI) IsUp(id int64) (bool, error) {
+func (api *NFSAPI) IsUp(id sacloud.ID) (bool, error) {
 	lb, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -202,7 +202,7 @@ func (api *NFSAPI) IsUp(id int64) (bool, error) {
 }
 
 // IsDown ダウンしているか判定
-func (api *NFSAPI) IsDown(id int64) (bool, error) {
+func (api *NFSAPI) IsDown(id sacloud.ID) (bool, error) {
 	lb, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -211,7 +211,7 @@ func (api *NFSAPI) IsDown(id int64) (bool, error) {
 }
 
 // Boot 起動
-func (api *NFSAPI) Boot(id int64) (bool, error) {
+func (api *NFSAPI) Boot(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -220,7 +220,7 @@ func (api *NFSAPI) Boot(id int64) (bool, error) {
 }
 
 // Shutdown シャットダウン(graceful)
-func (api *NFSAPI) Shutdown(id int64) (bool, error) {
+func (api *NFSAPI) Shutdown(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -230,7 +230,7 @@ func (api *NFSAPI) Shutdown(id int64) (bool, error) {
 }
 
 // Stop シャットダウン(force)
-func (api *NFSAPI) Stop(id int64) (bool, error) {
+func (api *NFSAPI) Stop(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -240,7 +240,7 @@ func (api *NFSAPI) Stop(id int64) (bool, error) {
 }
 
 // RebootForce 再起動
-func (api *NFSAPI) RebootForce(id int64) (bool, error) {
+func (api *NFSAPI) RebootForce(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -250,7 +250,7 @@ func (api *NFSAPI) RebootForce(id int64) (bool, error) {
 }
 
 // ResetForce リセット
-func (api *NFSAPI) ResetForce(id int64, recycleProcess bool) (bool, error) {
+func (api *NFSAPI) ResetForce(id sacloud.ID, recycleProcess bool) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -260,7 +260,7 @@ func (api *NFSAPI) ResetForce(id int64, recycleProcess bool) (bool, error) {
 }
 
 // SleepUntilUp 起動するまで待機
-func (api *NFSAPI) SleepUntilUp(id int64, timeout time.Duration) error {
+func (api *NFSAPI) SleepUntilUp(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForUpFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -268,7 +268,7 @@ func (api *NFSAPI) SleepUntilUp(id int64, timeout time.Duration) error {
 }
 
 // SleepUntilDown ダウンするまで待機
-func (api *NFSAPI) SleepUntilDown(id int64, timeout time.Duration) error {
+func (api *NFSAPI) SleepUntilDown(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForDownFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -276,7 +276,7 @@ func (api *NFSAPI) SleepUntilDown(id int64, timeout time.Duration) error {
 }
 
 // SleepWhileCopying コピー終了まで待機
-func (api *NFSAPI) SleepWhileCopying(id int64, timeout time.Duration, maxRetry int) error {
+func (api *NFSAPI) SleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) error {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -284,7 +284,7 @@ func (api *NFSAPI) SleepWhileCopying(id int64, timeout time.Duration, maxRetry i
 }
 
 // AsyncSleepWhileCopying コピー終了まで待機(非同期)
-func (api *NFSAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
+func (api *NFSAPI) AsyncSleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -292,11 +292,11 @@ func (api *NFSAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration, maxRe
 }
 
 // MonitorFreeDiskSize NFSディスク残量アクティビティモニター取得
-func (api *NFSAPI) MonitorFreeDiskSize(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *NFSAPI) MonitorFreeDiskSize(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "database", 0, body)
 }
 
 // MonitorInterface NICアクティビティーモニター取得
-func (api *NFSAPI) MonitorInterface(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *NFSAPI) MonitorInterface(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "interface", 0, body)
 }

--- a/api/nfs_test.go
+++ b/api/nfs_test.go
@@ -15,7 +15,6 @@
 package api
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/sacloud/libsacloud/sacloud"
@@ -47,7 +46,7 @@ func TestNFSCRUD(t *testing.T) {
 	assert.NotEmpty(t, sw)
 
 	//CREATE
-	createNFSValues.SwitchID = fmt.Sprintf("%d", sw.ID)
+	createNFSValues.SwitchID = sw.ID
 	item, err := api.CreateWithPlan(createNFSValues, sacloud.NFSPlanHDD, sacloud.NFSSize100G)
 
 	assert.NoError(t, err)

--- a/api/note_gen.go
+++ b/api/note_gen.go
@@ -216,21 +216,21 @@ func (api *NoteAPI) Create(value *sacloud.Note) (*sacloud.Note, error) {
 }
 
 // Read 読み取り
-func (api *NoteAPI) Read(id int64) (*sacloud.Note, error) {
+func (api *NoteAPI) Read(id sacloud.ID) (*sacloud.Note, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *NoteAPI) Update(id int64, value *sacloud.Note) (*sacloud.Note, error) {
+func (api *NoteAPI) Update(id sacloud.ID, value *sacloud.Note) (*sacloud.Note, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *NoteAPI) Delete(id int64) (*sacloud.Note, error) {
+func (api *NoteAPI) Delete(id sacloud.ID) (*sacloud.Note, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/packet_filter_gen.go
+++ b/api/packet_filter_gen.go
@@ -212,21 +212,21 @@ func (api *PacketFilterAPI) Create(value *sacloud.PacketFilter) (*sacloud.Packet
 }
 
 // Read 読み取り
-func (api *PacketFilterAPI) Read(id int64) (*sacloud.PacketFilter, error) {
+func (api *PacketFilterAPI) Read(id sacloud.ID) (*sacloud.PacketFilter, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *PacketFilterAPI) Update(id int64, value *sacloud.PacketFilter) (*sacloud.PacketFilter, error) {
+func (api *PacketFilterAPI) Update(id sacloud.ID, value *sacloud.PacketFilter) (*sacloud.PacketFilter, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *PacketFilterAPI) Delete(id int64) (*sacloud.PacketFilter, error) {
+func (api *PacketFilterAPI) Delete(id sacloud.ID) (*sacloud.PacketFilter, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/private_host_gen.go
+++ b/api/private_host_gen.go
@@ -212,21 +212,21 @@ func (api *PrivateHostAPI) Create(value *sacloud.PrivateHost) (*sacloud.PrivateH
 }
 
 // Read 読み取り
-func (api *PrivateHostAPI) Read(id int64) (*sacloud.PrivateHost, error) {
+func (api *PrivateHostAPI) Read(id sacloud.ID) (*sacloud.PrivateHost, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *PrivateHostAPI) Update(id int64, value *sacloud.PrivateHost) (*sacloud.PrivateHost, error) {
+func (api *PrivateHostAPI) Update(id sacloud.ID, value *sacloud.PrivateHost) (*sacloud.PrivateHost, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *PrivateHostAPI) Delete(id int64) (*sacloud.PrivateHost, error) {
+func (api *PrivateHostAPI) Delete(id sacloud.ID) (*sacloud.PrivateHost, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/product_disk_gen.go
+++ b/api/product_disk_gen.go
@@ -210,19 +210,19 @@ func (api *ProductDiskAPI) SetSortByName(reverse bool) {
 // }
 
 // Read 読み取り
-func (api *ProductDiskAPI) Read(id int64) (*sacloud.ProductDisk, error) {
+func (api *ProductDiskAPI) Read(id sacloud.ID) (*sacloud.ProductDisk, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
-// func (api *ProductDiskAPI) Update(id int64, value *sacloud.ProductDisk) (*sacloud.ProductDisk, error) {
+// func (api *ProductDiskAPI) Update(id sacloud.ID, value *sacloud.ProductDisk) (*sacloud.ProductDisk, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.update(id, api.createRequest(value), res)
 // 	})
 // }
 
-// func (api *ProductDiskAPI) Delete(id int64) (*sacloud.ProductDisk, error) {
+// func (api *ProductDiskAPI) Delete(id sacloud.ID) (*sacloud.ProductDisk, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.delete(id, nil, res)
 // 	})

--- a/api/product_internet_gen.go
+++ b/api/product_internet_gen.go
@@ -210,19 +210,19 @@ func (api *ProductInternetAPI) SortByName(reverse bool) *ProductInternetAPI {
 // }
 
 // Read 読み取り
-func (api *ProductInternetAPI) Read(id int64) (*sacloud.ProductInternet, error) {
+func (api *ProductInternetAPI) Read(id sacloud.ID) (*sacloud.ProductInternet, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
-// func (api *ProductInternetAPI) Update(id int64, value *sacloud.ProductInternet) (*sacloud.ProductInternet, error) {
+// func (api *ProductInternetAPI) Update(id sacloud.ID, value *sacloud.ProductInternet) (*sacloud.ProductInternet, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.update(id, api.createRequest(value), res)
 // 	})
 // }
 
-// func (api *ProductInternetAPI) Delete(id int64) (*sacloud.ProductInternet, error) {
+// func (api *ProductInternetAPI) Delete(id sacloud.ID) (*sacloud.ProductInternet, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.delete(id, nil, res)
 // 	})

--- a/api/product_license_gen.go
+++ b/api/product_license_gen.go
@@ -206,19 +206,19 @@ func (api *ProductLicenseAPI) SetSortByName(reverse bool) {
 // }
 
 // Read 読み取り
-func (api *ProductLicenseAPI) Read(id int64) (*sacloud.ProductLicense, error) {
+func (api *ProductLicenseAPI) Read(id sacloud.ID) (*sacloud.ProductLicense, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
-// func (api *ProductLicenseAPI) Update(id int64, value *sacloud.ProductLicense) (*sacloud.ProductLicense, error) {
+// func (api *ProductLicenseAPI) Update(id sacloud.ID, value *sacloud.ProductLicense) (*sacloud.ProductLicense, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.update(id, api.createRequest(value), res)
 // 	})
 // }
 
-// func (api *ProductLicenseAPI) Delete(id int64) (*sacloud.ProductLicense, error) {
+// func (api *ProductLicenseAPI) Delete(id sacloud.ID) (*sacloud.ProductLicense, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.delete(id, nil, res)
 // 	})

--- a/api/product_private_host_gen.go
+++ b/api/product_private_host_gen.go
@@ -210,19 +210,19 @@ func (api *ProductPrivateHostAPI) SetSortByName(reverse bool) {
 // }
 
 // Read 読み取り
-func (api *ProductPrivateHostAPI) Read(id int64) (*sacloud.ProductPrivateHost, error) {
+func (api *ProductPrivateHostAPI) Read(id sacloud.ID) (*sacloud.ProductPrivateHost, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
-// func (api *ProductPrivateHostAPI) Update(id int64, value *sacloud.ProductPrivateHost) (*sacloud.ProductPrivateHost, error) {
+// func (api *ProductPrivateHostAPI) Update(id sacloud.ID, value *sacloud.ProductPrivateHost) (*sacloud.ProductPrivateHost, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.update(id, api.createRequest(value), res)
 // 	})
 // }
 
-// func (api *ProductPrivateHostAPI) Delete(id int64) (*sacloud.ProductPrivateHost, error) {
+// func (api *ProductPrivateHostAPI) Delete(id sacloud.ID) (*sacloud.ProductPrivateHost, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.delete(id, nil, res)
 // 	})

--- a/api/product_server_gen.go
+++ b/api/product_server_gen.go
@@ -210,19 +210,19 @@ func (api *ProductServerAPI) SetSortByName(reverse bool) {
 // }
 
 // Read 読み取り
-func (api *ProductServerAPI) Read(id int64) (*sacloud.ProductServer, error) {
+func (api *ProductServerAPI) Read(id sacloud.ID) (*sacloud.ProductServer, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
-// func (api *ProductServerAPI) Update(id int64, value *sacloud.ProductServer) (*sacloud.ProductServer, error) {
+// func (api *ProductServerAPI) Update(id sacloud.ID, value *sacloud.ProductServer) (*sacloud.ProductServer, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.update(id, api.createRequest(value), res)
 // 	})
 // }
 
-// func (api *ProductServerAPI) Delete(id int64) (*sacloud.ProductServer, error) {
+// func (api *ProductServerAPI) Delete(id sacloud.ID) (*sacloud.ProductServer, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.delete(id, nil, res)
 // 	})

--- a/api/proxylb.go
+++ b/api/proxylb.go
@@ -113,21 +113,21 @@ func (api *ProxyLBAPI) Create(value *sacloud.ProxyLB) (*sacloud.ProxyLB, error) 
 }
 
 // Read 読み取り
-func (api *ProxyLBAPI) Read(id int64) (*sacloud.ProxyLB, error) {
+func (api *ProxyLBAPI) Read(id sacloud.ID) (*sacloud.ProxyLB, error) {
 	return api.request(func(res *proxyLBResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *ProxyLBAPI) Update(id int64, value *sacloud.ProxyLB) (*sacloud.ProxyLB, error) {
+func (api *ProxyLBAPI) Update(id sacloud.ID, value *sacloud.ProxyLB) (*sacloud.ProxyLB, error) {
 	return api.request(func(res *proxyLBResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // UpdateSetting 設定更新
-func (api *ProxyLBAPI) UpdateSetting(id int64, value *sacloud.ProxyLB) (*sacloud.ProxyLB, error) {
+func (api *ProxyLBAPI) UpdateSetting(id sacloud.ID, value *sacloud.ProxyLB) (*sacloud.ProxyLB, error) {
 	req := &sacloud.ProxyLB{
 		// Settings
 		Settings: value.Settings,
@@ -138,14 +138,14 @@ func (api *ProxyLBAPI) UpdateSetting(id int64, value *sacloud.ProxyLB) (*sacloud
 }
 
 // Delete 削除
-func (api *ProxyLBAPI) Delete(id int64) (*sacloud.ProxyLB, error) {
+func (api *ProxyLBAPI) Delete(id sacloud.ID) (*sacloud.ProxyLB, error) {
 	return api.request(func(res *proxyLBResponse) error {
 		return api.delete(id, nil, res)
 	})
 }
 
 // ChangePlan プラン変更
-func (api *ProxyLBAPI) ChangePlan(id int64, newPlan sacloud.ProxyLBPlan) (*sacloud.ProxyLB, error) {
+func (api *ProxyLBAPI) ChangePlan(id sacloud.ID, newPlan sacloud.ProxyLBPlan) (*sacloud.ProxyLB, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/plan", api.getResourceURL(), id)
@@ -169,7 +169,7 @@ type proxyLBCertificateResponse struct {
 }
 
 // GetCertificates 証明書取得
-func (api *ProxyLBAPI) GetCertificates(id int64) (*sacloud.ProxyLBCertificates, error) {
+func (api *ProxyLBAPI) GetCertificates(id sacloud.ID) (*sacloud.ProxyLBCertificates, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/proxylb/sslcertificate", api.getResourceURL(), id)
@@ -186,7 +186,7 @@ func (api *ProxyLBAPI) GetCertificates(id int64) (*sacloud.ProxyLBCertificates, 
 }
 
 // SetCertificates 証明書設定
-func (api *ProxyLBAPI) SetCertificates(id int64, certs *sacloud.ProxyLBCertificates) (bool, error) {
+func (api *ProxyLBAPI) SetCertificates(id sacloud.ID, certs *sacloud.ProxyLBCertificates) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/proxylb/sslcertificate", api.getResourceURL(), id)
@@ -202,7 +202,7 @@ func (api *ProxyLBAPI) SetCertificates(id int64, certs *sacloud.ProxyLBCertifica
 }
 
 // DeleteCertificates 証明書削除
-func (api *ProxyLBAPI) DeleteCertificates(id int64) (bool, error) {
+func (api *ProxyLBAPI) DeleteCertificates(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/proxylb/sslcertificate", api.getResourceURL(), id)
@@ -211,7 +211,7 @@ func (api *ProxyLBAPI) DeleteCertificates(id int64) (bool, error) {
 }
 
 // RenewLetsEncryptCert 証明書更新
-func (api *ProxyLBAPI) RenewLetsEncryptCert(id int64) (bool, error) {
+func (api *ProxyLBAPI) RenewLetsEncryptCert(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/proxylb/letsencryptrenew", api.getResourceURL(), id)
@@ -225,7 +225,7 @@ type proxyLBHealthResponse struct {
 }
 
 // Health ヘルスチェックステータス取得
-func (api *ProxyLBAPI) Health(id int64) (*sacloud.ProxyLBStatus, error) {
+func (api *ProxyLBAPI) Health(id sacloud.ID) (*sacloud.ProxyLBStatus, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/health", api.getResourceURL(), id)
@@ -242,6 +242,6 @@ func (api *ProxyLBAPI) Health(id int64) (*sacloud.ProxyLBStatus, error) {
 }
 
 // Monitor アクティビティーモニター取得
-func (api *ProxyLBAPI) Monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *ProxyLBAPI) Monitor(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "activity/proxylb", 0, body)
 }

--- a/api/public_price_gen.go
+++ b/api/public_price_gen.go
@@ -207,19 +207,19 @@ func (api *PublicPriceAPI) SetSortByName(reverse bool) {
 // 	})
 // }
 
-// func (api *PublicPriceAPI) Read(id int64) (*sacloud.PublicPrice, error) {
+// func (api *PublicPriceAPI) Read(id sacloud.ID) (*sacloud.PublicPrice, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.read(id, nil, res)
 // 	})
 // }
 
-// func (api *PublicPriceAPI) Update(id int64, value *sacloud.PublicPrice) (*sacloud.PublicPrice, error) {
+// func (api *PublicPriceAPI) Update(id sacloud.ID, value *sacloud.PublicPrice) (*sacloud.PublicPrice, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.update(id, api.createRequest(value), res)
 // 	})
 // }
 
-// func (api *PublicPriceAPI) Delete(id int64) (*sacloud.PublicPrice, error) {
+// func (api *PublicPriceAPI) Delete(id sacloud.ID) (*sacloud.PublicPrice, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.delete(id, nil, res)
 // 	})

--- a/api/region_gen.go
+++ b/api/region_gen.go
@@ -210,19 +210,19 @@ func (api *RegionAPI) SetSortByName(reverse bool) {
 // }
 
 // Read 読み取り
-func (api *RegionAPI) Read(id int64) (*sacloud.Region, error) {
+func (api *RegionAPI) Read(id sacloud.ID) (*sacloud.Region, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
-// func (api *RegionAPI) Update(id int64, value *sacloud.Region) (*sacloud.Region, error) {
+// func (api *RegionAPI) Update(id sacloud.ID, value *sacloud.Region) (*sacloud.Region, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.update(id, api.createRequest(value), res)
 // 	})
 // }
 
-// func (api *RegionAPI) Delete(id int64) (*sacloud.Region, error) {
+// func (api *RegionAPI) Delete(id sacloud.ID) (*sacloud.Region, error) {
 // 	return api.request(func(res *sacloud.Response) error {
 // 		return api.delete(id, nil, res)
 // 	})

--- a/api/server.go
+++ b/api/server.go
@@ -59,7 +59,7 @@ func (api *ServerAPI) WithStatusDown() *ServerAPI {
 }
 
 // WithISOImage ISOイメージ条件
-func (api *ServerAPI) WithISOImage(imageID int64) *ServerAPI {
+func (api *ServerAPI) WithISOImage(imageID sacloud.ID) *ServerAPI {
 	return api.FilterBy("Instance.CDROM.ID", imageID)
 }
 
@@ -76,14 +76,14 @@ func (api *ServerAPI) SortByMemory(reverse bool) *ServerAPI {
 }
 
 // DeleteWithDisk 指定のディスクと共に削除する
-func (api *ServerAPI) DeleteWithDisk(id int64, disks []int64) (*sacloud.Server, error) {
+func (api *ServerAPI) DeleteWithDisk(id sacloud.ID, disks []sacloud.ID) (*sacloud.Server, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, map[string]interface{}{"WithDisk": disks}, res)
 	})
 }
 
 // State ステータス(Availability)取得
-func (api *ServerAPI) State(id int64) (string, error) {
+func (api *ServerAPI) State(id sacloud.ID) (string, error) {
 	server, err := api.Read(id)
 	if err != nil {
 		return "", err
@@ -92,7 +92,7 @@ func (api *ServerAPI) State(id int64) (string, error) {
 }
 
 // IsUp 起動しているか判定
-func (api *ServerAPI) IsUp(id int64) (bool, error) {
+func (api *ServerAPI) IsUp(id sacloud.ID) (bool, error) {
 	server, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -101,7 +101,7 @@ func (api *ServerAPI) IsUp(id int64) (bool, error) {
 }
 
 // IsDown ダウンしているか判定
-func (api *ServerAPI) IsDown(id int64) (bool, error) {
+func (api *ServerAPI) IsDown(id sacloud.ID) (bool, error) {
 	server, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -110,7 +110,7 @@ func (api *ServerAPI) IsDown(id int64) (bool, error) {
 }
 
 // Boot 起動
-func (api *ServerAPI) Boot(id int64) (bool, error) {
+func (api *ServerAPI) Boot(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -119,7 +119,7 @@ func (api *ServerAPI) Boot(id int64) (bool, error) {
 }
 
 // Shutdown シャットダウン(graceful)
-func (api *ServerAPI) Shutdown(id int64) (bool, error) {
+func (api *ServerAPI) Shutdown(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -129,7 +129,7 @@ func (api *ServerAPI) Shutdown(id int64) (bool, error) {
 }
 
 // Stop シャットダウン(force)
-func (api *ServerAPI) Stop(id int64) (bool, error) {
+func (api *ServerAPI) Stop(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -139,7 +139,7 @@ func (api *ServerAPI) Stop(id int64) (bool, error) {
 }
 
 // RebootForce 再起動
-func (api *ServerAPI) RebootForce(id int64) (bool, error) {
+func (api *ServerAPI) RebootForce(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -149,7 +149,7 @@ func (api *ServerAPI) RebootForce(id int64) (bool, error) {
 }
 
 // SleepUntilUp 起動するまで待機
-func (api *ServerAPI) SleepUntilUp(id int64, timeout time.Duration) error {
+func (api *ServerAPI) SleepUntilUp(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForUpFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -157,7 +157,7 @@ func (api *ServerAPI) SleepUntilUp(id int64, timeout time.Duration) error {
 }
 
 // SleepUntilDown ダウンするまで待機
-func (api *ServerAPI) SleepUntilDown(id int64, timeout time.Duration) error {
+func (api *ServerAPI) SleepUntilDown(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForDownFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -165,7 +165,7 @@ func (api *ServerAPI) SleepUntilDown(id int64, timeout time.Duration) error {
 }
 
 // ChangePlan サーバープラン変更(サーバーIDが変更となるため注意)
-func (api *ServerAPI) ChangePlan(serverID int64, plan *sacloud.ProductServer) (*sacloud.Server, error) {
+func (api *ServerAPI) ChangePlan(serverID sacloud.ID, plan *sacloud.ProductServer) (*sacloud.Server, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/plan", api.getResourceURL(), serverID)
@@ -182,7 +182,7 @@ func (api *ServerAPI) ChangePlan(serverID int64, plan *sacloud.ProductServer) (*
 }
 
 // FindDisk 指定サーバーに接続されているディスク一覧を取得
-func (api *ServerAPI) FindDisk(serverID int64) ([]sacloud.Disk, error) {
+func (api *ServerAPI) FindDisk(serverID sacloud.ID) ([]sacloud.Disk, error) {
 	server, err := api.Read(serverID)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ func (api *ServerAPI) FindDisk(serverID int64) ([]sacloud.Disk, error) {
 }
 
 // InsertCDROM ISOイメージを挿入
-func (api *ServerAPI) InsertCDROM(serverID int64, cdromID int64) (bool, error) {
+func (api *ServerAPI) InsertCDROM(serverID sacloud.ID, cdromID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/cdrom", api.getResourceURL(), serverID)
@@ -207,7 +207,7 @@ func (api *ServerAPI) InsertCDROM(serverID int64, cdromID int64) (bool, error) {
 }
 
 // EjectCDROM ISOイメージを取り出し
-func (api *ServerAPI) EjectCDROM(serverID int64, cdromID int64) (bool, error) {
+func (api *ServerAPI) EjectCDROM(serverID sacloud.ID, cdromID sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/cdrom", api.getResourceURL(), serverID)
@@ -228,7 +228,7 @@ func (api *ServerAPI) NewKeyboardRequest() *sacloud.KeyboardRequest {
 }
 
 // SendKey キーボード入力送信
-func (api *ServerAPI) SendKey(serverID int64, body *sacloud.KeyboardRequest) (bool, error) {
+func (api *ServerAPI) SendKey(serverID sacloud.ID, body *sacloud.KeyboardRequest) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/keyboard", api.getResourceURL(), serverID)
@@ -245,7 +245,7 @@ func (api *ServerAPI) NewMouseRequest() *sacloud.MouseRequest {
 }
 
 // SendMouse マウス入力送信
-func (api *ServerAPI) SendMouse(serverID int64, mouseIndex string, body *sacloud.MouseRequest) (bool, error) {
+func (api *ServerAPI) SendMouse(serverID sacloud.ID, mouseIndex string, body *sacloud.MouseRequest) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/mouse/%s", api.getResourceURL(), serverID, mouseIndex)
@@ -260,7 +260,7 @@ func (api *ServerAPI) NewVNCSnapshotRequest() *sacloud.VNCSnapshotRequest {
 }
 
 // GetVNCProxy VNCプロキシ情報取得
-func (api *ServerAPI) GetVNCProxy(serverID int64) (*sacloud.VNCProxyResponse, error) {
+func (api *ServerAPI) GetVNCProxy(serverID sacloud.ID) (*sacloud.VNCProxyResponse, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/vnc/proxy", api.getResourceURL(), serverID)
@@ -274,7 +274,7 @@ func (api *ServerAPI) GetVNCProxy(serverID int64) (*sacloud.VNCProxyResponse, er
 }
 
 // GetVNCSize VNC画面サイズ取得
-func (api *ServerAPI) GetVNCSize(serverID int64) (*sacloud.VNCSizeResponse, error) {
+func (api *ServerAPI) GetVNCSize(serverID sacloud.ID) (*sacloud.VNCSizeResponse, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/vnc/size", api.getResourceURL(), serverID)
@@ -288,7 +288,7 @@ func (api *ServerAPI) GetVNCSize(serverID int64) (*sacloud.VNCSizeResponse, erro
 }
 
 // GetVNCSnapshot VNCスナップショット取得
-func (api *ServerAPI) GetVNCSnapshot(serverID int64, body *sacloud.VNCSnapshotRequest) (*sacloud.VNCSnapshotResponse, error) {
+func (api *ServerAPI) GetVNCSnapshot(serverID sacloud.ID, body *sacloud.VNCSnapshotRequest) (*sacloud.VNCSnapshotResponse, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/vnc/snapshot", api.getResourceURL(), serverID)
@@ -302,6 +302,6 @@ func (api *ServerAPI) GetVNCSnapshot(serverID int64, body *sacloud.VNCSnapshotRe
 }
 
 // Monitor アクティビティーモニター(CPU-TIME)取得
-func (api *ServerAPI) Monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *ServerAPI) Monitor(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.monitor(id, body)
 }

--- a/api/server_gen.go
+++ b/api/server_gen.go
@@ -212,21 +212,21 @@ func (api *ServerAPI) Create(value *sacloud.Server) (*sacloud.Server, error) {
 }
 
 // Read 読み取り
-func (api *ServerAPI) Read(id int64) (*sacloud.Server, error) {
+func (api *ServerAPI) Read(id sacloud.ID) (*sacloud.Server, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *ServerAPI) Update(id int64, value *sacloud.Server) (*sacloud.Server, error) {
+func (api *ServerAPI) Update(id sacloud.ID, value *sacloud.Server) (*sacloud.Server, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *ServerAPI) Delete(id int64) (*sacloud.Server, error) {
+func (api *ServerAPI) Delete(id sacloud.ID) (*sacloud.Server, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/sim.go
+++ b/api/sim.go
@@ -117,28 +117,28 @@ func (api *SIMAPI) New(name, iccID, passcode string) *sacloud.SIM {
 }
 
 // Read 読み取り
-func (api *SIMAPI) Read(id int64) (*sacloud.SIM, error) {
+func (api *SIMAPI) Read(id sacloud.ID) (*sacloud.SIM, error) {
 	return api.request(func(res *simResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *SIMAPI) Update(id int64, value *sacloud.SIM) (*sacloud.SIM, error) {
+func (api *SIMAPI) Update(id sacloud.ID, value *sacloud.SIM) (*sacloud.SIM, error) {
 	return api.request(func(res *simResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *SIMAPI) Delete(id int64) (*sacloud.SIM, error) {
+func (api *SIMAPI) Delete(id sacloud.ID) (*sacloud.SIM, error) {
 	return api.request(func(res *simResponse) error {
 		return api.delete(id, nil, res)
 	})
 }
 
 // Activate SIM有効化
-func (api *SIMAPI) Activate(id int64) (bool, error) {
+func (api *SIMAPI) Activate(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/sim/activate", api.getResourceURL(), id)
@@ -148,7 +148,7 @@ func (api *SIMAPI) Activate(id int64) (bool, error) {
 }
 
 // Deactivate SIM無効化
-func (api *SIMAPI) Deactivate(id int64) (bool, error) {
+func (api *SIMAPI) Deactivate(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/sim/deactivate", api.getResourceURL(), id)
@@ -158,7 +158,7 @@ func (api *SIMAPI) Deactivate(id int64) (bool, error) {
 }
 
 // AssignIP SIMへのIP割り当て
-func (api *SIMAPI) AssignIP(id int64, ip string) (bool, error) {
+func (api *SIMAPI) AssignIP(id sacloud.ID, ip string) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/sim/ip", api.getResourceURL(), id)
@@ -172,7 +172,7 @@ func (api *SIMAPI) AssignIP(id int64, ip string) (bool, error) {
 }
 
 // ClearIP SIMからのIP割り当て解除
-func (api *SIMAPI) ClearIP(id int64) (bool, error) {
+func (api *SIMAPI) ClearIP(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/sim/ip", api.getResourceURL(), id)
@@ -181,7 +181,7 @@ func (api *SIMAPI) ClearIP(id int64) (bool, error) {
 }
 
 // IMEILock IMEIロック
-func (api *SIMAPI) IMEILock(id int64, imei string) (bool, error) {
+func (api *SIMAPI) IMEILock(id sacloud.ID, imei string) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/sim/imeilock", api.getResourceURL(), id)
@@ -195,7 +195,7 @@ func (api *SIMAPI) IMEILock(id int64, imei string) (bool, error) {
 }
 
 // IMEIUnlock IMEIアンロック
-func (api *SIMAPI) IMEIUnlock(id int64) (bool, error) {
+func (api *SIMAPI) IMEIUnlock(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/sim/imeilock", api.getResourceURL(), id)
@@ -204,7 +204,7 @@ func (api *SIMAPI) IMEIUnlock(id int64) (bool, error) {
 }
 
 // Logs セッションログ取得
-func (api *SIMAPI) Logs(id int64, body interface{}) ([]sacloud.SIMLog, error) {
+func (api *SIMAPI) Logs(id sacloud.ID, body interface{}) ([]sacloud.SIMLog, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/sim/sessionlog", api.getResourceURL(), id)
@@ -219,7 +219,7 @@ func (api *SIMAPI) Logs(id int64, body interface{}) ([]sacloud.SIMLog, error) {
 }
 
 // GetNetworkOperator 通信キャリア 取得
-func (api *SIMAPI) GetNetworkOperator(id int64) (*sacloud.SIMNetworkOperatorConfigs, error) {
+func (api *SIMAPI) GetNetworkOperator(id sacloud.ID) (*sacloud.SIMNetworkOperatorConfigs, error) {
 
 	var (
 		method = "GET"
@@ -235,7 +235,7 @@ func (api *SIMAPI) GetNetworkOperator(id int64) (*sacloud.SIMNetworkOperatorConf
 }
 
 // SetNetworkOperator 通信キャリア 設定
-func (api *SIMAPI) SetNetworkOperator(id int64, opConfig ...*sacloud.SIMNetworkOperatorConfig) (bool, error) {
+func (api *SIMAPI) SetNetworkOperator(id sacloud.ID, opConfig ...*sacloud.SIMNetworkOperatorConfig) (bool, error) {
 
 	var (
 		method = "PUT"
@@ -250,7 +250,7 @@ func (api *SIMAPI) SetNetworkOperator(id int64, opConfig ...*sacloud.SIMNetworkO
 }
 
 // Monitor アクティビティーモニター(Up/Down link BPS)取得
-func (api *SIMAPI) Monitor(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *SIMAPI) Monitor(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/sim/metrics", api.getResourceURL(), id)

--- a/api/simple_monitor.go
+++ b/api/simple_monitor.go
@@ -112,21 +112,21 @@ func (api *SimpleMonitorAPI) Create(value *sacloud.SimpleMonitor) (*sacloud.Simp
 }
 
 // Read 読み取り
-func (api *SimpleMonitorAPI) Read(id int64) (*sacloud.SimpleMonitor, error) {
+func (api *SimpleMonitorAPI) Read(id sacloud.ID) (*sacloud.SimpleMonitor, error) {
 	return api.request(func(res *simpleMonitorResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *SimpleMonitorAPI) Update(id int64, value *sacloud.SimpleMonitor) (*sacloud.SimpleMonitor, error) {
+func (api *SimpleMonitorAPI) Update(id sacloud.ID, value *sacloud.SimpleMonitor) (*sacloud.SimpleMonitor, error) {
 	return api.request(func(res *simpleMonitorResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *SimpleMonitorAPI) Delete(id int64) (*sacloud.SimpleMonitor, error) {
+func (api *SimpleMonitorAPI) Delete(id sacloud.ID) (*sacloud.SimpleMonitor, error) {
 	return api.request(func(res *simpleMonitorResponse) error {
 		return api.delete(id, nil, res)
 	})
@@ -135,7 +135,7 @@ func (api *SimpleMonitorAPI) Delete(id int64) (*sacloud.SimpleMonitor, error) {
 // Health ヘルスチェック
 //
 // まだチェックが行われていない場合nilを返す
-func (api *SimpleMonitorAPI) Health(id int64) (*sacloud.SimpleMonitorHealthCheckStatus, error) {
+func (api *SimpleMonitorAPI) Health(id sacloud.ID) (*sacloud.SimpleMonitorHealthCheckStatus, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/health", api.getResourceURL(), id)
@@ -152,7 +152,7 @@ func (api *SimpleMonitorAPI) Health(id int64) (*sacloud.SimpleMonitorHealthCheck
 }
 
 // MonitorResponseTimeSec アクティビティーモニター(レスポンスタイム)取得
-func (api *SimpleMonitorAPI) MonitorResponseTimeSec(id int64, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *SimpleMonitorAPI) MonitorResponseTimeSec(id sacloud.ID, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/activity/responsetimesec/monitor", api.getResourceURL(), id)

--- a/api/ssh_key_gen.go
+++ b/api/ssh_key_gen.go
@@ -212,21 +212,21 @@ func (api *SSHKeyAPI) Create(value *sacloud.SSHKey) (*sacloud.SSHKey, error) {
 }
 
 // Read 読み取り
-func (api *SSHKeyAPI) Read(id int64) (*sacloud.SSHKey, error) {
+func (api *SSHKeyAPI) Read(id sacloud.ID) (*sacloud.SSHKey, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *SSHKeyAPI) Update(id int64, value *sacloud.SSHKey) (*sacloud.SSHKey, error) {
+func (api *SSHKeyAPI) Update(id sacloud.ID, value *sacloud.SSHKey) (*sacloud.SSHKey, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *SSHKeyAPI) Delete(id int64) (*sacloud.SSHKey, error) {
+func (api *SSHKeyAPI) Delete(id sacloud.ID) (*sacloud.SSHKey, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/subnet_gen.go
+++ b/api/subnet_gen.go
@@ -200,19 +200,19 @@ func (api *SubnetAPI) SetSortBy(key string, reverse bool) {
 //}
 
 // Read 読み取り
-func (api *SubnetAPI) Read(id int64) (*sacloud.Subnet, error) {
+func (api *SubnetAPI) Read(id sacloud.ID) (*sacloud.Subnet, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
-//func (api *SubnetAPI) Update(id int64, value *sacloud.Subnet) (*sacloud.Subnet, error) {
+//func (api *SubnetAPI) Update(id sacloud.ID, value *sacloud.Subnet) (*sacloud.Subnet, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.update(id, api.createRequest(value), res)
 //	})
 //}
 //
-//func (api *SubnetAPI) Delete(id int64) (*sacloud.Subnet, error) {
+//func (api *SubnetAPI) Delete(id sacloud.ID) (*sacloud.Subnet, error) {
 //	return api.request(func(res *sacloud.Response) error {
 //		return api.delete(id, nil, res)
 //	})

--- a/api/switch.go
+++ b/api/switch.go
@@ -38,7 +38,7 @@ func NewSwitchAPI(client *Client) *SwitchAPI {
 }
 
 // DisconnectFromBridge ブリッジとの切断
-func (api *SwitchAPI) DisconnectFromBridge(switchID int64) (bool, error) {
+func (api *SwitchAPI) DisconnectFromBridge(switchID sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/to/bridge", api.getResourceURL(), switchID)
@@ -47,7 +47,7 @@ func (api *SwitchAPI) DisconnectFromBridge(switchID int64) (bool, error) {
 }
 
 // ConnectToBridge ブリッジとの接続
-func (api *SwitchAPI) ConnectToBridge(switchID int64, bridgeID int64) (bool, error) {
+func (api *SwitchAPI) ConnectToBridge(switchID sacloud.ID, bridgeID sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/to/bridge/%d", api.getResourceURL(), switchID, bridgeID)
@@ -56,7 +56,7 @@ func (api *SwitchAPI) ConnectToBridge(switchID int64, bridgeID int64) (bool, err
 }
 
 // GetServers スイッチに接続されているサーバー一覧取得
-func (api *SwitchAPI) GetServers(switchID int64) ([]sacloud.Server, error) {
+func (api *SwitchAPI) GetServers(switchID sacloud.ID) ([]sacloud.Server, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/server", api.getResourceURL(), switchID)

--- a/api/switch_gen.go
+++ b/api/switch_gen.go
@@ -212,21 +212,21 @@ func (api *SwitchAPI) Create(value *sacloud.Switch) (*sacloud.Switch, error) {
 }
 
 // Read 読み取り
-func (api *SwitchAPI) Read(id int64) (*sacloud.Switch, error) {
+func (api *SwitchAPI) Read(id sacloud.ID) (*sacloud.Switch, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *SwitchAPI) Update(id int64, value *sacloud.Switch) (*sacloud.Switch, error) {
+func (api *SwitchAPI) Update(id sacloud.ID, value *sacloud.Switch) (*sacloud.Switch, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // Delete 削除
-func (api *SwitchAPI) Delete(id int64) (*sacloud.Switch, error) {
+func (api *SwitchAPI) Delete(id sacloud.ID) (*sacloud.Switch, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.delete(id, nil, res)
 	})

--- a/api/vpc_router.go
+++ b/api/vpc_router.go
@@ -126,21 +126,21 @@ func (api *VPCRouterAPI) Create(value *sacloud.VPCRouter) (*sacloud.VPCRouter, e
 }
 
 // Read 読み取り
-func (api *VPCRouterAPI) Read(id int64) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) Read(id sacloud.ID) (*sacloud.VPCRouter, error) {
 	return api.request(func(res *vpcRouterResponse) error {
 		return api.read(id, nil, res)
 	})
 }
 
 // Update 更新
-func (api *VPCRouterAPI) Update(id int64, value *sacloud.VPCRouter) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) Update(id sacloud.ID, value *sacloud.VPCRouter) (*sacloud.VPCRouter, error) {
 	return api.request(func(res *vpcRouterResponse) error {
 		return api.update(id, api.createRequest(value), res)
 	})
 }
 
 // UpdateSetting 設定更新
-func (api *VPCRouterAPI) UpdateSetting(id int64, value *sacloud.VPCRouter) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) UpdateSetting(id sacloud.ID, value *sacloud.VPCRouter) (*sacloud.VPCRouter, error) {
 	req := &sacloud.VPCRouter{
 		// Settings
 		Settings: value.Settings,
@@ -151,14 +151,14 @@ func (api *VPCRouterAPI) UpdateSetting(id int64, value *sacloud.VPCRouter) (*sac
 }
 
 // Delete 削除
-func (api *VPCRouterAPI) Delete(id int64) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) Delete(id sacloud.ID) (*sacloud.VPCRouter, error) {
 	return api.request(func(res *vpcRouterResponse) error {
 		return api.delete(id, nil, res)
 	})
 }
 
 // Config 設定変更の反映
-func (api *VPCRouterAPI) Config(id int64) (bool, error) {
+func (api *VPCRouterAPI) Config(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/config", api.getResourceURL(), id)
@@ -167,7 +167,7 @@ func (api *VPCRouterAPI) Config(id int64) (bool, error) {
 }
 
 // ConnectToSwitch 指定のインデックス位置のNICをスイッチへ接続
-func (api *VPCRouterAPI) ConnectToSwitch(id int64, switchID int64, nicIndex int) (bool, error) {
+func (api *VPCRouterAPI) ConnectToSwitch(id sacloud.ID, switchID sacloud.ID, nicIndex int) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/interface/%d/to/switch/%d", api.getResourceURL(), id, nicIndex, switchID)
@@ -176,7 +176,7 @@ func (api *VPCRouterAPI) ConnectToSwitch(id int64, switchID int64, nicIndex int)
 }
 
 // DisconnectFromSwitch 指定のインデックス位置のNICをスイッチから切断
-func (api *VPCRouterAPI) DisconnectFromSwitch(id int64, nicIndex int) (bool, error) {
+func (api *VPCRouterAPI) DisconnectFromSwitch(id sacloud.ID, nicIndex int) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/interface/%d/to/switch", api.getResourceURL(), id, nicIndex)
@@ -185,7 +185,7 @@ func (api *VPCRouterAPI) DisconnectFromSwitch(id int64, nicIndex int) (bool, err
 }
 
 // IsUp 起動しているか判定
-func (api *VPCRouterAPI) IsUp(id int64) (bool, error) {
+func (api *VPCRouterAPI) IsUp(id sacloud.ID) (bool, error) {
 	router, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -194,7 +194,7 @@ func (api *VPCRouterAPI) IsUp(id int64) (bool, error) {
 }
 
 // IsDown ダウンしているか判定
-func (api *VPCRouterAPI) IsDown(id int64) (bool, error) {
+func (api *VPCRouterAPI) IsDown(id sacloud.ID) (bool, error) {
 	router, err := api.Read(id)
 	if err != nil {
 		return false, err
@@ -203,7 +203,7 @@ func (api *VPCRouterAPI) IsDown(id int64) (bool, error) {
 }
 
 // Boot 起動
-func (api *VPCRouterAPI) Boot(id int64) (bool, error) {
+func (api *VPCRouterAPI) Boot(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -212,7 +212,7 @@ func (api *VPCRouterAPI) Boot(id int64) (bool, error) {
 }
 
 // Shutdown シャットダウン(graceful)
-func (api *VPCRouterAPI) Shutdown(id int64) (bool, error) {
+func (api *VPCRouterAPI) Shutdown(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -222,7 +222,7 @@ func (api *VPCRouterAPI) Shutdown(id int64) (bool, error) {
 }
 
 // Stop シャットダウン(force)
-func (api *VPCRouterAPI) Stop(id int64) (bool, error) {
+func (api *VPCRouterAPI) Stop(id sacloud.ID) (bool, error) {
 	var (
 		method = "DELETE"
 		uri    = fmt.Sprintf("%s/%d/power", api.getResourceURL(), id)
@@ -232,7 +232,7 @@ func (api *VPCRouterAPI) Stop(id int64) (bool, error) {
 }
 
 // RebootForce 再起動
-func (api *VPCRouterAPI) RebootForce(id int64) (bool, error) {
+func (api *VPCRouterAPI) RebootForce(id sacloud.ID) (bool, error) {
 	var (
 		method = "PUT"
 		uri    = fmt.Sprintf("%s/%d/reset", api.getResourceURL(), id)
@@ -242,7 +242,7 @@ func (api *VPCRouterAPI) RebootForce(id int64) (bool, error) {
 }
 
 // SleepUntilUp 起動するまで待機
-func (api *VPCRouterAPI) SleepUntilUp(id int64, timeout time.Duration) error {
+func (api *VPCRouterAPI) SleepUntilUp(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForUpFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -250,7 +250,7 @@ func (api *VPCRouterAPI) SleepUntilUp(id int64, timeout time.Duration) error {
 }
 
 // SleepUntilDown ダウンするまで待機
-func (api *VPCRouterAPI) SleepUntilDown(id int64, timeout time.Duration) error {
+func (api *VPCRouterAPI) SleepUntilDown(id sacloud.ID, timeout time.Duration) error {
 	handler := waitingForDownFunc(func() (hasUpDown, error) {
 		return api.Read(id)
 	}, 0)
@@ -261,7 +261,7 @@ func (api *VPCRouterAPI) SleepUntilDown(id int64, timeout time.Duration) error {
 //
 // maxRetry: リクエストタイミングによって、コピー完了までの間に404エラーとなる場合がある。
 // 通常そのまま待てばコピー完了するため、404エラーが発生してもmaxRetryで指定した回数分は待機する。
-func (api *VPCRouterAPI) SleepWhileCopying(id int64, timeout time.Duration, maxRetry int) error {
+func (api *VPCRouterAPI) SleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) error {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -269,7 +269,7 @@ func (api *VPCRouterAPI) SleepWhileCopying(id int64, timeout time.Duration, maxR
 }
 
 // AsyncSleepWhileCopying コピー終了まで待機(非同期)
-func (api *VPCRouterAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
+func (api *VPCRouterAPI) AsyncSleepWhileCopying(id sacloud.ID, timeout time.Duration, maxRetry int) (chan (interface{}), chan (interface{}), chan (error)) {
 	handler := waitingForAvailableFunc(func() (hasAvailable, error) {
 		return api.Read(id)
 	}, maxRetry)
@@ -277,7 +277,7 @@ func (api *VPCRouterAPI) AsyncSleepWhileCopying(id int64, timeout time.Duration,
 }
 
 // AddStandardInterface スタンダードプランでのインターフェース追加
-func (api *VPCRouterAPI) AddStandardInterface(routerID int64, switchID int64, ipaddress string, maskLen int) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) AddStandardInterface(routerID sacloud.ID, switchID sacloud.ID, ipaddress string, maskLen int) (*sacloud.VPCRouter, error) {
 	return api.addInterface(routerID, switchID, &sacloud.VPCRouterInterface{
 		IPAddress:        []string{ipaddress},
 		NetworkMaskLen:   maskLen,
@@ -286,7 +286,7 @@ func (api *VPCRouterAPI) AddStandardInterface(routerID int64, switchID int64, ip
 }
 
 // AddPremiumInterface プレミアムプランでのインターフェース追加
-func (api *VPCRouterAPI) AddPremiumInterface(routerID int64, switchID int64, ipaddresses []string, maskLen int, virtualIP string) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) AddPremiumInterface(routerID sacloud.ID, switchID sacloud.ID, ipaddresses []string, maskLen int, virtualIP string) (*sacloud.VPCRouter, error) {
 	return api.addInterface(routerID, switchID, &sacloud.VPCRouterInterface{
 		IPAddress:        ipaddresses,
 		NetworkMaskLen:   maskLen,
@@ -294,7 +294,7 @@ func (api *VPCRouterAPI) AddPremiumInterface(routerID int64, switchID int64, ipa
 	})
 }
 
-func (api *VPCRouterAPI) addInterface(routerID int64, switchID int64, routerNIC *sacloud.VPCRouterInterface) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) addInterface(routerID sacloud.ID, switchID sacloud.ID, routerNIC *sacloud.VPCRouterInterface) (*sacloud.VPCRouter, error) {
 	router, err := api.Read(routerID)
 	if err != nil {
 		return nil, err
@@ -316,7 +316,7 @@ func (api *VPCRouterAPI) addInterface(routerID int64, switchID int64, routerNIC 
 }
 
 // AddStandardInterfaceAt スタンダードプランでの指定位置へのインターフェース追加
-func (api *VPCRouterAPI) AddStandardInterfaceAt(routerID int64, switchID int64, ipaddress string, maskLen int, index int) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) AddStandardInterfaceAt(routerID sacloud.ID, switchID sacloud.ID, ipaddress string, maskLen int, index int) (*sacloud.VPCRouter, error) {
 	return api.addInterfaceAt(routerID, switchID, &sacloud.VPCRouterInterface{
 		IPAddress:        []string{ipaddress},
 		NetworkMaskLen:   maskLen,
@@ -325,7 +325,7 @@ func (api *VPCRouterAPI) AddStandardInterfaceAt(routerID int64, switchID int64, 
 }
 
 // AddPremiumInterfaceAt プレミアムプランでの指定位置へのインターフェース追加
-func (api *VPCRouterAPI) AddPremiumInterfaceAt(routerID int64, switchID int64, ipaddresses []string, maskLen int, virtualIP string, index int) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) AddPremiumInterfaceAt(routerID sacloud.ID, switchID sacloud.ID, ipaddresses []string, maskLen int, virtualIP string, index int) (*sacloud.VPCRouter, error) {
 	return api.addInterfaceAt(routerID, switchID, &sacloud.VPCRouterInterface{
 		IPAddress:        ipaddresses,
 		NetworkMaskLen:   maskLen,
@@ -333,7 +333,7 @@ func (api *VPCRouterAPI) AddPremiumInterfaceAt(routerID int64, switchID int64, i
 	}, index)
 }
 
-func (api *VPCRouterAPI) addInterfaceAt(routerID int64, switchID int64, routerNIC *sacloud.VPCRouterInterface, index int) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) addInterfaceAt(routerID sacloud.ID, switchID sacloud.ID, routerNIC *sacloud.VPCRouterInterface, index int) (*sacloud.VPCRouter, error) {
 	router, err := api.Read(routerID)
 	if err != nil {
 		return nil, err
@@ -379,7 +379,7 @@ func (api *VPCRouterAPI) addInterfaceAt(routerID int64, switchID int64, routerNI
 }
 
 // DeleteInterfaceAt 指定位置のインターフェース削除
-func (api *VPCRouterAPI) DeleteInterfaceAt(routerID int64, index int) (*sacloud.VPCRouter, error) {
+func (api *VPCRouterAPI) DeleteInterfaceAt(routerID sacloud.ID, index int) (*sacloud.VPCRouter, error) {
 	router, err := api.Read(routerID)
 	if err != nil {
 		return nil, err
@@ -419,12 +419,12 @@ func (api *VPCRouterAPI) DeleteInterfaceAt(routerID int64, index int) (*sacloud.
 }
 
 // MonitorBy 指定位置のインターフェースのアクティビティーモニター取得
-func (api *VPCRouterAPI) MonitorBy(id int64, nicIndex int, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
+func (api *VPCRouterAPI) MonitorBy(id sacloud.ID, nicIndex int, body *sacloud.ResourceMonitorRequest) (*sacloud.MonitorValues, error) {
 	return api.baseAPI.applianceMonitorBy(id, "interface", nicIndex, body)
 }
 
 // Status ログなどのステータス情報 取得
-func (api *VPCRouterAPI) Status(id int64) (*sacloud.VPCRouterStatus, error) {
+func (api *VPCRouterAPI) Status(id sacloud.ID) (*sacloud.VPCRouterStatus, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/status", api.getResourceURL(), id)
@@ -438,7 +438,7 @@ func (api *VPCRouterAPI) Status(id int64) (*sacloud.VPCRouterStatus, error) {
 }
 
 // SiteToSiteConnectionDetails サイト間VPN接続情報を取得
-func (api *VPCRouterAPI) SiteToSiteConnectionDetails(id int64) (*sacloud.SiteToSiteConnectionInfo, error) {
+func (api *VPCRouterAPI) SiteToSiteConnectionDetails(id sacloud.ID) (*sacloud.SiteToSiteConnectionInfo, error) {
 	var (
 		method = "GET"
 		uri    = fmt.Sprintf("%s/%d/vpcrouter/sitetosite/connectiondetails", api.getResourceURL(), id)

--- a/api/webaccel.go
+++ b/api/webaccel.go
@@ -66,7 +66,7 @@ func (api *WebAccelAPI) Read(id string) (*sacloud.WebAccelSite, error) {
 }
 
 // ReadCertificate 証明書 参照
-func (api *WebAccelAPI) ReadCertificate(id string) (*sacloud.WebAccelCertResponseBody, error) {
+func (api *WebAccelAPI) ReadCertificate(id sacloud.ID) (*sacloud.WebAccelCertResponseBody, error) {
 	uri := fmt.Sprintf("%s/site/%s/certificate", api.getResourceURL(), id)
 
 	data, err := api.client.newRequest("GET", uri, nil)
@@ -82,7 +82,7 @@ func (api *WebAccelAPI) ReadCertificate(id string) (*sacloud.WebAccelCertRespons
 }
 
 // CreateCertificate 証明書 更新
-func (api *WebAccelAPI) CreateCertificate(id string, request *sacloud.WebAccelCertRequest) (*sacloud.WebAccelCertResponse, error) {
+func (api *WebAccelAPI) CreateCertificate(id sacloud.ID, request *sacloud.WebAccelCertRequest) (*sacloud.WebAccelCertResponse, error) {
 	uri := fmt.Sprintf("%s/site/%s/certificate", api.getResourceURL(), id)
 
 	if request.CertificateChain != "" {
@@ -107,7 +107,7 @@ func (api *WebAccelAPI) CreateCertificate(id string, request *sacloud.WebAccelCe
 }
 
 // UpdateCertificate 証明書 更新
-func (api *WebAccelAPI) UpdateCertificate(id string, request *sacloud.WebAccelCertRequest) (*sacloud.WebAccelCertResponse, error) {
+func (api *WebAccelAPI) UpdateCertificate(id sacloud.ID, request *sacloud.WebAccelCertRequest) (*sacloud.WebAccelCertResponse, error) {
 	uri := fmt.Sprintf("%s/site/%s/certificate", api.getResourceURL(), id)
 
 	if request.CertificateChain != "" {

--- a/api/zone_gen.go
+++ b/api/zone_gen.go
@@ -210,7 +210,7 @@ func (api *ZoneAPI) SetSortByName(reverse bool) {
 // }
 
 // Read 読み取り
-func (api *ZoneAPI) Read(id int64) (*sacloud.Zone, error) {
+func (api *ZoneAPI) Read(id sacloud.ID) (*sacloud.Zone, error) {
 	return api.request(func(res *sacloud.Response) error {
 		return api.read(id, nil, res)
 	})

--- a/builder/api_client.go
+++ b/builder/api_client.go
@@ -25,30 +25,30 @@ import (
 // APIClient represents SAKURA CLOUD api client
 type APIClient interface {
 	ServerNew() *sacloud.Server
-	ServerRead(serverID int64) (*sacloud.Server, error)
+	ServerRead(serverID sacloud.ID) (*sacloud.Server, error)
 	ServerCreate(value *sacloud.Server) (*sacloud.Server, error)
-	ServerSleepUntilUp(serverID int64, timeout time.Duration) error
-	ServerInsertCDROM(serverID int64, cdromID int64) (bool, error)
-	ServerBoot(serverID int64) (bool, error)
+	ServerSleepUntilUp(serverID sacloud.ID, timeout time.Duration) error
+	ServerInsertCDROM(serverID sacloud.ID, cdromID sacloud.ID) (bool, error)
+	ServerBoot(serverID sacloud.ID) (bool, error)
 
 	SSHKeyNew() *sacloud.SSHKey
 	SSHKeyCreate(value *sacloud.SSHKey) (*sacloud.SSHKey, error)
-	SSHKeyDelete(sshKeyID int64) (*sacloud.SSHKey, error)
+	SSHKeyDelete(sshKeyID sacloud.ID) (*sacloud.SSHKey, error)
 	SSHKeyGenerate(name string, passPhrase string, desc string) (*sacloud.SSHKeyGenerated, error)
 
 	NoteNew() *sacloud.Note
 	NoteCreate(value *sacloud.Note) (*sacloud.Note, error)
-	NoteDelete(noteID int64) (*sacloud.Note, error)
+	NoteDelete(noteID sacloud.ID) (*sacloud.Note, error)
 
 	DiskNew() *sacloud.Disk
 	DiskNewCondig() *sacloud.DiskEditValue
 	DiskCreate(value *sacloud.Disk) (*sacloud.Disk, error)
 	DiskCreateWithConfig(value *sacloud.Disk, config *sacloud.DiskEditValue, bootAtAvailable bool) (*sacloud.Disk, error)
-	DiskSleepWhileCopying(id int64, timeout time.Duration) error
-	DiskConnectToServer(diskID int64, serverID int64) (bool, error)
+	DiskSleepWhileCopying(id sacloud.ID, timeout time.Duration) error
+	DiskConnectToServer(diskID sacloud.ID, serverID sacloud.ID) (bool, error)
 
-	InterfaceConnectToPacketFilter(interfaceID int64, packetFilterID int64) (bool, error)
-	InterfaceSetDisplayIPAddress(interfaceID int64, ip string) (bool, error) // Interface
+	InterfaceConnectToPacketFilter(interfaceID sacloud.ID, packetFilterID sacloud.ID) (bool, error)
+	InterfaceSetDisplayIPAddress(interfaceID sacloud.ID, ip string) (bool, error) // Interface
 
 	ServerPlanGetBySpec(core, memGB int, gen sacloud.PlanGenerations, commitment sacloud.ECommitment) (*sacloud.ProductServer, error)
 
@@ -70,7 +70,7 @@ func (a *apiClient) ServerNew() *sacloud.Server {
 	return a.client.Server.New()
 }
 
-func (a *apiClient) ServerRead(serverID int64) (*sacloud.Server, error) {
+func (a *apiClient) ServerRead(serverID sacloud.ID) (*sacloud.Server, error) {
 	return a.client.Server.Read(serverID)
 }
 
@@ -78,15 +78,15 @@ func (a *apiClient) ServerCreate(value *sacloud.Server) (*sacloud.Server, error)
 	return a.client.Server.Create(value)
 }
 
-func (a *apiClient) ServerSleepUntilUp(serverID int64, timeout time.Duration) error {
+func (a *apiClient) ServerSleepUntilUp(serverID sacloud.ID, timeout time.Duration) error {
 	return a.client.Server.SleepUntilUp(serverID, timeout)
 }
 
-func (a *apiClient) ServerInsertCDROM(serverID int64, cdromID int64) (bool, error) {
+func (a *apiClient) ServerInsertCDROM(serverID sacloud.ID, cdromID sacloud.ID) (bool, error) {
 	return a.client.Server.InsertCDROM(serverID, cdromID)
 }
 
-func (a *apiClient) ServerBoot(serverID int64) (bool, error) {
+func (a *apiClient) ServerBoot(serverID sacloud.ID) (bool, error) {
 	return a.client.Server.Boot(serverID)
 }
 
@@ -98,7 +98,7 @@ func (a *apiClient) SSHKeyCreate(value *sacloud.SSHKey) (*sacloud.SSHKey, error)
 	return a.client.SSHKey.Create(value)
 }
 
-func (a *apiClient) SSHKeyDelete(sshKeyID int64) (*sacloud.SSHKey, error) {
+func (a *apiClient) SSHKeyDelete(sshKeyID sacloud.ID) (*sacloud.SSHKey, error) {
 	return a.client.SSHKey.Delete(sshKeyID)
 }
 
@@ -114,7 +114,7 @@ func (a *apiClient) NoteCreate(value *sacloud.Note) (*sacloud.Note, error) {
 	return a.client.Note.Create(value)
 }
 
-func (a *apiClient) NoteDelete(noteID int64) (*sacloud.Note, error) {
+func (a *apiClient) NoteDelete(noteID sacloud.ID) (*sacloud.Note, error) {
 	return a.client.Note.Delete(noteID)
 }
 
@@ -137,19 +137,19 @@ func (a *apiClient) DiskCreateWithConfig(
 	return a.client.Disk.CreateWithConfig(value, config, bootAtAvailable)
 }
 
-func (a *apiClient) DiskSleepWhileCopying(id int64, timeout time.Duration) error {
+func (a *apiClient) DiskSleepWhileCopying(id sacloud.ID, timeout time.Duration) error {
 	return a.client.Disk.SleepWhileCopying(id, timeout)
 }
 
-func (a *apiClient) DiskConnectToServer(diskID int64, serverID int64) (bool, error) {
+func (a *apiClient) DiskConnectToServer(diskID sacloud.ID, serverID sacloud.ID) (bool, error) {
 	return a.client.Disk.ConnectToServer(diskID, serverID)
 }
 
-func (a *apiClient) InterfaceConnectToPacketFilter(interfaceID int64, packetFilterID int64) (bool, error) {
+func (a *apiClient) InterfaceConnectToPacketFilter(interfaceID sacloud.ID, packetFilterID sacloud.ID) (bool, error) {
 	return a.client.Interface.ConnectToPacketFilter(interfaceID, packetFilterID)
 }
 
-func (a *apiClient) InterfaceSetDisplayIPAddress(interfaceID int64, ip string) (bool, error) {
+func (a *apiClient) InterfaceSetDisplayIPAddress(interfaceID sacloud.ID, ip string) (bool, error) {
 	return a.client.Interface.SetDisplayIPAddress(interfaceID, ip)
 }
 

--- a/builder/base_builder.go
+++ b/builder/base_builder.go
@@ -16,6 +16,7 @@ package builder
 
 import (
 	"fmt"
+	"github.com/sacloud/libsacloud/sacloud"
 	"strings"
 )
 
@@ -24,10 +25,10 @@ type baseBuilder struct {
 	errors []error
 }
 
-func (b *baseBuilder) toStringList(values []int64) []string {
-	keys := []string{}
+func (b *baseBuilder) toStringList(values []sacloud.ID) []string {
+	var keys []string
 	for _, k := range values {
-		keys = append(keys, fmt.Sprintf("%d", k))
+		keys = append(keys, k.String())
 	}
 	return keys
 }

--- a/builder/disk.go
+++ b/builder/disk.go
@@ -80,15 +80,15 @@ type DiskBuilder struct {
 
 	name            string
 	size            int
-	distantFrom     []int64
+	distantFrom     []sacloud.ID
 	planID          sacloud.DiskPlanID
 	connection      sacloud.EDiskConnection
-	sourceArchiveID int64
-	sourceDiskID    int64
+	sourceArchiveID sacloud.ID
+	sourceDiskID    sacloud.ID
 	description     string
 	tags            []string
-	iconID          int64
-	serverID        int64
+	iconID          sacloud.ID
+	serverID        sacloud.ID
 
 	ipAddress          string
 	networkMaskLen     int
@@ -98,10 +98,10 @@ type DiskBuilder struct {
 	disablePWAuth      bool
 	sshKeys            []string
 	isSSHKeysEphemeral bool
-	sshKeyIDs          []int64
+	sshKeyIDs          []sacloud.ID
 	notes              []string
 	isNotesEphemeral   bool
-	noteIDs            []int64
+	noteIDs            []sacloud.ID
 
 	// for sshkey generate
 	generateSSHKeyName        string
@@ -166,24 +166,24 @@ func (b *DiskBuilder) SetSize(size int) {
 }
 
 // GetDistantFrom ストレージ隔離対象ディスク 取得
-func (b *DiskBuilder) GetDistantFrom() []int64 {
+func (b *DiskBuilder) GetDistantFrom() []sacloud.ID {
 	return b.distantFrom
 }
 
 // SetDistantFrom ストレージ隔離対象ディスク 設定
-func (b *DiskBuilder) SetDistantFrom(diskIDs []int64) {
+func (b *DiskBuilder) SetDistantFrom(diskIDs []sacloud.ID) {
 	b.distantFrom = diskIDs
 }
 
 // AddDistantFrom ストレージ隔離対象ディスク 追加
-func (b *DiskBuilder) AddDistantFrom(diskID int64) *DiskBuilder {
+func (b *DiskBuilder) AddDistantFrom(diskID sacloud.ID) *DiskBuilder {
 	b.distantFrom = append(b.distantFrom, diskID)
 	return b
 }
 
 // ClearDistantFrom ストレージ隔離対象ディスク クリア
 func (b *DiskBuilder) ClearDistantFrom() {
-	b.distantFrom = []int64{}
+	b.distantFrom = []sacloud.ID{}
 }
 
 // GetPlanID ディスクプラン(SSD/HDD) 取得
@@ -219,23 +219,23 @@ func (b *DiskBuilder) SetConnection(connection sacloud.EDiskConnection) {
 }
 
 // GetSourceArchiveID ソースアーカイブID 取得
-func (b *DiskBuilder) GetSourceArchiveID() int64 {
+func (b *DiskBuilder) GetSourceArchiveID() sacloud.ID {
 	return b.sourceArchiveID
 }
 
 // SetSourceArchiveID ソースアーカイブID 設定
-func (b *DiskBuilder) SetSourceArchiveID(id int64) {
+func (b *DiskBuilder) SetSourceArchiveID(id sacloud.ID) {
 	b.sourceArchiveID = id
 	b.sourceDiskID = 0
 }
 
 // GetSourceDiskID ソースディスクID 取得
-func (b *DiskBuilder) GetSourceDiskID() int64 {
+func (b *DiskBuilder) GetSourceDiskID() sacloud.ID {
 	return b.sourceDiskID
 }
 
 // SetSourceDiskID ソースディスクID 設定
-func (b *DiskBuilder) SetSourceDiskID(id int64) {
+func (b *DiskBuilder) SetSourceDiskID(id sacloud.ID) {
 	b.sourceArchiveID = 0
 	b.sourceDiskID = id
 }
@@ -261,22 +261,22 @@ func (b *DiskBuilder) SetTags(tags []string) {
 }
 
 // GetIconID アイコンID 取得
-func (b *DiskBuilder) GetIconID() int64 {
+func (b *DiskBuilder) GetIconID() sacloud.ID {
 	return b.iconID
 }
 
 // SetIconID アイコンID 設定
-func (b *DiskBuilder) SetIconID(id int64) {
+func (b *DiskBuilder) SetIconID(id sacloud.ID) {
 	b.iconID = id
 }
 
 // GetServerID サーバーID 取得
-func (b *DiskBuilder) GetServerID() int64 {
+func (b *DiskBuilder) GetServerID() sacloud.ID {
 	return b.serverID
 }
 
 // SetServerID サーバーID 設定
-func (b *DiskBuilder) SetServerID(id int64) {
+func (b *DiskBuilder) SetServerID(id sacloud.ID) {
 	b.serverID = id
 }
 
@@ -341,17 +341,17 @@ func (b *DiskBuilder) SetDisablePWAuth(disable bool) {
 }
 
 // AddSSHKeyID 公開鍵ID 追加
-func (b *DiskBuilder) AddSSHKeyID(sshKeyID int64) {
+func (b *DiskBuilder) AddSSHKeyID(sshKeyID sacloud.ID) {
 	b.sshKeyIDs = append(b.sshKeyIDs, sshKeyID)
 }
 
 // ClearSSHKeyIDs 公開鍵ID クリア
 func (b *DiskBuilder) ClearSSHKeyIDs() {
-	b.sshKeyIDs = []int64{}
+	b.sshKeyIDs = []sacloud.ID{}
 }
 
 // GetSSHKeyIds 公開鍵ID 取得
-func (b *DiskBuilder) GetSSHKeyIds() []int64 {
+func (b *DiskBuilder) GetSSHKeyIds() []sacloud.ID {
 	return b.sshKeyIDs
 }
 
@@ -386,17 +386,17 @@ func (b *DiskBuilder) GetNotes() []string {
 }
 
 // AddNoteID スタートアップスクリプトID 追加
-func (b *DiskBuilder) AddNoteID(noteID int64) {
+func (b *DiskBuilder) AddNoteID(noteID sacloud.ID) {
 	b.noteIDs = append(b.noteIDs, noteID)
 }
 
 // ClearNoteIDs スタートアップスクリプトID クリア
 func (b *DiskBuilder) ClearNoteIDs() {
-	b.noteIDs = []int64{}
+	b.noteIDs = []sacloud.ID{}
 }
 
 // GetNoteIDs スタートアップスクリプトID 取得
-func (b *DiskBuilder) GetNoteIDs() []int64 {
+func (b *DiskBuilder) GetNoteIDs() []sacloud.ID {
 	return b.noteIDs
 }
 

--- a/builder/factory.go
+++ b/builder/factory.go
@@ -16,6 +16,7 @@ package builder
 
 import (
 	"fmt"
+	"github.com/sacloud/libsacloud/sacloud"
 
 	"github.com/sacloud/libsacloud/sacloud/ostype"
 )
@@ -90,18 +91,18 @@ func ServerBlankDisk(client APIClient, name string) BlankDiskServerBuilder {
 }
 
 // ServerFromExistsDisk 既存ディスクを接続するビルダー
-func ServerFromExistsDisk(client APIClient, name string, sourceDiskID int64) ConnectDiskServerBuilder {
+func ServerFromExistsDisk(client APIClient, name string, sourceDiskID sacloud.ID) ConnectDiskServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
 	b.hasAdditionalDiskProperty = true
 
-	b.connectDiskIDs = []int64{sourceDiskID}
+	b.connectDiskIDs = []sacloud.ID{sourceDiskID}
 	return b
 }
 
 // ServerFromDisk 既存ディスクをコピーして新たなディスクを作成するビルダー
-func ServerFromDisk(client APIClient, name string, sourceDiskID int64) CommonServerBuilder {
+func ServerFromDisk(client APIClient, name string, sourceDiskID sacloud.ID) CommonServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -117,7 +118,7 @@ func ServerFromDisk(client APIClient, name string, sourceDiskID int64) CommonSer
 }
 
 // ServerFromArchive 既存アーカイブをコピーして新たなディスクを作成するビルダー
-func ServerFromArchive(client APIClient, name string, sourceArchiveID int64) CommonServerBuilder {
+func ServerFromArchive(client APIClient, name string, sourceArchiveID sacloud.ID) CommonServerBuilder {
 	b := newServerBuilder(client, name)
 	b.hasCommonProperty = true
 	b.hasNetworkInterfaceProperty = true
@@ -174,13 +175,13 @@ func (b *serverBuilder) serverPublicArchiveWindows(os ostype.ArchiveOSTypes) {
 	b.disk.forceEditDisk = true
 }
 
-func (b *serverBuilder) serverFromDisk(sourceDiskID int64) {
+func (b *serverBuilder) serverFromDisk(sourceDiskID sacloud.ID) {
 	b.disk = Disk(b.client, b.serverName)
 	b.disk.sourceArchiveID = 0
 	b.disk.sourceDiskID = sourceDiskID
 }
 
-func (b *serverBuilder) serverFromArchive(sourceArchiveID int64) {
+func (b *serverBuilder) serverFromArchive(sourceArchiveID sacloud.ID) {
 
 	b.disk = Disk(b.client, b.serverName)
 	b.disk.sourceArchiveID = sourceArchiveID

--- a/builder/server.go
+++ b/builder/server.go
@@ -35,28 +35,28 @@ type serverBuilder struct {
 	commitment      sacloud.ECommitment
 	interfaceDriver sacloud.EInterfaceDriver
 	description     string
-	iconID          int64
+	iconID          sacloud.ID
 	tags            []string
 	bootAfterCreate bool
 
 	// CDROM
-	isoImageID int64
+	isoImageID sacloud.ID
 
 	// privateHost
-	privateHostID int64
+	privateHostID sacloud.ID
 
 	// for nic
 	nicConnections     []string
 	displayIPAddresses []string
 
 	// for PacketFilter
-	packetFilterIDs []int64
+	packetFilterIDs []sacloud.ID
 
 	// for disks
 	disk            *DiskBuilder
 	additionalDisks []*DiskBuilder
 
-	connectDiskIDs []int64
+	connectDiskIDs []sacloud.ID
 
 	currentBuildValue  *ServerBuildValue
 	currentBuildResult *ServerBuildResult
@@ -434,22 +434,22 @@ func (b *serverBuilder) SetDescription(description string) {
 }
 
 // GetIconID アイコンID 取得
-func (b *serverBuilder) GetIconID() int64 {
+func (b *serverBuilder) GetIconID() sacloud.ID {
 	return b.iconID
 }
 
 // SetIconID アイコンID 設定
-func (b *serverBuilder) SetIconID(iconID int64) {
+func (b *serverBuilder) SetIconID(iconID sacloud.ID) {
 	b.iconID = iconID
 }
 
 // GetPrivateHostID 専有ホストID 取得
-func (b *serverBuilder) GetPrivateHostID() int64 {
+func (b *serverBuilder) GetPrivateHostID() sacloud.ID {
 	return b.privateHostID
 }
 
 // SetPrivateHostID 専有ホストID 設定
-func (b *serverBuilder) SetPrivateHostID(privateHostID int64) {
+func (b *serverBuilder) SetPrivateHostID(privateHostID sacloud.ID) {
 	b.privateHostID = privateHostID
 }
 
@@ -474,12 +474,12 @@ func (b *serverBuilder) SetTags(tags []string) {
 }
 
 // GetISOImageID ISOイメージ(CDROM)ID 取得
-func (b *serverBuilder) GetISOImageID() int64 {
+func (b *serverBuilder) GetISOImageID() sacloud.ID {
 	return b.isoImageID
 }
 
 // SetISOImageID ISOイメージ(CDROM)ID 設定
-func (b *serverBuilder) SetISOImageID(id int64) {
+func (b *serverBuilder) SetISOImageID(id sacloud.ID) {
 	b.isoImageID = id
 }
 
@@ -520,12 +520,12 @@ func (b *serverBuilder) AddDisconnectedNIC() {
 }
 
 // GetPacketFilterIDs パケットフィルタID 取得
-func (b *serverBuilder) GetPacketFilterIDs() []int64 {
+func (b *serverBuilder) GetPacketFilterIDs() []sacloud.ID {
 	return b.packetFilterIDs
 }
 
 // SetPacketFilterIDs パケットフィルタID 設定
-func (b *serverBuilder) SetPacketFilterIDs(ids []int64) {
+func (b *serverBuilder) SetPacketFilterIDs(ids []sacloud.ID) {
 	b.packetFilterIDs = ids
 }
 
@@ -544,17 +544,17 @@ func (b *serverBuilder) SetDiskSize(diskSize int) {
 }
 
 // GetDistantFrom ストレージ隔離対象ディスク 取得
-func (b *serverBuilder) GetDistantFrom() []int64 {
+func (b *serverBuilder) GetDistantFrom() []sacloud.ID {
 	return b.disk.GetDistantFrom()
 }
 
 // SetDistantFrom ストレージ隔離対象ディスク 設定
-func (b *serverBuilder) SetDistantFrom(distantFrom []int64) {
+func (b *serverBuilder) SetDistantFrom(distantFrom []sacloud.ID) {
 	b.disk.SetDistantFrom(distantFrom)
 }
 
 // AddDistantFrom ストレージ隔離対象ディスク 追加
-func (b *serverBuilder) AddDistantFrom(diskID int64) {
+func (b *serverBuilder) AddDistantFrom(diskID sacloud.ID) {
 	b.disk.AddDistantFrom(diskID)
 }
 
@@ -593,12 +593,12 @@ func (b *serverBuilder) SetDiskConnection(diskConnection sacloud.EDiskConnection
 ---------------------------------------------------------*/
 
 // GetSourceArchiveID ソースアーカイブID 取得
-func (b *serverBuilder) GetSourceArchiveID() int64 {
+func (b *serverBuilder) GetSourceArchiveID() sacloud.ID {
 	return b.disk.GetSourceArchiveID()
 }
 
 // GetSourceDiskID ソースディスクID 設定
-func (b *serverBuilder) GetSourceDiskID() int64 {
+func (b *serverBuilder) GetSourceDiskID() sacloud.ID {
 	return b.disk.GetSourceDiskID()
 }
 
@@ -678,7 +678,7 @@ func (b *serverBuilder) GetSSHKeys() []string {
 }
 
 // AddSSHKeyID 公開鍵ID 追加
-func (b *serverBuilder) AddSSHKeyID(sshKeyID int64) {
+func (b *serverBuilder) AddSSHKeyID(sshKeyID sacloud.ID) {
 	b.disk.AddSSHKeyID(sshKeyID)
 }
 
@@ -688,7 +688,7 @@ func (b *serverBuilder) ClearSSHKeyIDs() {
 }
 
 // GetSSHKeyIds 公開鍵ID 取得
-func (b *serverBuilder) GetSSHKeyIds() []int64 {
+func (b *serverBuilder) GetSSHKeyIds() []sacloud.ID {
 	return b.disk.GetSSHKeyIds()
 }
 
@@ -708,7 +708,7 @@ func (b *serverBuilder) GetNotes() []string {
 }
 
 // AddNoteID スタートアップスクリプト 追加
-func (b *serverBuilder) AddNoteID(noteID int64) {
+func (b *serverBuilder) AddNoteID(noteID sacloud.ID) {
 	b.disk.AddNoteID(noteID)
 }
 
@@ -718,7 +718,7 @@ func (b *serverBuilder) ClearNoteIDs() {
 }
 
 // GetNoteIDs スタートアップスクリプトID 取得
-func (b *serverBuilder) GetNoteIDs() []int64 {
+func (b *serverBuilder) GetNoteIDs() []sacloud.ID {
 	return b.disk.GetNoteIDs()
 }
 

--- a/builder/server_test.go
+++ b/builder/server_test.go
@@ -129,7 +129,7 @@ func TestServerBuilder_Build_WithPacketFilter(t *testing.T) {
 	assert.NoError(t, err)
 
 	builder.AddPublicNWConnectedNIC()
-	builder.SetPacketFilterIDs([]int64{pf.ID})
+	builder.SetPacketFilterIDs([]sacloud.ID{pf.ID})
 	res, err := builder.Build()
 
 	assert.NoError(t, err)

--- a/builder/types.go
+++ b/builder/types.go
@@ -26,7 +26,7 @@ const (
 	// DefaultDescription 説明 (デフォルト値)
 	DefaultDescription = ""
 	// DefaultIconID アイコンID(デフォルト値)
-	DefaultIconID = int64(0)
+	DefaultIconID = sacloud.EmptyID
 	// DefaultBootAfterCreate サーバー作成後すぐに起動フラグ(デフォルト値)
 	DefaultBootAfterCreate = true
 )
@@ -106,14 +106,14 @@ type CommonProperty interface {
 	SetDescription(description string)
 
 	// GetIconID アイコンID 取得
-	GetIconID() int64
+	GetIconID() sacloud.ID
 	// SetIconID アイコンID 設定
-	SetIconID(iconID int64)
+	SetIconID(iconID sacloud.ID)
 
 	// GetPrivateHostID アイコンID 取得
-	GetPrivateHostID() int64
+	GetPrivateHostID() sacloud.ID
 	// SetPrivateHostID アイコンID 設定
-	SetPrivateHostID(privateHostID int64)
+	SetPrivateHostID(privateHostID sacloud.ID)
 
 	// IsBootAfterCreate サーバー作成後すぐに起動フラグ 取得
 	IsBootAfterCreate() bool
@@ -126,9 +126,9 @@ type CommonProperty interface {
 	SetTags(tags []string)
 
 	// GetISOImageID ISOイメージ(CDROM)ID 取得
-	GetISOImageID() int64
+	GetISOImageID() sacloud.ID
 	// SetISOImageID ISOイメージ(CDROM)ID 設定
-	SetISOImageID(id int64)
+	SetISOImageID(id sacloud.ID)
 }
 
 // NetworkInterfaceProperty NIC関連プロパティ
@@ -149,9 +149,9 @@ type NetworkInterfaceProperty interface {
 	AddDisconnectedNIC()
 
 	// GetPacketFilterIDs パケットフィルタID 取得
-	GetPacketFilterIDs() []int64
+	GetPacketFilterIDs() []sacloud.ID
 	// SetPacketFilterIDs パケットフィルタID 設定
-	SetPacketFilterIDs(ids []int64)
+	SetPacketFilterIDs(ids []sacloud.ID)
 }
 
 // DiskProperty ディスク関連プロパティ
@@ -162,11 +162,11 @@ type DiskProperty interface {
 	SetDiskSize(diskSize int)
 
 	// GetDistantFrom ストレージ隔離対象ディスク 取得
-	GetDistantFrom() []int64
+	GetDistantFrom() []sacloud.ID
 	// SetDistantFrom ストレージ隔離対象ディスク 設定
-	SetDistantFrom(distantFrom []int64)
+	SetDistantFrom(distantFrom []sacloud.ID)
 	// AddDistantFrom ストレージ隔離対象ディスク 追加
-	AddDistantFrom(diskID int64)
+	AddDistantFrom(diskID sacloud.ID)
 	// ClearDistantFrom ストレージ隔離対象ディスク クリア
 	ClearDistantFrom()
 
@@ -216,10 +216,10 @@ type DiskEventProperty interface {
 // DiskSourceProperty コピー元アーカイブ/ディスクプロパティ
 type DiskSourceProperty interface {
 	// GetSourceArchiveID ソースアーカイブID 取得
-	GetSourceArchiveID() int64
+	GetSourceArchiveID() sacloud.ID
 
 	// GetSourceDiskID ソースディスクID 設定
-	GetSourceDiskID() int64
+	GetSourceDiskID() sacloud.ID
 }
 
 // DiskEditProperty ディスクの修正関連プロパティ
@@ -258,11 +258,11 @@ type DiskEditProperty interface {
 	// GetSSHKeys 公開鍵 取得
 	GetSSHKeys() []string
 	// GetSSHKeyIds 公開鍵ID 取得
-	GetSSHKeyIds() []int64
+	GetSSHKeyIds() []sacloud.ID
 	// AddSSHKey 公開鍵 追加
 	AddSSHKey(sshKey string)
 	// AddSSHKeyID 公開鍵ID 追加
-	AddSSHKeyID(sshKeyID int64)
+	AddSSHKeyID(sshKeyID sacloud.ID)
 	// ClearSSHKey 公開鍵 クリア
 	ClearSSHKey()
 	// ClearSSHKeyIDs 公開鍵ID クリア
@@ -275,11 +275,11 @@ type DiskEditProperty interface {
 	// GetNotes スタートアップスクリプト 取得
 	GetNotes() []string
 	// AddNoteID スタートアップスクリプト 追加
-	AddNoteID(noteID int64)
+	AddNoteID(noteID sacloud.ID)
 	// ClearNoteIDs スタートアップスクリプト クリア
 	ClearNoteIDs()
 	// GetNoteIDs スタートアップスクリプトID 取得
-	GetNoteIDs() []int64
+	GetNoteIDs() []sacloud.ID
 
 	// IsSSHKeysEphemeral ディスク作成後の公開鍵削除フラグ 取得
 	IsSSHKeysEphemeral() bool

--- a/sacloud/appliance.go
+++ b/sacloud/appliance.go
@@ -54,8 +54,8 @@ type ApplianceRemarkBase struct {
 
 // ApplianceRemarkSwitch スイッチ
 type ApplianceRemarkSwitch struct {
-	ID        string `json:",omitempty"` // リソースID
-	propScope        // スコープ
+	ID        ID `json:",omitempty"` // リソースID
+	propScope    // スコープ
 }
 
 // ApplianceRemarkVRRP VRRP

--- a/sacloud/auto_backup.go
+++ b/sacloud/auto_backup.go
@@ -14,11 +14,6 @@
 
 package sacloud
 
-import (
-	"encoding/json"
-	"fmt"
-)
-
 // AutoBackup 自動バックアップ(CommonServiceItem)
 type AutoBackup struct {
 	*Resource        // ID
@@ -38,9 +33,9 @@ type AutoBackup struct {
 
 // AutoBackupSettings 自動バックアップ設定
 type AutoBackupSettings struct {
-	AccountID  json.Number           `json:"AccountId,omitempty"` // アカウントID
-	DiskID     string                `json:"DiskId,omitempty"`    // ディスクID
-	ZoneID     int64                 `json:"ZoneId,omitempty"`    // ゾーンID
+	AccountID  ID                    `json:"AccountId,omitempty"` // アカウントID
+	DiskID     ID                    `json:"DiskId,omitempty"`    // ディスクID
+	ZoneID     ID                    `json:"ZoneId,omitempty"`    // ゾーンID
 	ZoneName   string                `json:",omitempty"`          // ゾーン名称
 	Autobackup *AutoBackupRecordSets `json:",omitempty"`          // 自動バックアップ定義
 
@@ -48,10 +43,10 @@ type AutoBackupSettings struct {
 
 // AutoBackupStatus 自動バックアップステータス
 type AutoBackupStatus struct {
-	AccountID json.Number `json:"AccountId,omitempty"` // アカウントID
-	DiskID    string      `json:"DiskId,omitempty"`    // ディスクID
-	ZoneID    int64       `json:"ZoneId,omitempty"`    // ゾーンID
-	ZoneName  string      `json:",omitempty"`          // ゾーン名称
+	AccountID ID     `json:"AccountId,omitempty"` // アカウントID
+	DiskID    ID     `json:"DiskId,omitempty"`    // ディスクID
+	ZoneID    ID     `json:"ZoneId,omitempty"`    // ゾーンID
+	ZoneName  string `json:",omitempty"`          // ゾーン名称
 }
 
 // AutoBackupProvider 自動バックアッププロバイダ
@@ -60,12 +55,12 @@ type AutoBackupProvider struct {
 }
 
 // CreateNewAutoBackup 自動バックアップ 作成(CommonServiceItem)
-func CreateNewAutoBackup(backupName string, diskID int64) *AutoBackup {
+func CreateNewAutoBackup(backupName string, diskID ID) *AutoBackup {
 	return &AutoBackup{
 		Resource: &Resource{},
 		propName: propName{Name: backupName},
 		Status: &AutoBackupStatus{
-			DiskID: fmt.Sprintf("%d", diskID),
+			DiskID: diskID,
 		},
 		Provider: &AutoBackupProvider{
 			Class: "autobackup",

--- a/sacloud/bill.go
+++ b/sacloud/bill.go
@@ -19,22 +19,22 @@ import "time"
 // Bill 請求情報
 type Bill struct {
 	Amount         int64      `json:",omitempty"` // 金額
-	BillID         int64      `json:",omitempty"` // 請求ID
+	BillID         ID         `json:",omitempty"` // 請求ID
 	Date           *time.Time `json:",omitempty"` // 請求日
 	MemberID       string     `json:",omitempty"` // 会員ID
 	Paid           bool       `json:",omitempty"` // 支払済フラグ
 	PayLimit       *time.Time `json:",omitempty"` // 支払い期限
-	PaymentClassID int        `json:",omitempty"` // 支払いクラスID
+	PaymentClassID ID         `json:",omitempty"` // 支払いクラスID
 
 }
 
 // BillDetail 支払い明細情報
 type BillDetail struct {
+	ContractID     ID         `json:",omitempty"` // 契約ID
 	Amount         int64      `json:",omitempty"` // 金額
-	ContractID     int64      `json:",omitempty"` // 契約ID
 	Description    string     `json:",omitempty"` // 説明
 	Index          int        `json:",omitempty"` // インデックス
-	ServiceClassID int64      `json:",omitempty"` // サービスクラスID
+	ServiceClassID ID         `json:",omitempty"` // サービスクラスID
 	Usage          int64      `json:",omitempty"` // 秒数
 	Zone           string     `json:",omitempty"` // ゾーン
 	ContractEndAt  *time.Time `json:",omitempty"` // 契約終了日時

--- a/sacloud/common_types.go
+++ b/sacloud/common_types.go
@@ -15,58 +15,49 @@
 package sacloud
 
 import (
-	"fmt"
-	"strconv"
 	"time"
 )
 
 // Resource IDを持つ、さくらのクラウド上のリソース
 type Resource struct {
-	ID int64 // ID
+	ID ID // ID
 }
 
 // ResourceIDHolder ID保持インターフェース
 type ResourceIDHolder interface {
-	SetID(int64)
-	GetID() int64
+	SetID(id ID)
+	GetID() ID
 }
 
 // EmptyID 空ID
-const EmptyID int64 = 0
+const EmptyID = ID(0)
 
 // NewResource 新規リソース作成
-func NewResource(id int64) *Resource {
+func NewResource(id ID) *Resource {
 	return &Resource{ID: id}
 }
 
 // NewResourceByStringID ID文字列からリソース作成
 func NewResourceByStringID(id string) *Resource {
-	intID, err := strconv.ParseInt(id, 10, 64)
-	if err != nil {
-		panic(err)
-	}
-	return &Resource{ID: intID}
+	return &Resource{ID: StringID(id)}
 }
 
 // SetID ID 設定
-func (n *Resource) SetID(id int64) {
+func (n *Resource) SetID(id ID) {
 	n.ID = id
 }
 
 // GetID ID 取得
-func (n *Resource) GetID() int64 {
+func (n *Resource) GetID() ID {
 	if n == nil {
-		return -1
+		return EmptyID
 	}
 	return n.ID
 }
 
 // GetStrID 文字列でID取得
 func (n *Resource) GetStrID() string {
-	if n == nil {
-		return ""
-	}
-	return fmt.Sprintf("%d", n.ID)
+	return n.ID.String()
 }
 
 // EAvailability 有効状態
@@ -269,7 +260,7 @@ type Request struct {
 	Filter               map[string]interface{} `json:",omitempty"` // フィルタ
 	Exclude              []string               `json:",omitempty"` // 除外する項目
 	Include              []string               `json:",omitempty"` // 取得する項目
-	DistantFrom          []int64                `json:",omitempty"` // ストレージ隔離対象ディスク
+	DistantFrom          []ID                   `json:",omitempty"` // ストレージ隔離対象ディスク
 }
 
 // AddFilter フィルタの追加

--- a/sacloud/coupon.go
+++ b/sacloud/coupon.go
@@ -18,10 +18,10 @@ import "time"
 
 // Coupon クーポン情報
 type Coupon struct {
-	CouponID       string    `json:",omitempty"` // クーポンID
+	CouponID       ID        `json:",omitempty"` // クーポンID
 	MemberID       string    `json:",omitempty"` // メンバーID
-	ContractID     int64     `json:",omitempty"` // 契約ID
-	ServiceClassID int64     `json:",omitempty"` // サービスクラスID
+	ContractID     ID        `json:",omitempty"` // 契約ID
+	ServiceClassID ID        `json:",omitempty"` // サービスクラスID
 	Discount       int64     `json:",omitempty"` // クーポン残高
 	AppliedAt      time.Time `json:",omitempty"` // 適用開始日
 	UntilAt        time.Time `json:",omitempty"` // 有効期限

--- a/sacloud/coupon_test.go
+++ b/sacloud/coupon_test.go
@@ -25,7 +25,7 @@ var testCouponJSON = `
     {
       "AppliedAt": "2019-01-10T11:12:13+09:00",
       "ContractID": 111111111111,
-      "CouponID": "xxxxxxxxxxxxxxxx",
+      "CouponID": "123456789012",
       "Discount": 999999,
       "MemberID": "abc99999",
       "ServiceClassID": 50122,

--- a/sacloud/database.go
+++ b/sacloud/database.go
@@ -41,13 +41,13 @@ type DatabaseRemark struct {
 	Network         *DatabaseRemarkNetwork   // ネットワーク
 	SourceAppliance *DatabaseSourceAppliance `json:",omitempty"` // クローン元DB
 	Zone            struct {                 // ゾーン
-		ID json.Number `json:",omitempty"` // ゾーンID
+		ID ID `json:",omitempty"` // ゾーンID
 	}
 }
 
 // DatabaseSourceAppliance ソースアプライアンス(クローン元DB)
 type DatabaseSourceAppliance struct {
-	ID json.Number `json:",omitempty"`
+	ID ID `json:",omitempty"`
 }
 
 // DatabaseRemarkNetwork ネットワーク
@@ -233,7 +233,7 @@ type CreateDatabaseValue struct {
 	BackupRotate     int          // バックアップ世代数
 	BackupTime       string       // バックアップ開始時間
 	BackupDayOfWeek  []string     // バックアップ取得曜日
-	SwitchID         string       // 接続先スイッチ
+	SwitchID         ID           // 接続先スイッチ
 	IPAddress1       string       // IPアドレス1
 	MaskLen          int          // ネットワークマスク長
 	DefaultRoute     string       // デフォルトルート
@@ -256,7 +256,7 @@ type SlaveDatabaseValue struct {
 	Plan            DatabasePlan // プラン
 	DefaultUser     string       // ユーザー名
 	UserPassword    string       // パスワード
-	SwitchID        string       // 接続先スイッチ
+	SwitchID        ID           // 接続先スイッチ
 	IPAddress1      string       // IPアドレス1
 	MaskLen         int          // ネットワークマスク長
 	DefaultRoute    string       // デフォルトルート
@@ -268,7 +268,7 @@ type SlaveDatabaseValue struct {
 	DatabaseVersion string       // データベースバージョン
 	// ReplicaUser      string    // レプリケーションユーザー 現在はreplica固定
 	ReplicaPassword   string // レプリケーションパスワード
-	MasterApplianceID int64  // クローン元DB
+	MasterApplianceID ID     // クローン元DB
 	MasterIPAddress   string // マスターIPアドレス
 	MasterPort        int    // マスターポート
 }
@@ -347,7 +347,7 @@ func CreateNewDatabase(values *CreateDatabaseValue) *Database {
 				},
 			},
 			// Plan
-			propPlanID: propPlanID{Plan: &Resource{ID: int64(values.Plan)}},
+			propPlanID: propPlanID{Plan: &Resource{ID: ID(values.Plan)}},
 		},
 		// Settings
 		Settings: &DatabaseSettings{
@@ -376,8 +376,8 @@ func CreateNewDatabase(values *CreateDatabaseValue) *Database {
 		},
 	}
 
-	if values.SourceAppliance.GetStrID() != "" {
-		db.Remark.SourceAppliance = &DatabaseSourceAppliance{ID: json.Number(values.SourceAppliance.GetStrID())}
+	if !values.SourceAppliance.ID.IsEmpty() {
+		db.Remark.SourceAppliance = &DatabaseSourceAppliance{ID: values.SourceAppliance.ID}
 	}
 
 	if values.ServicePort > 0 {
@@ -462,7 +462,7 @@ func NewSlaveDatabaseValue(values *SlaveDatabaseValue) *Database {
 				},
 			},
 			// Plan
-			propPlanID: propPlanID{Plan: &Resource{ID: int64(values.Plan) + 1}},
+			propPlanID: propPlanID{Plan: &Resource{ID: ID(int64(values.Plan) + 1)}},
 		},
 		// Settings
 		Settings: &DatabaseSettings{
@@ -478,7 +478,7 @@ func NewSlaveDatabaseValue(values *SlaveDatabaseValue) *Database {
 				// Replication
 				Replication: &DatabaseReplicationSetting{
 					Model:     DatabaseReplicationModelAsyncReplica,
-					Appliance: &DatabaseSourceAppliance{ID: json.Number(fmt.Sprintf("%d", values.MasterApplianceID))},
+					Appliance: &DatabaseSourceAppliance{ID: values.MasterApplianceID},
 					IPAddress: values.MasterIPAddress,
 					Port:      values.MasterPort,
 					User:      "replica",

--- a/sacloud/disk.go
+++ b/sacloud/disk.go
@@ -63,14 +63,14 @@ const (
 
 var (
 	// DiskPlanHDD HDDプラン
-	DiskPlanHDD = &Resource{ID: int64(DiskPlanHDDID)}
+	DiskPlanHDD = DiskPlanHDDID.ToResource()
 	// DiskPlanSSD SSDプラン
-	DiskPlanSSD = &Resource{ID: int64(DiskPlanSSDID)}
+	DiskPlanSSD = DiskPlanSSDID.ToResource()
 )
 
 // ToResource ディスクプランIDからリソースへの変換
 func (d DiskPlanID) ToResource() *Resource {
-	return &Resource{ID: int64(d)}
+	return &Resource{ID: ID(d)}
 }
 
 // CreateNewDisk ディスクの作成

--- a/sacloud/id.go
+++ b/sacloud/id.go
@@ -1,0 +1,74 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sacloud
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// ID さくらのクラウド上のリソースのIDを示す
+//
+// libsacloud v2のtypes.IDのバックポート
+// APIリクエスト/レスポンスに文字列/数値が混在するためここで吸収する
+type ID int64
+
+// UnmarshalJSON implements unmarshal from both of JSON number and JSON string
+func (i *ID) UnmarshalJSON(b []byte) error {
+	s := string(b)
+	if s == "" || s == "null" {
+		return nil
+	}
+	var n json.Number
+	if err := json.Unmarshal(b, &n); err != nil {
+		return err
+	}
+	id, err := n.Int64()
+	if err != nil {
+		return err
+	}
+	*i = ID(id)
+	return nil
+}
+
+// IsEmpty return true if ID is empty or zero value
+func (i ID) IsEmpty() bool {
+	return i.Int64() == 0
+}
+
+// String returns the literal text of the number.
+func (i ID) String() string {
+	if i.IsEmpty() {
+		return ""
+	}
+	return fmt.Sprintf("%d", i)
+}
+
+// Int64 returns the number as an int64.
+func (i ID) Int64() int64 {
+	return int64(i)
+}
+
+// Int64ID creates new ID from int64
+func Int64ID(id int64) ID {
+	return ID(id)
+}
+
+// StringID creates new ID from string
+func StringID(id string) ID {
+	intID, _ := strconv.ParseInt(id, 10, 64)
+	return ID(intID)
+}

--- a/sacloud/ipv6addr.go
+++ b/sacloud/ipv6addr.go
@@ -24,7 +24,7 @@ type IPv6Addr struct {
 }
 
 // GetIPv6NetID IPv6アドレスが所属するIPv6NetのIDを取得
-func (a *IPv6Addr) GetIPv6NetID() int64 {
+func (a *IPv6Addr) GetIPv6NetID() ID {
 	if a.IPv6Net != nil {
 		return a.IPv6Net.ID
 	}
@@ -32,7 +32,7 @@ func (a *IPv6Addr) GetIPv6NetID() int64 {
 }
 
 // GetInternetID IPv6アドレスを所有するルータ+スイッチ(Internet)のIDを取得
-func (a *IPv6Addr) GetInternetID() int64 {
+func (a *IPv6Addr) GetInternetID() ID {
 	if a.IPv6Net != nil && a.IPv6Net.Switch != nil && a.IPv6Net.Switch.Internet != nil {
 		return a.IPv6Net.Switch.Internet.ID
 	}

--- a/sacloud/ipv6net.go
+++ b/sacloud/ipv6net.go
@@ -26,7 +26,7 @@ type IPv6Net struct {
 	IPv6PrefixTail     string    `json:",omitempty"` // IPv6プレフィックス末尾
 	IPv6Table          *Resource `json:",omitempty"` // IPv6テーブル
 	NamedIPv6AddrCount int       `json:",omitempty"` // 名前付きIPv6アドレス数
-	ServiceID          int64     `json:",omitempty"` // サービスID
+	ServiceID          ID        `json:",omitempty"` // サービスID
 	Switch             *Switch   `json:",omitempty"` // 接続先スイッチ
 
 }

--- a/sacloud/license.go
+++ b/sacloud/license.go
@@ -36,6 +36,6 @@ func (l *License) SetLicenseInfo(license *ProductLicense) {
 }
 
 // SetLicenseInfoByID ライセンス情報 設定
-func (l *License) SetLicenseInfoByID(id int64) {
+func (l *License) SetLicenseInfoByID(id ID) {
 	l.LicenseInfo = &ProductLicense{Resource: NewResource(id)}
 }

--- a/sacloud/loadbalancer.go
+++ b/sacloud/loadbalancer.go
@@ -112,7 +112,7 @@ var (
 
 // CreateLoadBalancerValue ロードバランサー作成用パラメーター
 type CreateLoadBalancerValue struct {
-	SwitchID     string           // 接続先スイッチID
+	SwitchID     ID               // 接続先スイッチID
 	VRID         int              // VRID
 	Plan         LoadBalancerPlan // プラン
 	IPAddress1   string           // IPアドレス
@@ -144,7 +144,7 @@ func CreateNewLoadBalancerSingle(values *CreateLoadBalancerValue, settings []*Lo
 			propName:        propName{Name: values.Name},
 			propDescription: propDescription{Description: values.Description},
 			propTags:        propTags{Tags: values.Tags},
-			propPlanID:      propPlanID{Plan: &Resource{ID: int64(values.Plan)}},
+			propPlanID:      propPlanID{Plan: &Resource{ID: ID(values.Plan)}},
 			propIcon: propIcon{
 				&Icon{
 					Resource: values.Icon,

--- a/sacloud/loadbalancer_test.go
+++ b/sacloud/loadbalancer_test.go
@@ -142,7 +142,7 @@ var (
     	`
 
 	createLoadBalancerValues = &CreateLoadBalancerValue{
-		SwitchID:     "9999999999",
+		SwitchID:     9999999999,
 		VRID:         1,
 		Plan:         LoadBalancerPlanStandard,
 		IPAddress1:   "192.168.11.11",
@@ -232,7 +232,7 @@ func TestCreateNewLoadBalancerSingle(t *testing.T) {
 
 	assert.Equal(t, lb.Class, "loadbalancer")
 
-	assert.Equal(t, lb.Remark.Switch.ID, "9999999999")
+	assert.Equal(t, lb.Remark.Switch.ID, ID(9999999999))
 	assert.Equal(t, lb.Remark.VRRP.VRID, 1)
 	plan := lb.Plan.ID
 	assert.NoError(t, err)
@@ -281,7 +281,7 @@ func TestCreateNewLoadBalancerDouble(t *testing.T) {
 
 	assert.Equal(t, lb.Class, "loadbalancer")
 
-	assert.Equal(t, lb.Remark.Switch.ID, "9999999999")
+	assert.Equal(t, lb.Remark.Switch.ID, ID(9999999999))
 	assert.Equal(t, lb.Remark.VRRP.VRID, 1)
 	plan := lb.Plan.ID
 	assert.NoError(t, err)

--- a/sacloud/mobile_gateway.go
+++ b/sacloud/mobile_gateway.go
@@ -140,7 +140,7 @@ type CreateMobileGatewayValue struct {
 	Name        string   // 名称
 	Description string   // 説明
 	Tags        []string // タグ
-	IconID      int64    // アイコン
+	IconID      ID       // アイコン
 }
 
 // CreateNewMobileGateway モバイルゲートウェイ作成
@@ -152,7 +152,7 @@ func CreateNewMobileGateway(values *CreateMobileGatewayValue, setting *MobileGat
 			propName:        propName{Name: values.Name},
 			propDescription: propDescription{Description: values.Description},
 			propTags:        propTags{Tags: values.Tags},
-			propPlanID:      propPlanID{Plan: &Resource{ID: int64(MobileGatewayPlanStandard)}},
+			propPlanID:      propPlanID{Plan: &Resource{ID: ID(MobileGatewayPlanStandard)}},
 			propIcon: propIcon{
 				&Icon{
 					Resource: NewResource(values.IconID),
@@ -314,7 +314,7 @@ type MobileGatewaySIMRoutes struct {
 }
 
 // AddSIMRoute SIMルート追加
-func (m *MobileGatewaySIMRoutes) AddSIMRoute(simID int64, prefix string) (int, *MobileGatewaySIMRoute) {
+func (m *MobileGatewaySIMRoutes) AddSIMRoute(simID ID, prefix string) (int, *MobileGatewaySIMRoute) {
 	var exists bool
 	for _, route := range m.SIMRoutes {
 		if route.ResourceID == fmt.Sprintf("%d", simID) && route.Prefix == prefix {
@@ -334,7 +334,7 @@ func (m *MobileGatewaySIMRoutes) AddSIMRoute(simID int64, prefix string) (int, *
 }
 
 // DeleteSIMRoute SIMルート削除
-func (m *MobileGatewaySIMRoutes) DeleteSIMRoute(simID int64, prefix string) bool {
+func (m *MobileGatewaySIMRoutes) DeleteSIMRoute(simID ID, prefix string) bool {
 	routes := []*MobileGatewaySIMRoute{} // nolint (JSONヘのMarshal時に要素が0の場合にNULLではなく[]とするため)
 	var exists bool
 
@@ -357,15 +357,13 @@ func (m *MobileGatewaySIMRoutes) DeleteSIMRouteAt(index int) bool {
 
 	if index < len(m.SIMRoutes) {
 		s := m.SIMRoutes[index]
-		if simID, err := strconv.ParseInt(s.ResourceID, 10, 64); err == nil {
-			return m.DeleteSIMRoute(simID, s.Prefix)
-		}
+		return m.DeleteSIMRoute(StringID(s.ResourceID), s.Prefix)
 	}
 	return false
 }
 
 // FindSIMRoute SIMルート設定 検索
-func (m *MobileGatewaySIMRoutes) FindSIMRoute(simID int64, prefix string) (int, *MobileGatewaySIMRoute) {
+func (m *MobileGatewaySIMRoutes) FindSIMRoute(simID ID, prefix string) (int, *MobileGatewaySIMRoute) {
 	for i, r := range m.SIMRoutes {
 		if r.Prefix == prefix && r.ResourceID == fmt.Sprintf("%d", simID) {
 			return i, r

--- a/sacloud/nfs.go
+++ b/sacloud/nfs.go
@@ -38,7 +38,7 @@ type NFSRemark struct {
 }
 
 // SetRemarkPlanID プランID設定
-func (n NFSRemark) SetRemarkPlanID(planID int64) {
+func (n NFSRemark) SetRemarkPlanID(planID ID) {
 	if n.Plan == nil {
 		n.Plan = &struct {
 			ID json.Number `json:",omitempty"`
@@ -119,7 +119,7 @@ func AllowNFSSSDPlanSizes() []int {
 
 // CreateNFSValue NFS作成用パラメーター
 type CreateNFSValue struct {
-	SwitchID        string    // 接続先スイッチID
+	SwitchID        ID        // 接続先スイッチID
 	IPAddress       string    // IPアドレス
 	MaskLen         int       // ネットワークマスク長
 	DefaultRoute    string    // デフォルトルート
@@ -205,7 +205,7 @@ type NFSPlans struct {
 }
 
 // FindPlanID プランとサイズからプランIDを取得
-func (p NFSPlans) FindPlanID(plan NFSPlan, size NFSSize) int64 {
+func (p NFSPlans) FindPlanID(plan NFSPlan, size NFSSize) ID {
 	var plans []NFSPlanValue
 	switch plan {
 	case NFSPlanHDD:
@@ -218,11 +218,7 @@ func (p NFSPlans) FindPlanID(plan NFSPlan, size NFSSize) int64 {
 
 	for _, plan := range plans {
 		if plan.Availability == "available" && plan.Size == int(size) {
-			res, err := plan.PlanID.Int64()
-			if err != nil {
-				return -1
-			}
-			return res
+			return plan.PlanID
 		}
 	}
 
@@ -230,23 +226,17 @@ func (p NFSPlans) FindPlanID(plan NFSPlan, size NFSSize) int64 {
 }
 
 // FindByPlanID プランIDから該当プランを取得
-func (p NFSPlans) FindByPlanID(planID int64) (NFSPlan, *NFSPlanValue) {
+func (p NFSPlans) FindByPlanID(planID ID) (NFSPlan, *NFSPlanValue) {
 
 	for _, plan := range p.SSD {
-		id, err := plan.PlanID.Int64()
-		if err != nil {
-			continue
-		}
+		id := plan.PlanID
 		if id == planID {
 			return NFSPlanSSD, &plan
 		}
 	}
 
 	for _, plan := range p.HDD {
-		id, err := plan.PlanID.Int64()
-		if err != nil {
-			continue
-		}
+		id := plan.PlanID
 		if id == planID {
 			return NFSPlanHDD, &plan
 		}
@@ -256,7 +246,7 @@ func (p NFSPlans) FindByPlanID(planID int64) (NFSPlan, *NFSPlanValue) {
 
 // NFSPlanValue NFSプラン
 type NFSPlanValue struct {
-	Size         int         `json:"size"`
-	Availability string      `json:"availability"`
-	PlanID       json.Number `json:"planId"`
+	Size         int    `json:"size"`
+	Availability string `json:"availability"`
+	PlanID       ID     `json:"planId"`
 }

--- a/sacloud/prop_copy_source.go
+++ b/sacloud/prop_copy_source.go
@@ -22,8 +22,8 @@ type propCopySource struct {
 }
 
 // SetSourceArchive ソースアーカイブ設定
-func (p *propCopySource) SetSourceArchive(sourceID int64) {
-	if sourceID == EmptyID {
+func (p *propCopySource) SetSourceArchive(sourceID ID) {
+	if sourceID.IsEmpty() {
 		return
 	}
 	p.SourceArchive = &Archive{
@@ -33,8 +33,8 @@ func (p *propCopySource) SetSourceArchive(sourceID int64) {
 }
 
 // SetSourceDisk ソースディスク設定
-func (p *propCopySource) SetSourceDisk(sourceID int64) {
-	if sourceID == EmptyID {
+func (p *propCopySource) SetSourceDisk(sourceID ID) {
+	if sourceID.IsEmpty() {
 		return
 	}
 	p.SourceDisk = &Disk{
@@ -54,17 +54,17 @@ func (p *propCopySource) GetSourceDisk() *Disk {
 }
 
 // GetSourceArchiveID ソースアーカイブID取得
-func (p *propCopySource) GetSourceArchiveID() int64 {
+func (p *propCopySource) GetSourceArchiveID() ID {
 	if p.SourceArchive != nil {
-		return p.SourceArchive.GetID()
+		return p.SourceArchive.ID
 	}
 	return EmptyID
 }
 
 // GetSourceDiskID ソースディスクID取得
-func (p *propCopySource) GetSourceDiskID() int64 {
+func (p *propCopySource) GetSourceDiskID() ID {
 	if p.SourceDisk != nil {
-		return p.SourceDisk.GetID()
+		return p.SourceDisk.ID
 	}
 	return EmptyID
 }

--- a/sacloud/prop_disks.go
+++ b/sacloud/prop_disks.go
@@ -25,12 +25,11 @@ func (p *propDisks) GetDisks() []Disk {
 }
 
 // GetDiskIDs ディスクID配列を返す
-func (p *propDisks) GetDiskIDs() []int64 {
+func (p *propDisks) GetDiskIDs() []ID {
 
-	ids := []int64{}
+	var ids []ID
 	for _, disk := range p.Disks {
 		ids = append(ids, disk.ID)
 	}
 	return ids
-
 }

--- a/sacloud/prop_distant_from.go
+++ b/sacloud/prop_distant_from.go
@@ -16,25 +16,25 @@ package sacloud
 
 // propDistantFrom ストレージ隔離対象ディスク内包型
 type propDistantFrom struct {
-	DistantFrom []int64 `json:",omitempty"` // ストレージ隔離対象ディスク
+	DistantFrom []ID `json:",omitempty"` // ストレージ隔離対象ディスク
 }
 
 // GetDistantFrom ストレージ隔離対象ディスク 取得
-func (p *propDistantFrom) GetDistantFrom() []int64 {
+func (p *propDistantFrom) GetDistantFrom() []ID {
 	return p.DistantFrom
 }
 
 // SetDistantFrom ストレージ隔離対象ディスク 設定
-func (p *propDistantFrom) SetDistantFrom(ids []int64) {
+func (p *propDistantFrom) SetDistantFrom(ids []ID) {
 	p.DistantFrom = ids
 }
 
 // AddDistantFrom ストレージ隔離対象ディスク 追加
-func (p *propDistantFrom) AddDistantFrom(id int64) {
+func (p *propDistantFrom) AddDistantFrom(id ID) {
 	p.DistantFrom = append(p.DistantFrom, id)
 }
 
 // ClearDistantFrom ストレージ隔離対象ディスク クリア
 func (p *propDistantFrom) ClearDistantFrom() {
-	p.DistantFrom = []int64{}
+	p.DistantFrom = []ID{}
 }

--- a/sacloud/prop_icon.go
+++ b/sacloud/prop_icon.go
@@ -25,9 +25,9 @@ func (p *propIcon) GetIcon() *Icon {
 }
 
 // GetIconID アイコンIDを取得
-func (p *propIcon) GetIconID() int64 {
+func (p *propIcon) GetIconID() ID {
 	if p.HasIcon() {
-		return p.Icon.GetID()
+		return p.Icon.ID
 	}
 	return -1
 }
@@ -46,7 +46,7 @@ func (p *propIcon) HasIcon() bool {
 }
 
 // SetIconByID 指定のアイコンIDを設定
-func (p *propIcon) SetIconByID(id int64) {
+func (p *propIcon) SetIconByID(id ID) {
 	p.Icon = &Icon{Resource: NewResource(id)}
 }
 

--- a/sacloud/prop_original_archive_id.go
+++ b/sacloud/prop_original_archive_id.go
@@ -20,11 +20,11 @@ type propOriginalArchiveID struct {
 }
 
 // GetOriginalArchiveID プランID 取得
-func (p *propOriginalArchiveID) GetOriginalArchiveID() int64 {
+func (p *propOriginalArchiveID) GetOriginalArchiveID() ID {
 	if p.OriginalArchive == nil {
-		return -1
+		return EmptyID
 	}
-	return p.OriginalArchive.GetID()
+	return p.OriginalArchive.ID
 }
 
 // GetStrOriginalArchiveID プランID(文字列) 取得
@@ -32,5 +32,5 @@ func (p *propOriginalArchiveID) GetStrOriginalArchiveID() string {
 	if p.OriginalArchive == nil {
 		return ""
 	}
-	return p.OriginalArchive.GetStrID()
+	return p.OriginalArchive.ID.String()
 }

--- a/sacloud/prop_plan_id.go
+++ b/sacloud/prop_plan_id.go
@@ -20,7 +20,7 @@ type propPlanID struct {
 }
 
 // GetPlanID プランID 取得
-func (p *propPlanID) GetPlanID() int64 {
+func (p *propPlanID) GetPlanID() ID {
 	if p.Plan == nil {
 		return -1
 	}

--- a/sacloud/prop_private_host.go
+++ b/sacloud/prop_private_host.go
@@ -19,17 +19,17 @@ type propPrivateHost struct {
 	PrivateHost *PrivateHost // 専有ホスト
 }
 
-// SetPrivateHostByID 指定のアイコンIDを設定
-func (p *propPrivateHost) SetPrivateHostByID(id int64) {
+// SetPrivateHostByID 指定の専有ホストIDを設定
+func (p *propPrivateHost) SetPrivateHostByID(id ID) {
 	p.PrivateHost = &PrivateHost{Resource: NewResource(id)}
 }
 
-// SetPrivateHost 指定のアイコンオブジェクトを設定
+// SetPrivateHost 指定の専有ホストオブジェクトを設定
 func (p *propPrivateHost) SetPrivateHost(icon *PrivateHost) {
 	p.PrivateHost = icon
 }
 
-// ClearPrivateHost アイコンをクリア(空IDを持つアイコンオブジェクトをセット)
+// ClearPrivateHost 専有ホストをクリア(空IDを持つ専有ホストオブジェクトをセット)
 func (p *propPrivateHost) ClearPrivateHost() {
 	p.PrivateHost = &PrivateHost{Resource: NewResource(EmptyID)}
 }

--- a/sacloud/prop_private_host_plan.go
+++ b/sacloud/prop_private_host_plan.go
@@ -30,7 +30,7 @@ func (p *propPrivateHostPlan) SetPrivateHostPlan(plan *ProductPrivateHost) {
 }
 
 // SetPrivateHostPlanByID 専有ホストプラン設定
-func (p *propPrivateHostPlan) SetPrivateHostPlanByID(planID int64) {
+func (p *propPrivateHostPlan) SetPrivateHostPlanByID(planID ID) {
 	if p.Plan == nil {
 		p.Plan = &ProductPrivateHost{}
 	}

--- a/sacloud/prop_region.go
+++ b/sacloud/prop_region.go
@@ -25,7 +25,7 @@ func (p *propRegion) GetRegion() *Region {
 }
 
 // GetRegionID リージョンID 取得
-func (p *propRegion) GetRegionID() int64 {
+func (p *propRegion) GetRegionID() ID {
 	if p.Region == nil {
 		return -1
 	}

--- a/sacloud/prop_server.go
+++ b/sacloud/prop_server.go
@@ -30,6 +30,6 @@ func (p *propServer) SetServer(server *Server) {
 }
 
 // SetServerID サーバーIDの設定
-func (p *propServer) SetServerID(id int64) {
+func (p *propServer) SetServerID(id ID) {
 	p.Server = &Server{Resource: &Resource{ID: id}}
 }

--- a/sacloud/prop_switch.go
+++ b/sacloud/prop_switch.go
@@ -30,6 +30,6 @@ func (p *propSwitch) SetSwitch(sw *Switch) {
 }
 
 // SetSwitchID スイッチID 設定
-func (p *Interface) SetSwitchID(id int64) {
+func (p *Interface) SetSwitchID(id ID) {
 	p.Switch = &Switch{Resource: &Resource{ID: id}}
 }

--- a/sacloud/prop_zone.go
+++ b/sacloud/prop_zone.go
@@ -25,7 +25,7 @@ func (p *propZone) GetZone() *Zone {
 }
 
 // GetZoneID ゾーンID 取得
-func (p *propZone) GetZoneID() int64 {
+func (p *propZone) GetZoneID() ID {
 	if p.Zone == nil {
 		return -1
 	}
@@ -58,7 +58,7 @@ func (p *propZone) GetRegion() *Region {
 }
 
 // GetRegionID リージョンID 取得
-func (p *propZone) GetRegionID() int64 {
+func (p *propZone) GetRegionID() ID {
 	if p.Zone == nil {
 		return -1
 	}

--- a/sacloud/server.go
+++ b/sacloud/server.go
@@ -116,14 +116,14 @@ func (s *Server) UpstreamTypeAt(index int) EUpstreamNetworkType {
 // SwitchID 上流のスイッチのID
 //
 // NICがない、上流スイッチが見つからない、上流が共有セグメントの場合は-1を返す
-func (s *Server) SwitchID() int64 {
+func (s *Server) SwitchID() ID {
 	return s.SwitchIDAt(0)
 }
 
 // SwitchIDAt 上流ネットワークのスイッチのID
 //
 // NICがない、上流スイッチが見つからない、上流が共有セグメントの場合は-1を返す
-func (s *Server) SwitchIDAt(index int) int64 {
+func (s *Server) SwitchIDAt(index int) ID {
 	if len(s.Interfaces) <= index {
 		return -1
 	}

--- a/sacloud/subnet.go
+++ b/sacloud/subnet.go
@@ -24,7 +24,7 @@ type Subnet struct {
 	IPAddresses    []*IPAddress `json:",omitempty"` // IPv4アドレス範囲
 	NetworkAddress string       `json:",omitempty"` // ネットワークアドレス
 	NetworkMaskLen int          `json:",omitempty"` // ネットワークマスク長
-	ServiceID      int64        `json:",omitempty"` // サービスID
+	ServiceID      ID           `json:",omitempty"` // サービスID
 	StaticRoute    string       `json:",omitempty"` // スタティックルート
 	NextHop        string       `json:",omitempty"` // ネクストホップ
 	Switch         *Switch      `json:",omitempty"` // スイッチ

--- a/sacloud/switch.go
+++ b/sacloud/switch.go
@@ -15,7 +15,6 @@
 package sacloud
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 )
@@ -43,10 +42,7 @@ type Switch struct {
 	Bridge *struct { // 接続先ブリッジ(Info.Switches配下のIDデータ型HACK)
 		*Bridge // ブリッジ
 		Info    *struct {
-			Switches []struct { // 接続スイッチリスト
-				*Switch             // スイッチ
-				ID      json.Number `json:",omitempty"` // HACK
-			}
+			Switches []*Switch
 		}
 	} `json:",omitempty"`
 

--- a/sacloud/switch_test.go
+++ b/sacloud/switch_test.go
@@ -238,7 +238,7 @@ func TestIPHandling(t *testing.T) {
 func TestSwitchProp(t *testing.T) {
 
 	type PropID interface {
-		GetID() int64
+		GetID() ID
 	}
 	type PropName interface {
 		GetName() string

--- a/sacloud/vpc_router.go
+++ b/sacloud/vpc_router.go
@@ -124,7 +124,7 @@ func (v *VPCRouter) SetHighSpec4000MbpsPlan(switchID string, virtualIPAddress st
 
 func (v *VPCRouter) setPremiumServices(switchID string, virtualIPAddress string, ipAddress1 string, ipAddress2 string, vrid int, ipAliases []string) {
 	v.Remark.Switch = &ApplianceRemarkSwitch{
-		ID: switchID,
+		ID: StringID(switchID),
 	}
 	v.Remark.Servers = []interface{}{
 		map[string]string{"IPAddress": ipAddress1},

--- a/sacloud/vpc_router_test.go
+++ b/sacloud/vpc_router_test.go
@@ -265,7 +265,7 @@ func TestVPCRouter_RealIPAddress(t *testing.T) {
 	for _, e := range expects {
 
 		vpcRouter.InitVPCRouterSetting()
-		vpcRouter.Plan.SetID(int64(e.plan))
+		vpcRouter.Plan.SetID(ID(e.plan))
 		vpcRouter.Settings.Router.Interfaces = e.interfaces
 
 		actual, _ := vpcRouter.RealIPAddress(e.index)
@@ -296,7 +296,7 @@ func TestVPCRouter_FindBelongsInterface(t *testing.T) {
 
 	vpcRouter := CreateNewVPCRouter()
 	vpcRouter.InitVPCRouterSetting()
-	vpcRouter.Plan.SetID(int64(1))
+	vpcRouter.Plan.SetID(ID(1))
 	vpcRouter.Settings.Router.Interfaces = []*VPCRouterInterface{
 		{IPAddress: []string{"192.168.0.1"}, NetworkMaskLen: 24},
 		{IPAddress: []string{"192.168.1.1"}, NetworkMaskLen: 24},

--- a/sacloud/webaccel.go
+++ b/sacloud/webaccel.go
@@ -16,8 +16,6 @@ package sacloud
 
 import (
 	"encoding/json"
-	"fmt"
-	"strconv"
 	"strings"
 )
 
@@ -43,7 +41,7 @@ const (
 
 // WebAccelSite ウェブアクセラレータ サイト
 type WebAccelSite struct {
-	ID                 string              // ID
+	ID                 ID                  // ID
 	Name               string              `json:",omitempty"`
 	DomainType         EWebAccelDomainType `json:",omitempty"`
 	Domain             string              `json:",omitempty"`
@@ -61,20 +59,16 @@ type WebAccelSite struct {
 }
 
 // SetID ID 設定
-func (n *WebAccelSite) SetID(id int64) {
-	n.ID = fmt.Sprintf("%d", id)
+func (n *WebAccelSite) SetID(id ID) {
+	n.ID = id
 }
 
 // GetID ID 取得
-func (n *WebAccelSite) GetID() int64 {
+func (n *WebAccelSite) GetID() ID {
 	if n == nil {
 		return -1
 	}
-	i, err := strconv.ParseInt(n.ID, 10, 64)
-	if err != nil {
-		return -1
-	}
-	return i
+	return n.ID
 }
 
 // GetStrID 文字列でID取得
@@ -82,7 +76,7 @@ func (n *WebAccelSite) GetStrID() string {
 	if n == nil {
 		return ""
 	}
-	return n.ID
+	return n.ID.String()
 }
 
 // GetName 名称取得
@@ -103,8 +97,8 @@ func (n *WebAccelSite) SetName(name string) {
 
 // WebAccelCert ウェブアクセラレータ証明書
 type WebAccelCert struct {
-	ID               string `json:",omitempty"`
-	SiteID           string `json:",omitempty"`
+	ID               ID     `json:",omitempty"`
+	SiteID           ID     `json:",omitempty"`
 	CertificateChain string `json:",omitempty"`
 	Key              string `json:",omitempty"`
 	propCreatedAt    `json:",omitempty"`
@@ -135,20 +129,16 @@ type WebAccelCert struct {
 }
 
 // SetID ID 設定
-func (n *WebAccelCert) SetID(id int64) {
-	n.ID = fmt.Sprintf("%d", id)
+func (n *WebAccelCert) SetID(id ID) {
+	n.ID = id
 }
 
 // GetID ID 取得
-func (n *WebAccelCert) GetID() int64 {
+func (n *WebAccelCert) GetID() ID {
 	if n == nil {
 		return -1
 	}
-	i, err := strconv.ParseInt(n.ID, 10, 64)
-	if err != nil {
-		return -1
-	}
-	return i
+	return n.ID
 }
 
 // GetStrID 文字列でID取得
@@ -156,7 +146,7 @@ func (n *WebAccelCert) GetStrID() string {
 	if n == nil {
 		return ""
 	}
-	return n.ID
+	return n.ID.String()
 }
 
 // WebAccelCertRequest ウェブアクセラレータ証明書API リクエスト

--- a/sacloud/webaccel_test.go
+++ b/sacloud/webaccel_test.go
@@ -23,7 +23,7 @@ import (
 
 var testWebAccelSiteJSON = `
 {
-      "ID": "000000000001",
+      "ID": "123456789012",
       "Name": "サイト1",
       "DomainType": "own_domain",
       "Domain": "cdn1.example.com",
@@ -46,7 +46,7 @@ var testWebAccelCertResponseValid = `
   "Certificate": {
     "Current":{
       "ID": "1",
-      "SiteID": "000000000001",
+      "SiteID": "123456789012",
       "CertificateChain": "-----BEGIN CERTIFICATE-----・・・・・",
       "Key": "-----BEGIN RSA PRIVATE KEY-----・・・・・",
       "CreatedAt": "2015-11-13T02:57:01+09:00",
@@ -55,7 +55,7 @@ var testWebAccelCertResponseValid = `
     "Old": [
       {
         "ID": "1",
-        "SiteID": "000000000001",
+        "SiteID": "123456789012",
         "CertificateChain": "-----BEGIN CERTIFICATE-----・・・・・",
         "CreatedAt": "2015-11-13T02:57:01+09:00",
         "UpdatedAt": "2015-11-14T02:57:01+09:00"

--- a/utils/server/user_name.go
+++ b/utils/server/user_name.go
@@ -20,7 +20,7 @@ import (
 )
 
 // GetDefaultUserName returns default admin user name from source archives/disks
-func GetDefaultUserName(client *api.Client, serverID int64) (string, error) {
+func GetDefaultUserName(client *api.Client, serverID sacloud.ID) (string, error) {
 
 	// read server
 	server, err := client.GetServerAPI().Read(serverID)
@@ -35,7 +35,7 @@ func GetDefaultUserName(client *api.Client, serverID int64) (string, error) {
 	return getSSHDefaultUserNameDiskRec(client, server.Disks[0].ID)
 }
 
-func getSSHDefaultUserNameDiskRec(client *api.Client, diskID int64) (string, error) {
+func getSSHDefaultUserNameDiskRec(client *api.Client, diskID sacloud.ID) (string, error) {
 
 	disk, err := client.GetDiskAPI().Read(diskID)
 	if err != nil {
@@ -54,7 +54,7 @@ func getSSHDefaultUserNameDiskRec(client *api.Client, diskID int64) (string, err
 	return "", nil
 }
 
-func getSSHDefaultUserNameArchiveRec(client *api.Client, archiveID int64) (string, error) {
+func getSSHDefaultUserNameArchiveRec(client *api.Client, archiveID sacloud.ID) (string, error) {
 	// read archive
 	archive, err := client.GetArchiveAPI().Read(archiveID)
 	if err != nil {

--- a/utils/setup/retryable_setup.go
+++ b/utils/setup/retryable_setup.go
@@ -43,7 +43,7 @@ const DefaultDeleteWaitInterval = 10 * time.Second
 type CreateFunc func() (sacloud.ResourceIDHolder, error)
 
 // AsyncWaitForCopyFunc リソース作成時のコピー待ち(非同期)関数
-type AsyncWaitForCopyFunc func(id int64) (
+type AsyncWaitForCopyFunc func(id sacloud.ID) (
 	chan interface{}, chan interface{}, chan error,
 )
 
@@ -51,15 +51,15 @@ type AsyncWaitForCopyFunc func(id int64) (
 //
 // リソース作成後に起動が行われないリソース(VPCルータなど)向け。
 // 必要であればこの中でリソース起動処理を行う。
-type ProvisionBeforeUpFunc func(id int64, target interface{}) error
+type ProvisionBeforeUpFunc func(id sacloud.ID, target interface{}) error
 
 // DeleteFunc リソース削除関数。
 //
 // リソース作成時のコピー待ちの間にリソースのAvailabilityがFailedになった場合に利用される。
-type DeleteFunc func(id int64) error
+type DeleteFunc func(id sacloud.ID) error
 
 // WaitForUpFunc リソース起動待ち関数
-type WaitForUpFunc func(id int64) error
+type WaitForUpFunc func(id sacloud.ID) error
 
 // RetryableSetup リソース作成時にコピー待ちや起動待ちが必要なリソースのビルダー。
 //
@@ -165,7 +165,7 @@ func (r *RetryableSetup) createResource() (sacloud.ResourceIDHolder, error) {
 	return r.Create()
 }
 
-func (r *RetryableSetup) waitForCopyWithCleanup(resourceID int64) (interface{}, error) {
+func (r *RetryableSetup) waitForCopyWithCleanup(resourceID sacloud.ID) (interface{}, error) {
 
 	//wait
 	compChan, progChan, errChan := r.AsyncWaitForCopy(resourceID)
@@ -211,7 +211,7 @@ loop:
 	return nil, nil
 }
 
-func (r *RetryableSetup) provisionBeforeUp(id int64, created interface{}) error {
+func (r *RetryableSetup) provisionBeforeUp(id sacloud.ID, created interface{}) error {
 	if r.ProvisionBeforeUp != nil && created != nil {
 		var err error
 		for i := 0; i < r.ProvisioningRetryCount; i++ {
@@ -225,7 +225,7 @@ func (r *RetryableSetup) provisionBeforeUp(id int64, created interface{}) error 
 	return nil
 }
 
-func (r *RetryableSetup) waitForUp(id int64, created interface{}) error {
+func (r *RetryableSetup) waitForUp(id sacloud.ID, created interface{}) error {
 	if r.WaitForUp != nil && created != nil {
 		if err := r.WaitForUp(id); err != nil {
 			return err

--- a/utils/setup/retryable_setup_test.go
+++ b/utils/setup/retryable_setup_test.go
@@ -29,7 +29,7 @@ func TestRetryableSetup_Setup(t *testing.T) {
 		t.Run("no error", func(t *testing.T) {
 			retryable := &RetryableSetup{
 				Create: func() (sacloud.ResourceIDHolder, error) {
-					return sacloud.NewResource(1), nil
+					return sacloud.NewResource(sacloud.ID(1)), nil
 				},
 			}
 			res, err := retryable.Setup()
@@ -65,7 +65,7 @@ func TestRetryableSetup_Setup(t *testing.T) {
 					return sacloud.NewResource(1), nil
 				},
 				AsyncWaitForCopy: waiter.asyncWaitForCopy,
-				Delete: func(id int64) error {
+				Delete: func(id sacloud.ID) error {
 					return nil
 				},
 				RetryCount: 3,
@@ -87,7 +87,7 @@ func TestRetryableSetup_Setup(t *testing.T) {
 					return sacloud.NewResource(1), nil
 				},
 				AsyncWaitForCopy: waiter.asyncWaitForCopy,
-				Delete: func(id int64) error {
+				Delete: func(id sacloud.ID) error {
 					return nil
 				},
 				RetryCount: 3,
@@ -109,7 +109,7 @@ type dummyAsyncWaiter struct {
 	calledCount      int
 }
 
-func (d *dummyAsyncWaiter) asyncWaitForCopy(id int64) (chan interface{}, chan interface{}, chan error) {
+func (d *dummyAsyncWaiter) asyncWaitForCopy(id sacloud.ID) (chan interface{}, chan interface{}, chan error) {
 	d.calledCount++
 
 	compChan := make(chan interface{})

--- a/utils/setup/setup_test.go
+++ b/utils/setup/setup_test.go
@@ -64,7 +64,7 @@ func TestAccRetryAbleSetUp(t *testing.T) {
 	assert.NotNil(t, sw)
 
 	param := &sacloud.CreateNFSValue{
-		SwitchID:  sw.GetStrID(),
+		SwitchID:  sw.ID,
 		IPAddress: "192.2.0.1",
 		MaskLen:   24,
 		Name:      testResourceName,
@@ -74,15 +74,15 @@ func TestAccRetryAbleSetUp(t *testing.T) {
 		Create: func() (sacloud.ResourceIDHolder, error) {
 			return client.NFS.CreateWithPlan(param, sacloud.NFSPlanSSD, sacloud.NFSSize100G)
 		},
-		AsyncWaitForCopy: func(id int64) (chan interface{}, chan interface{}, chan error) {
+		AsyncWaitForCopy: func(id sacloud.ID) (chan interface{}, chan interface{}, chan error) {
 			c, p, e := client.NFS.AsyncSleepWhileCopying(id, client.DefaultTimeoutDuration, 5)
 			return c, p, e
 		},
-		Delete: func(id int64) error {
+		Delete: func(id sacloud.ID) error {
 			_, err := client.NFS.Delete(id)
 			return err
 		},
-		WaitForUp: func(id int64) error {
+		WaitForUp: func(id sacloud.ID) error {
 			return client.NFS.SleepUntilUp(id, client.DefaultTimeoutDuration)
 		},
 		RetryCount: 3,


### PR DESCRIPTION
Fixes #511 

IDの型不整合対応としてv2のtypes.IDをv1にバックポートする。
v1にはtypesパッケージが存在しないため、sacloud.IDとして導入する。

あわせてこれまでint64やjson.Numberとして扱ってきた各種IDをsacloud.IDに置き換える。
これにより既存クライアントに対しbreaking-changeとなる。