### PR TITLE
Use power utils when running CRUD tests

### DIFF
--- a/sacloud/test/database_op_test.go
+++ b/sacloud/test/database_op_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 )
 
 func TestDatabaseOpCRUD(t *testing.T) {
@@ -88,7 +89,7 @@ func TestDatabaseOpCRUD(t *testing.T) {
 		},
 		Shutdown: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
 			client := sacloud.NewDatabaseOp(caller)
-			return client.Shutdown(ctx, testZone, ctx.ID, &sacloud.ShutdownOption{Force: true})
+			return power.ShutdownDatabase(ctx, client, testZone, ctx.ID, true)
 		},
 
 		Delete: &testutil.CRUDTestDeleteFunc{

--- a/sacloud/test/load_balancer_op_test.go
+++ b/sacloud/test/load_balancer_op_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 )
 
 func TestLoadBalancerOp_CRUD(t *testing.T) {
@@ -84,7 +85,7 @@ func TestLoadBalancerOp_CRUD(t *testing.T) {
 
 		Shutdown: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
 			client := sacloud.NewLoadBalancerOp(caller)
-			return client.Shutdown(ctx, testZone, ctx.ID, &sacloud.ShutdownOption{Force: true})
+			return power.ShutdownLoadBalancer(ctx, client, testZone, ctx.ID, true)
 		},
 
 		Delete: &testutil.CRUDTestDeleteFunc{

--- a/sacloud/test/mobile_gateway_op_test.go
+++ b/sacloud/test/mobile_gateway_op_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 )
 
 func TestMobileGatewayOpCRUD(t *testing.T) {
@@ -380,7 +381,7 @@ func TestMobileGatewayOpCRUD(t *testing.T) {
 		},
 		Shutdown: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
 			client := sacloud.NewMobileGatewayOp(caller)
-			return client.Shutdown(ctx, testZone, ctx.ID, &sacloud.ShutdownOption{Force: true})
+			return power.ShutdownMobileGateway(ctx, client, testZone, ctx.ID, true)
 		},
 		Delete: &testutil.CRUDTestDeleteFunc{
 			Func: testMobileGatewayDelete,

--- a/sacloud/test/nfs_op_test.go
+++ b/sacloud/test/nfs_op_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 	"github.com/sacloud/libsacloud/v2/utils/query"
 )
 
@@ -86,7 +87,7 @@ func TestNFSOp_CRUD(t *testing.T) {
 
 		Shutdown: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
 			client := sacloud.NewNFSOp(caller)
-			return client.Shutdown(ctx, testZone, ctx.ID, &sacloud.ShutdownOption{Force: true})
+			return power.ShutdownNFS(ctx, client, testZone, ctx.ID, true)
 		},
 
 		Delete: &testutil.CRUDTestDeleteFunc{

--- a/sacloud/test/server_op_test.go
+++ b/sacloud/test/server_op_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/search/keys"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -136,7 +137,7 @@ func TestServerOp_CRUD(t *testing.T) {
 
 		Shutdown: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
 			client := sacloud.NewServerOp(caller)
-			return client.Shutdown(ctx, testZone, ctx.ID, &sacloud.ShutdownOption{Force: true})
+			return power.ShutdownServer(ctx, client, testZone, ctx.ID, true)
 		},
 
 		Delete: &testutil.CRUDTestDeleteFunc{

--- a/sacloud/test/vpc_router_op_test.go
+++ b/sacloud/test/vpc_router_op_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/power"
 )
 
 func TestVPCRouterOp_CRUD(t *testing.T) {
@@ -55,7 +56,7 @@ func TestVPCRouterOp_CRUD(t *testing.T) {
 
 		Shutdown: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
 			client := sacloud.NewVPCRouterOp(caller)
-			return client.Shutdown(ctx, testZone, ctx.ID, &sacloud.ShutdownOption{Force: true})
+			return power.ShutdownVPCRouter(ctx, client, testZone, ctx.ID, true)
 		},
 
 		Delete: &testutil.CRUDTestDeleteFunc{
@@ -386,7 +387,7 @@ func TestVPCRouterOp_WithRouterCRUD(t *testing.T) {
 
 		Shutdown: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
 			client := sacloud.NewVPCRouterOp(caller)
-			return client.Shutdown(ctx, testZone, ctx.ID, &sacloud.ShutdownOption{Force: true})
+			return power.ShutdownVPCRouter(ctx, client, testZone, ctx.ID, true)
 		},
 
 		Delete: &testutil.CRUDTestDeleteFunc{

--- a/sacloud/testutil/testing.go
+++ b/sacloud/testutil/testing.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -214,6 +215,9 @@ func Run(t TestT, testCase *CRUDTestCase) {
 			if err := testCase.Cleanup(testContext, testCase.SetupAPICallerFunc()); err != nil {
 				t.Logf("Cleanup is failed: ", err)
 			}
+		}
+		if err := recover(); err != nil {
+			t.Logf("Unexcepted error is occurred: %v, Trace: %s", err, string(debug.Stack()))
 		}
 	}()
 


### PR DESCRIPTION
sacloud/test配下でのCRUDテスト時、アプライアンスのシャットダウンにutils/powerパッケージを利用する。

related: #516 