### PR TITLE
Remove structs tag:omitempty from bool or types.StringFlag attributes

### DIFF
--- a/pkg/mapconv/map.go
+++ b/pkg/mapconv/map.go
@@ -100,7 +100,7 @@ func (m *Map) Get(key string) (interface{}, error) {
 		k = strings.Replace(k, "[]", "", -1)
 
 		value := targetMap[k]
-		if value == nil {
+		if value == nil || reflect.ValueOf(value).IsZero() {
 			return nil, nil
 		}
 		if last {

--- a/sacloud/naked/auth_status.go
+++ b/sacloud/naked/auth_status.go
@@ -25,7 +25,7 @@ type AuthStatus struct {
 	AuthClass          types.EAuthClass         `json:",omitempty" yaml:"auth_class,omitempty" structs:",omitempty"`          // 認証クラス
 	AuthMethod         types.EAuthMethod        `json:",omitempty" yaml:"auth_method,omitempty" structs:",omitempty"`         // 認証方法
 	ExternalPermission types.ExternalPermission `json:",omitempty" yaml:"external_permission,omitempty" structs:",omitempty"` // 他サービスへのアクセス権
-	IsAPIKey           bool                     `json:",omitempty" yaml:"is_api_key,omitempty" structs:",omitempty"`          // APIキーでのアクセスフラグ
+	IsAPIKey           bool                     `yaml:"is_api_key"`                                                           // APIキーでのアクセスフラグ
 	OperationPenalty   types.EOperationPenalty  `json:",omitempty" yaml:"operation_penalty,omitempty" structs:",omitempty"`   // オペレーションペナルティ
 	Permission         types.EPermission        `json:",omitempty" yaml:"permission,omitempty" structs:",omitempty"`          // 権限
 }

--- a/sacloud/naked/bill.go
+++ b/sacloud/naked/bill.go
@@ -26,7 +26,7 @@ type Bill struct {
 	Amount         int64      `json:",omitempty" yaml:"amount,omitempty" structs:",omitempty"`           // 金額
 	Date           *time.Time `json:",omitempty" yaml:"date,omitempty" structs:",omitempty"`             // 請求日
 	MemberID       string     `json:",omitempty" yaml:"member_id,omitempty" structs:",omitempty"`        // 会員ID
-	Paid           bool       `json:",omitempty" yaml:"paid,omitempty" structs:",omitempty"`             // 支払済フラグ
+	Paid           bool       `yaml:"paid"`                                                              // 支払済フラグ
 	PayLimit       *time.Time `json:",omitempty" yaml:"pay_limit,omitempty" structs:",omitempty"`        // 支払い期限
 	PaymentClassID types.ID   `json:",omitempty" yaml:"payment_class_id,omitempty" structs:",omitempty"` // 支払いクラスID
 }

--- a/sacloud/naked/disk.go
+++ b/sacloud/naked/disk.go
@@ -77,5 +77,5 @@ func (e *JobConfigError) String() string {
 
 // ResizePartitionRequest リサイズ時のオプション
 type ResizePartitionRequest struct {
-	Background bool `json:",omitempty" yaml:"background,omitempty" structs:",omitempty"`
+	Background bool `yaml:"background"`
 }

--- a/sacloud/naked/load_balancer.go
+++ b/sacloud/naked/load_balancer.go
@@ -88,7 +88,7 @@ func (s LoadBalancerSetting) MarshalJSON() ([]byte, error) {
 type LoadBalancerDestinationServer struct {
 	IPAddress   string             `json:",omitempty" yaml:"ip_address,omitempty" structs:",omitempty"`
 	Port        types.StringNumber `json:",omitempty" yaml:"port,omitempty" structs:",omitempty"`
-	Enabled     types.StringFlag   `json:",omitempty" yaml:"enabled,omitempty" structs:",omitempty"`
+	Enabled     types.StringFlag   `yaml:"enabled"`
 	HealthCheck *HealthCheck       `json:",omitempty" yaml:"health_check,omitempty" structs:",omitempty"`
 }
 

--- a/sacloud/naked/server.go
+++ b/sacloud/naked/server.go
@@ -39,7 +39,7 @@ type Server struct {
 	Disks             []*Disk                `json:",omitempty" yaml:"disks,omitempty" structs:",omitempty"`
 	Interfaces        []*Interface           `json:",omitempty" yaml:"interfaces,omitempty" structs:",omitempty"`
 	PrivateHost       *PrivateHost           `json:",omitempty" yaml:"private_host,omitempty" structs:",omitempty"`
-	WaitDiskMigration bool                   `json:",omitempty" yaml:"wait_disk_migration,omitempty" structs:",omitempty"`
+	WaitDiskMigration bool                   `yaml:"wait_disk_migration"`
 	ConnectedSwitches []*ConnectedSwitch     `json:",omitempty" yaml:"connected_switches,omitempty" structs:",omitempty"`
 }
 

--- a/sacloud/naked/sim.go
+++ b/sacloud/naked/sim.go
@@ -50,9 +50,9 @@ type SIMInfo struct {
 	IMSI                       []string         `json:"imsi,omitempty" yaml:"imsi,omitempty" structs:",omitempty"`
 	IP                         string           `json:"ip,omitempty" yaml:"ip,omitempty" structs:",omitempty"`
 	SessionStatus              string           `json:"session_status,omitempty" yaml:"session_status,omitempty" structs:",omitempty"`
-	IMEILock                   bool             `json:"imei_lock,omitempty" yaml:"imei_lock,omitempty" structs:",omitempty"`
-	Registered                 bool             `json:"registered,omitempty" yaml:"registered,omitempty" structs:",omitempty"`
-	Activated                  bool             `json:"activated,omitempty" yaml:"activated,omitempty" structs:",omitempty"`
+	IMEILock                   bool             `yaml:"imei_lock"`
+	Registered                 bool             `yaml:"registered"`
+	Activated                  bool             `yaml:"activated"`
 	ResourceID                 string           `json:"resource_id,omitempty" yaml:"resource_id,omitempty" structs:",omitempty"`
 	RegisteredDate             time.Time        `json:"registered_date,omitempty" yaml:"registered_date,omitempty" structs:",omitempty"`
 	ActivatedDate              time.Time        `json:"activated_date,omitempty" yaml:"activated_date,omitempty" structs:",omitempty"`
@@ -108,7 +108,7 @@ type SIMLog struct {
 
 // SIMNetworkOperatorConfig SIM通信キャリア設定
 type SIMNetworkOperatorConfig struct {
-	Allow       bool   `json:"allow,omitempty" yaml:"allow,omitempty" structs:",omitempty"`
+	Allow       bool   `yaml:"allow"`
 	CountryCode string `json:"country_code,omitempty" yaml:"country_code,omitempty" structs:",omitempty"`
 	Name        string `json:"name,omitempty" yaml:"name,omitempty" structs:",omitempty"`
 }

--- a/sacloud/naked/vpc_router.go
+++ b/sacloud/naked/vpc_router.go
@@ -72,7 +72,7 @@ type VPCRouterSetting struct {
 
 // VPCRouterInternetConnection インターフェース
 type VPCRouterInternetConnection struct {
-	Enabled types.StringFlag `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag `yaml:"enabled"`
 }
 
 // VPCRouterInterface インターフェース
@@ -152,7 +152,7 @@ func (i *VPCRouterInterface) MarshalJSON() ([]byte, error) {
 // VPCRouterStaticNAT スタティックNAT
 type VPCRouterStaticNAT struct {
 	Config  []*VPCRouterStaticNATConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag            `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag            `yaml:"enabled"`
 }
 
 // MarshalJSON Configが一つ以上ある場合にEnabledをtrueに設定する
@@ -178,7 +178,7 @@ type VPCRouterStaticNATConfig struct {
 // VPCRouterPortForwarding ポートフォワーディング設定
 type VPCRouterPortForwarding struct {
 	Config  []*VPCRouterPortForwardingConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag                 `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag                 `yaml:"enabled"`
 }
 
 // MarshalJSON Configが一つ以上ある場合にEnabledをtrueに設定する
@@ -206,7 +206,7 @@ type VPCRouterPortForwardingConfig struct {
 // VPCRouterFirewall ファイアウォール
 type VPCRouterFirewall struct {
 	Config  VPCRouterFirewallConfigs `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag         `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag         `yaml:"enabled"`
 }
 
 // MarshalJSON 常にEnabledをtrueに設定する
@@ -292,14 +292,14 @@ type VPCRouterFirewallRule struct {
 	DestinationNetwork types.VPCFirewallNetwork `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	DestinationPort    types.VPCFirewallPort    `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 	Action             types.Action             `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Logging            types.StringFlag         `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Logging            types.StringFlag         `yaml:"enabled"`
 	Description        string                   `yaml:"description"`
 }
 
 // VPCRouterDHCPServer DHCPサーバ
 type VPCRouterDHCPServer struct {
 	Config  []*VPCRouterDHCPServerConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag             `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag             `yaml:"enabled"`
 }
 
 // MarshalJSON Configが一つ以上ある場合にEnabledをtrueに設定する
@@ -326,7 +326,7 @@ type VPCRouterDHCPServerConfig struct {
 // VPCRouterDHCPStaticMappings DHCPスタティックマッピング
 type VPCRouterDHCPStaticMappings struct {
 	Config  []*VPCRouterDHCPStaticMappingConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag                    `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag                    `yaml:"enabled"`
 }
 
 // MarshalJSON Configが一つ以上ある場合にEnabledをtrueに設定する
@@ -351,7 +351,7 @@ type VPCRouterDHCPStaticMappingConfig struct {
 // VPCRouterPPTPServer PPTP
 type VPCRouterPPTPServer struct {
 	Config  *VPCRouterPPTPServerConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag           `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag           `yaml:"enabled"`
 }
 
 // VPCRouterPPTPServerConfig PPTP
@@ -363,7 +363,7 @@ type VPCRouterPPTPServerConfig struct {
 // VPCRouterL2TPIPsecServer L2TP
 type VPCRouterL2TPIPsecServer struct {
 	Config  *VPCRouterL2TPIPsecServerConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag                `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag                `yaml:"enabled"`
 }
 
 // VPCRouterL2TPIPsecServerConfig L2TP
@@ -376,7 +376,7 @@ type VPCRouterL2TPIPsecServerConfig struct {
 // VPCRouterRemoteAccessUsers リモートアクセスユーザー
 type VPCRouterRemoteAccessUsers struct {
 	Config  []*VPCRouterRemoteAccessUserConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag                   `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag                   `yaml:"enabled"`
 }
 
 // MarshalJSON Configが一つ以上ある場合にEnabledをtrueに設定する
@@ -401,7 +401,7 @@ type VPCRouterRemoteAccessUserConfig struct {
 // VPCRouterSiteToSiteIPsecVPN サイト間VPN
 type VPCRouterSiteToSiteIPsecVPN struct {
 	Config  []*VPCRouterSiteToSiteIPsecVPNConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag                     `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag                     `yaml:"enabled"`
 }
 
 // MarshalJSON Configが一つ以上ある場合にEnabledをtrueに設定する
@@ -429,7 +429,7 @@ type VPCRouterSiteToSiteIPsecVPNConfig struct {
 // VPCRouterStaticRoutes スタティックルート
 type VPCRouterStaticRoutes struct {
 	Config  []*VPCRouterStaticRouteConfig `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	Enabled types.StringFlag              `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	Enabled types.StringFlag              `yaml:"enabled"`
 }
 
 // MarshalJSON Configが一つ以上ある場合にEnabledをtrueに設定する

--- a/sacloud/naked/vpc_router_test.go
+++ b/sacloud/naked/vpc_router_test.go
@@ -144,7 +144,7 @@ const vpcRouterMultipleFirewallJSON = `
 }
 `
 
-var vpcRouterFirewallMarshaled = `{"Config":[{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[{"Protocol":"ip","Action":"deny","Description":""}]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]}],"Enabled":"True"}`
+var vpcRouterFirewallMarshaled = `{"Config":[{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[{"Protocol":"ip","Action":"deny","Logging":"False","Description":""}]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]},{"Receive":[],"Send":[]}],"Enabled":"True"}`
 
 func TestVPCRouterFirewall_UnmarshalJSON(t *testing.T) {
 	var firewallConfig VPCRouterFirewall

--- a/sacloud/naked/webaccel.go
+++ b/sacloud/naked/webaccel.go
@@ -33,8 +33,8 @@ type WebAccelSite struct {
 	Origin             string                    `json:",omitempty" yaml:"origin,omitempty" structs:",omitempty"`
 	HostHeader         string                    `json:",omitempty" yaml:"host_header,omitempty" structs:",omitempty"`
 	Status             types.EWebAccelStatus     `json:",omitempty" yaml:"status,omitempty" structs:",omitempty"`
-	HasCertificate     bool                      `json:",omitempty" yaml:"has_certificate,omitempty" structs:",omitempty"`
-	HasOldCertificate  bool                      `json:",omitempty" yaml:"has_old_certificate,omitempty" structs:",omitempty"`
+	HasCertificate     bool                      `yaml:"has_certificate"`
+	HasOldCertificate  bool                      `yaml:"has_old_certificate"`
 	GibSentInLastWeek  int64                     `json:",omitempty" yaml:"gib_sent_in_last_week,omitempty" structs:",omitempty"`
 	CertValidNotBefore int64                     `json:",omitempty" yaml:"cert_valid_not_before,omitempty" structs:",omitempty"`
 	CertValidNotAfter  int64                     `json:",omitempty" yaml:"cert_valid_not_after,omitempty" structs:",omitempty"`

--- a/sacloud/naked/zone.go
+++ b/sacloud/naked/zone.go
@@ -22,7 +22,7 @@ type Zone struct {
 	DisplayOrder int        `json:",omitempty" yaml:"display_order,omitempty" structs:",omitempty"`
 	Name         string     `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
 	Description  string     `json:",omitempty" yaml:"description,omitempty" structs:",omitempty"`
-	IsDummy      bool       `json:",omitempty" yaml:"is_dummy,omitempty" structs:",omitempty"`
+	IsDummy      bool       `yaml:"is_dummy"`
 	VNCProxy     *VNCProxy  `json:",omitempty" yaml:"vnc_proxy,omitempty" structs:",omitempty"`
 	FTPServer    *FTPServer `json:",omitempty" yaml:"ftp_server,omitempty" structs:",omitempty"`
 	Region       *Region    `json:",omitempty" yaml:"region,omitempty" structs:",omitempty"`


### PR DESCRIPTION
nakedモデルのbool型またはtypes.StringFlag型の項目からstructs:omitemptyタグを除去する。

### 問題

mapconvによるデータマッピング時にstructs.New(<target>).Map()を利用している。

https://github.com/sacloud/libsacloud/blob/564db1b0c2ab3cb5a6ad3d615b5ce3671160b37c/pkg/mapconv/mapconv.go#L109

ref: https://github.com/fatih/structs

この際、ネストしたstruct内の全てのエクスポートされている、かつomitemptyタグが指定されているフィールドがゼロ値を返した場合、map[string]interface{}に変換されずに元の型を維持したままとなる。

```go
	switch v.Kind() {
	case reflect.Struct:
		n := New(val.Interface())
		n.TagName = s.TagName
		m := n.Map()

		// do not add the converted value if there are no exported fields, ie:
		// time.Time
		if len(m) == 0 {
			finalVal = val.Interface()
		} else {
			finalVal = m
		}
```
https://github.com/fatih/structs/blob/878a968ab22548362a09bdb3322f98b00f470d46/structs.go#L517-L529

一方mapconvではネストしたstructについてはmap[string]interface{}で返されることを期待している。

https://github.com/sacloud/libsacloud/blob/564db1b0c2ab3cb5a6ad3d615b5ce3671160b37c/pkg/mapconv/map.go#L110-L156

しかし一部のtypes.StringFlag項目はゼロ値の場合でもリクエスト/レスポンスに含まれる場合があり、前述の通りネストしたstructがmap[string]interface{}に変換されないケースだとmapconvからエラーが返される。

### 対応

mapconv側を修正し変換されないケースに対応する、またはomitemptyタグを外す、のいずれかで対応できるが、ゼロ値が意味を持つ項目は現状だとtypes.StringFlag or bool項目に限られるため、今回はomitemptyタグを外す方向で修正する。

なお、一部のbool型項目にomitemptyが残っているが、送信専用、かつfalseの場合リクエスト時に値を含めたくない値となっている。