### PR TITLE
Return latest working status when error is occurred

### DIFF
--- a/utils/builder/database/builder.go
+++ b/utils/builder/database/builder.go
@@ -116,10 +116,13 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.Database, er
 	}
 
 	result, err := builder.Setup(ctx, zone)
-	if err != nil {
-		return nil, err
+	var db *sacloud.Database
+	if result != nil {
+		db = result.(*sacloud.Database)
 	}
-	db := result.(*sacloud.Database)
+	if err != nil {
+		return db, err
+	}
 
 	// refresh
 	db, err = b.Client.Database.Read(ctx, zone, db.ID)

--- a/utils/builder/disk/builder.go
+++ b/utils/builder/disk/builder.go
@@ -696,6 +696,9 @@ func build(ctx context.Context, client *APIClient, zone string, serverID types.I
 		disk, err = client.Disk.CreateWithConfig(ctx, zone, diskReq, editReq, false, distantFrom)
 	}
 	if err != nil {
+		if disk != nil {
+			return &BuildResult{DiskID: disk.ID}, err
+		}
 		return nil, err
 	}
 
@@ -704,6 +707,9 @@ func build(ctx context.Context, client *APIClient, zone string, serverID types.I
 	})
 	lastState, err := waiter.WaitForState(ctx)
 	if err != nil {
+		if lastState != nil {
+			return &BuildResult{DiskID: lastState.(*sacloud.Disk).ID}, err
+		}
 		return nil, err
 	}
 	disk = lastState.(*sacloud.Disk)

--- a/utils/builder/internet/builder.go
+++ b/utils/builder/internet/builder.go
@@ -81,13 +81,13 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.Internet, er
 		return b.Client.Internet.Read(ctx, zone, internet.ID)
 	}, b.NotFoundRetry)
 	if _, err := waiter.WaitForState(ctx); err != nil {
-		return nil, err
+		return internet, err
 	}
 
 	if b.EnableIPv6 {
 		_, err = b.Client.Internet.EnableIPv6(ctx, zone, internet.ID)
 		if err != nil {
-			return nil, err
+			return internet, err
 		}
 	}
 

--- a/utils/builder/localrouter/builder.go
+++ b/utils/builder/localrouter/builder.go
@@ -67,18 +67,18 @@ func (b *Builder) Build(ctx context.Context) (*sacloud.LocalRouter, error) {
 		return nil, err
 	}
 
-	localRouter, err = b.Client.LocalRouter.UpdateSettings(ctx, localRouter.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+	updLocalRouter, err := b.Client.LocalRouter.UpdateSettings(ctx, localRouter.ID, &sacloud.LocalRouterUpdateSettingsRequest{
 		Switch:       b.Switch,
 		Interface:    b.Interface,
 		StaticRoutes: b.StaticRoutes,
 		SettingsHash: localRouter.SettingsHash,
 	})
 	if err != nil {
-		return nil, err
+		return localRouter, err
 	}
 
 	if len(b.Peers) > 0 {
-		localRouter, err = b.Client.LocalRouter.UpdateSettings(ctx, localRouter.ID, &sacloud.LocalRouterUpdateSettingsRequest{
+		updLocalRouter, err = b.Client.LocalRouter.UpdateSettings(ctx, localRouter.ID, &sacloud.LocalRouterUpdateSettingsRequest{
 			Switch:       localRouter.Switch,
 			Interface:    localRouter.Interface,
 			StaticRoutes: localRouter.StaticRoutes,
@@ -86,11 +86,11 @@ func (b *Builder) Build(ctx context.Context) (*sacloud.LocalRouter, error) {
 			SettingsHash: localRouter.SettingsHash,
 		})
 		if err != nil {
-			return nil, err
+			return localRouter, err
 		}
 	}
 
-	return localRouter, nil
+	return updLocalRouter, nil
 }
 
 // Update ローカルルータの更新

--- a/utils/builder/mobilegateway/builder.go
+++ b/utils/builder/mobilegateway/builder.go
@@ -213,17 +213,20 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.MobileGatewa
 	}
 
 	result, err := builder.Setup(ctx, zone)
-	if err != nil {
-		return nil, err
+	var mgw *sacloud.MobileGateway
+	if result != nil {
+		mgw = result.(*sacloud.MobileGateway)
 	}
-	mgw := result.(*sacloud.MobileGateway)
+	if err != nil {
+		return mgw, err
+	}
 
 	// refresh
-	mgw, err = b.Client.MobileGateway.Read(ctx, zone, mgw.ID)
+	refreshed, err := b.Client.MobileGateway.Read(ctx, zone, mgw.ID)
 	if err != nil {
-		return nil, err
+		return mgw, err
 	}
-	return mgw, nil
+	return refreshed, nil
 }
 
 // Update モバイルゲートウェイの更新

--- a/utils/builder/registry/builder.go
+++ b/utils/builder/registry/builder.go
@@ -79,7 +79,7 @@ func (b *Builder) Build(ctx context.Context) (*sacloud.ContainerRegistry, error)
 			Permission: user.Permission,
 		}
 		if err := b.Client.ContainerRegistry.AddUser(ctx, reg.ID, u); err != nil {
-			return nil, err
+			return reg, err
 		}
 	}
 

--- a/utils/builder/server/builder_test.go
+++ b/utils/builder/server/builder_test.go
@@ -179,7 +179,7 @@ func TestBuilder_Build(t *testing.T) {
 			err: errors.New("dummy"),
 		},
 		{
-			msg: "building disk returns error",
+			msg: "validating disk returns error",
 			in: &Builder{
 				DiskBuilders: []disk.Builder{
 					&dummyDiskBuilder{
@@ -229,7 +229,7 @@ func TestBuilder_Build(t *testing.T) {
 					},
 				},
 			},
-			out: nil,
+			out: &BuildResult{ServerID: 1},
 			err: errors.New("dummy"),
 		},
 		{
@@ -250,7 +250,7 @@ func TestBuilder_Build(t *testing.T) {
 					},
 				},
 			},
-			out: nil,
+			out: &BuildResult{ServerID: 1},
 			err: errors.New("dummy"),
 		},
 		{
@@ -271,7 +271,7 @@ func TestBuilder_Build(t *testing.T) {
 					},
 				},
 			},
-			out: nil,
+			out: &BuildResult{ServerID: 1},
 			err: errors.New("dummy"),
 		},
 	}

--- a/utils/builder/sim/builder.go
+++ b/utils/builder/sim/builder.go
@@ -72,27 +72,27 @@ func (b *Builder) Build(ctx context.Context) (*sacloud.SIM, error) {
 	}
 
 	if err := b.Client.SIM.SetNetworkOperator(ctx, sim.ID, b.Carrier); err != nil {
-		return nil, err
+		return sim, err
 	}
 
 	if b.Activate {
 		if err := b.Client.SIM.Activate(ctx, sim.ID); err != nil {
-			return nil, err
+			return sim, err
 		}
 	}
 
 	if b.IMEI != "" {
 		if err := b.Client.SIM.IMEILock(ctx, sim.ID, &sacloud.SIMIMEILockRequest{IMEI: b.IMEI}); err != nil {
-			return nil, err
+			return sim, err
 		}
 	}
 
 	// reload
-	sim, err = query.FindSIMByID(ctx, b.Client.SIM, sim.ID)
+	refreshed, err := query.FindSIMByID(ctx, b.Client.SIM, sim.ID)
 	if err != nil {
-		return nil, err
+		return sim, err
 	}
-	return sim, nil
+	return refreshed, nil
 }
 
 // Update SIMの更新

--- a/utils/builder/vpcrouter/builder.go
+++ b/utils/builder/vpcrouter/builder.go
@@ -248,17 +248,20 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.VPCRouter, e
 	}
 
 	result, err := builder.Setup(ctx, zone)
-	if err != nil {
-		return nil, err
+	var vpcRouter *sacloud.VPCRouter
+	if result != nil {
+		vpcRouter = result.(*sacloud.VPCRouter)
 	}
-	vpcRouter := result.(*sacloud.VPCRouter)
+	if err != nil {
+		return vpcRouter, err
+	}
 
 	// refresh
-	vpcRouter, err = b.Client.Read(ctx, zone, vpcRouter.ID)
+	refreshed, err := b.Client.Read(ctx, zone, vpcRouter.ID)
 	if err != nil {
-		return nil, err
+		return vpcRouter, err
 	}
-	return vpcRouter, nil
+	return refreshed, nil
 }
 
 // Update VPCルータの更新(再起動を伴う場合あり)

--- a/utils/setup/retryable_setup.go
+++ b/utils/setup/retryable_setup.go
@@ -118,7 +118,7 @@ func (r *RetryableSetup) Setup(ctx context.Context, zone string) (interface{}, e
 			// コピー待ち、Failedになった場合はリソース削除
 			state, err := r.waitForCopyWithCleanup(ctx, zone, id)
 			if err != nil {
-				return nil, err
+				return state, err
 			}
 			if state != nil {
 				created = state
@@ -129,12 +129,12 @@ func (r *RetryableSetup) Setup(ctx context.Context, zone string) (interface{}, e
 
 		// 起動前の設定など
 		if err := r.provisionBeforeUp(ctx, zone, id, created); err != nil {
-			return nil, err
+			return created, err
 		}
 
 		// 起動待ち
 		if err := r.waitForUp(ctx, zone, id, created); err != nil {
-			return nil, err
+			return created, err
 		}
 
 		if created != nil {


### PR DESCRIPTION
fixes #495 

builderパッケージのリソース作成処理でエラーが発生した時にそこまでに作成されたリソースについての情報を返すようにする。

### Motivation

これまではエラーが発生した時は以下の様にnil+エラーを返していた。
```go
if err != nil {
    return nil , err
}
```

これをステートレスなクライアントから扱う際、Builder内ですでに作成されたリソースについての情報を得る手段がなく、リカバリーのための手段が提供されない。

例えばVPCルータ向けのbuilderでは作成 -> 設定投入 -> 電源操作という流れで構築される。
この中で、VPCルータ作成後にエラーになった場合などが問題となる。

### 対応

builderはエラー発生時でもなるべく最新の情報を返すようにする。
クライアント側は以下の様にエラーチェックに加えて必要に応じてクリーンアップ処理を実装する。

```go
result, err := builder.Setup(ctx, zone)
if err != nil {
    if result != nil {
       // クリーンアップ処理
    }
    log.Fatal(err) // エラー処理
}
```