### PR TITLE
Introduce reference utils

### DIFF
--- a/utils/cleanup/bridge.go
+++ b/utils/cleanup/bridge.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// DeleteBridge 他リソースからの参照を確認した上でリソースの削除を行う
+func DeleteBridge(ctx context.Context, caller sacloud.APICaller, zone string, zones []string, id types.ID, option query.CheckReferencedOption) error {
+	if err := query.WaitWhileBridgeIsReferenced(ctx, caller, zones, id, option); err != nil {
+		return fmt.Errorf("Bridge[%s] is still being used by other resources: %s", id, err)
+	}
+	return sacloud.NewBridgeOp(caller).Delete(ctx, zone, id)
+}

--- a/utils/cleanup/cdrom.go
+++ b/utils/cleanup/cdrom.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// DeleteCDROM 他のリソースから参照されていないかを確認した上で削除する
+func DeleteCDROM(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID, option query.CheckReferencedOption) error {
+	if err := query.WaitWhileCDROMIsReferenced(ctx, caller, zone, id, option); err != nil {
+		return fmt.Errorf("CD-ROM[%s] is still being used by other resources: %s", id, err)
+	}
+	return sacloud.NewCDROMOp(caller).Delete(ctx, zone, id)
+}

--- a/utils/cleanup/disk.go
+++ b/utils/cleanup/disk.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// DeleteDisk 他のリソースから参照されていないかを確認した上で削除する
+func DeleteDisk(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID, option query.CheckReferencedOption) error {
+	if err := query.WaitWhileDiskIsReferenced(ctx, caller, zone, id, option); err != nil {
+		return fmt.Errorf("Disk[%s] is still being used by other resources: %s", id, err)
+	}
+	return sacloud.NewDiskOp(caller).Delete(ctx, zone, id)
+}

--- a/utils/cleanup/packet_filter.go
+++ b/utils/cleanup/packet_filter.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// DeletePacketFilter 他のリソースから参照されていないかを確認した上で削除する
+func DeletePacketFilter(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID, option query.CheckReferencedOption) error {
+	if err := query.WaitWhilePacketFilterIsReferenced(ctx, caller, zone, id, option); err != nil {
+		return fmt.Errorf("PacketFilter[%s] is still being used by other resources: %s", id, err)
+	}
+	return sacloud.NewPacketFilterOp(caller).Delete(ctx, zone, id)
+}

--- a/utils/cleanup/private_host.go
+++ b/utils/cleanup/private_host.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// DeletePrivateHost 他のリソースから参照されていないかを確認した上で削除する
+func DeletePrivateHost(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID, option query.CheckReferencedOption) error {
+	if err := query.WaitWhilePrivateHostIsReferenced(ctx, caller, zone, id, option); err != nil {
+		return fmt.Errorf("PrivateHost[%s] is still being used by other resources: %s", id, err)
+	}
+	return sacloud.NewPrivateHostOp(caller).Delete(ctx, zone, id)
+}

--- a/utils/cleanup/sim.go
+++ b/utils/cleanup/sim.go
@@ -16,6 +16,7 @@ package cleanup
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -34,4 +35,12 @@ func DeleteSIM(ctx context.Context, client sacloud.SIMAPI, id types.ID) error {
 		}
 	}
 	return client.Delete(ctx, id)
+}
+
+// DeleteSIMWithReferencedCheck 他リソースからの参照を確認した上でリソースの削除を行う
+func DeleteSIMWithReferencedCheck(ctx context.Context, caller sacloud.APICaller, zones []string, id types.ID, option query.CheckReferencedOption) error {
+	if err := query.WaitWhileSIMIsReferenced(ctx, caller, zones, id, option); err != nil {
+		return fmt.Errorf("SIM[%s] is still being used by other resources: %s", id, err)
+	}
+	return DeleteSIM(ctx, sacloud.NewSIMOp(caller), id)
 }

--- a/utils/cleanup/switch.go
+++ b/utils/cleanup/switch.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// DeleteSwitch 他のリソースから参照されていないかを確認した上で削除する
+func DeleteSwitch(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID, option query.CheckReferencedOption) error {
+	if err := query.WaitWhileSwitchIsReferenced(ctx, caller, zone, id, option); err != nil {
+		return fmt.Errorf("Switch[%s] is still being used by other resources: %s", id, err)
+	}
+	return sacloud.NewSwitchOp(caller).Delete(ctx, zone, id)
+}

--- a/utils/query/referenced.go
+++ b/utils/query/referenced.go
@@ -1,0 +1,393 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// IsPrivateHostReferenced 指定の専有ホストが利用されている場合trueを返す
+func IsPrivateHostReferenced(ctx context.Context, caller sacloud.APICaller, zone string, privateHostID types.ID) (bool, error) {
+	return checkReferenced(ctx, caller, []string{zone}, privateHostID, []referenceFindFunc{
+		findServerByPrivateHostID,
+	})
+}
+
+// WaitWhilePrivateHostIsReferenced 指定の専有ホストが利用されている間待ち合わせる
+func WaitWhilePrivateHostIsReferenced(ctx context.Context, caller sacloud.APICaller, zone string, privateHostID types.ID, option CheckReferencedOption) error {
+	return waitWhileReferenced(ctx, option, func() (bool, error) {
+		return IsPrivateHostReferenced(ctx, caller, zone, privateHostID)
+	})
+}
+
+// IsPacketFilterReferenced 指定のパケットフィルタが利用されている場合trueを返す
+func IsPacketFilterReferenced(ctx context.Context, caller sacloud.APICaller, zone string, packetFilterID types.ID) (bool, error) {
+	return checkReferenced(ctx, caller, []string{zone}, packetFilterID, []referenceFindFunc{
+		findServerByPacketFilterID,
+	})
+}
+
+// WaitWhilePacketFilterIsReferenced 指定のパケットフィルタが利用されている間待ち合わせる
+func WaitWhilePacketFilterIsReferenced(ctx context.Context, caller sacloud.APICaller, zone string, packetFilterID types.ID, option CheckReferencedOption) error {
+	return waitWhileReferenced(ctx, option, func() (bool, error) {
+		return IsPacketFilterReferenced(ctx, caller, zone, packetFilterID)
+	})
+}
+
+// IsSIMReferenced 指定のSIMが利用されている場合trueを返す
+func IsSIMReferenced(ctx context.Context, caller sacloud.APICaller, zones []string, simID types.ID) (bool, error) {
+	return checkReferenced(ctx, caller, zones, simID, []referenceFindFunc{
+		findMobileGatewayBySIMID,
+	})
+}
+
+// WaitWhileSIMIsReferenced 指定のSIMが利用されている間待ち合わせる
+func WaitWhileSIMIsReferenced(ctx context.Context, caller sacloud.APICaller, zones []string, simID types.ID, option CheckReferencedOption) error {
+	return waitWhileReferenced(ctx, option, func() (bool, error) {
+		return IsSIMReferenced(ctx, caller, zones, simID)
+	})
+}
+
+// IsBridgeReferenced 指定のブリッジが利用されている場合trueを返す
+func IsBridgeReferenced(ctx context.Context, caller sacloud.APICaller, zones []string, bridgeID types.ID) (bool, error) {
+	return checkReferenced(ctx, caller, zones, bridgeID, []referenceFindFunc{
+		findSwitchByBridgeID,
+	})
+}
+
+// WaitWhileBridgeIsReferenced 指定のSIMが利用されている間待ち合わせる
+func WaitWhileBridgeIsReferenced(ctx context.Context, caller sacloud.APICaller, zones []string, bridgeID types.ID, option CheckReferencedOption) error {
+	return waitWhileReferenced(ctx, option, func() (bool, error) {
+		return IsBridgeReferenced(ctx, caller, zones, bridgeID)
+	})
+}
+
+// IsCDROMReferenced 指定のCD-ROM(ISOイメージ)が利用されている場合trueを返す
+func IsCDROMReferenced(ctx context.Context, caller sacloud.APICaller, zone string, cdromID types.ID) (bool, error) {
+	return checkReferenced(ctx, caller, []string{zone}, cdromID, []referenceFindFunc{
+		findServerByCDROMID,
+	})
+}
+
+// WaitWhileCDROMIsReferenced 指定のCD-ROM(ISOイメージ)が利用されている間待ち合わせる
+func WaitWhileCDROMIsReferenced(ctx context.Context, caller sacloud.APICaller, zone string, cdromID types.ID, option CheckReferencedOption) error {
+	return waitWhileReferenced(ctx, option, func() (bool, error) {
+		return IsCDROMReferenced(ctx, caller, zone, cdromID)
+	})
+}
+
+// IsDiskReferenced 指定のディスクが利用されている場合trueを返す
+func IsDiskReferenced(ctx context.Context, caller sacloud.APICaller, zone string, diskID types.ID) (bool, error) {
+	return checkReferenced(ctx, caller, []string{zone}, diskID, []referenceFindFunc{
+		findServerByDiskID,
+	})
+}
+
+// WaitWhileDiskIsReferenced 指定のディスクが利用されている間待ち合わせる
+func WaitWhileDiskIsReferenced(ctx context.Context, caller sacloud.APICaller, zone string, diskID types.ID, option CheckReferencedOption) error {
+	return waitWhileReferenced(ctx, option, func() (bool, error) {
+		return IsDiskReferenced(ctx, caller, zone, diskID)
+	})
+}
+
+// IsSwitchReferenced 指定のスイッチが利用されている場合trueを返す
+//
+// ハイブリッド接続情報が残っている場合にも参照されているものとみなしtrueを返す
+func IsSwitchReferenced(ctx context.Context, caller sacloud.APICaller, zone string, switchID types.ID) (bool, error) {
+	return checkReferenced(ctx, caller, []string{zone}, switchID, []referenceFindFunc{
+		switchHasHybridConnection,
+		findServerBySwitchID,
+		findLoadBalancerBySwitchID,
+		findVPCRouterBySwitchID,
+		findDatabaseBySwitchID,
+		findNFSBySwitchID,
+		findMobileGatewayBySwitchID,
+	})
+}
+
+// WaitWhileSwitchIsReferenced 指定のディスクが利用されている間待ち合わせる
+func WaitWhileSwitchIsReferenced(ctx context.Context, caller sacloud.APICaller, zone string, switchID types.ID, option CheckReferencedOption) error {
+	return waitWhileReferenced(ctx, option, func() (bool, error) {
+		return IsSwitchReferenced(ctx, caller, zone, switchID)
+	})
+}
+
+type referenceFindFunc func(context.Context, sacloud.APICaller, string, types.ID) (bool, error)
+
+func checkReferenced(ctx context.Context, caller sacloud.APICaller, zones []string, id types.ID, finder []referenceFindFunc) (bool, error) {
+	if len(zones) == 0 {
+		zones = sacloud.SakuraCloudZones
+	}
+
+	errCh := make(chan error)
+	compCh := make(chan bool)
+	defer close(errCh)
+	defer close(compCh)
+
+	var wg sync.WaitGroup
+	wg.Add(len(finder))
+
+	for _, zone := range zones {
+		for _, f := range finder {
+			go func(zone string, f referenceFindFunc) {
+				exists, err := f(ctx, caller, zone, id)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if exists {
+					compCh <- true
+				}
+				wg.Done()
+			}(zone, f)
+		}
+	}
+	go func() {
+		wg.Wait()
+		compCh <- false
+	}()
+
+	for {
+		select {
+		case err := <-errCh:
+			return false, err
+		case result := <-compCh:
+			return result, nil
+		}
+	}
+}
+
+func switchHasHybridConnection(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	swOp := sacloud.NewSwitchOp(caller)
+	sw, err := swOp.Read(ctx, zone, id)
+	if err != nil {
+		return false, fmt.Errorf("reading switch is failed: %s", err)
+	}
+	return !sw.HybridConnectionID.IsEmpty(), nil
+}
+
+func findServerBySwitchID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	swOp := sacloud.NewSwitchOp(caller)
+
+	searched, err := swOp.GetServers(ctx, zone, id)
+	if err != nil {
+		return false, fmt.Errorf("finding server is failed: %s", err)
+	}
+	return searched.Count != 0, nil
+}
+
+func findServerByPrivateHostID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	serverOp := sacloud.NewServerOp(caller)
+
+	searched, err := serverOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding Server is failed: %s", err)
+	}
+
+	for _, s := range searched.Servers {
+		if s.PrivateHostID == id {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func findServerByPacketFilterID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	serverOp := sacloud.NewServerOp(caller)
+
+	searched, err := serverOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding Server is failed: %s", err)
+	}
+
+	for _, s := range searched.Servers {
+		for _, iface := range s.Interfaces {
+			if iface.PacketFilterID == id {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func findServerByCDROMID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	serverOp := sacloud.NewServerOp(caller)
+
+	searched, err := serverOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding Server is failed: %s", err)
+	}
+
+	for _, server := range searched.Servers {
+		if server.CDROMID == id {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func findServerByDiskID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	serverOp := sacloud.NewServerOp(caller)
+
+	searched, err := serverOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding Server is failed: %s", err)
+	}
+
+	for _, server := range searched.Servers {
+		for _, disk := range server.Disks {
+			if disk.ID == id {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func findSwitchByBridgeID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	swOp := sacloud.NewSwitchOp(caller)
+
+	searched, err := swOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding Switch is failed: %s", err)
+	}
+
+	for _, sw := range searched.Switches {
+		if sw.BridgeID == id {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func findMobileGatewayBySIMID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	mgwOp := sacloud.NewMobileGatewayOp(caller)
+
+	searched, err := mgwOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding MobileGateway is failed: %s", err)
+	}
+
+	for _, mgw := range searched.MobileGateways {
+		sims, err := mgwOp.ListSIM(ctx, zone, mgw.ID)
+		if err != nil {
+			if sacloud.IsNotFoundError(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("finding SIMs is failed: %s", err)
+		}
+		for _, sim := range sims {
+			if sim.ResourceID == id.String() {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func findVPCRouterBySwitchID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	vrOp := sacloud.NewVPCRouterOp(caller)
+
+	searched, err := vrOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding VPCRouter is failed: %s", err)
+	}
+
+	for _, vpcRouter := range searched.VPCRouters {
+		for _, iface := range vpcRouter.Interfaces {
+			if iface.SwitchScope != types.Scopes.Shared && iface.SwitchID == id {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func findLoadBalancerBySwitchID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	lbOp := sacloud.NewLoadBalancerOp(caller)
+
+	searched, err := lbOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding LoadBalancer is failed: %s", err)
+	}
+
+	for _, lb := range searched.LoadBalancers {
+		for _, iface := range lb.Interfaces {
+			if iface.SwitchScope != types.Scopes.Shared && iface.SwitchID == id {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func findDatabaseBySwitchID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	dbOp := sacloud.NewDatabaseOp(caller)
+
+	searched, err := dbOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding Database is failed: %s", err)
+	}
+
+	for _, db := range searched.Databases {
+		for _, iface := range db.Interfaces {
+			if iface.SwitchScope != types.Scopes.Shared && iface.SwitchID == id {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func findNFSBySwitchID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	nfsOp := sacloud.NewNFSOp(caller)
+
+	searched, err := nfsOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding NFS is failed: %s", err)
+	}
+
+	for _, nfs := range searched.NFS {
+		for _, iface := range nfs.Interfaces {
+			if iface.SwitchScope != types.Scopes.Shared && iface.SwitchID == id {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func findMobileGatewayBySwitchID(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+	mgwOp := sacloud.NewMobileGatewayOp(caller)
+
+	searched, err := mgwOp.Find(ctx, zone, &sacloud.FindCondition{})
+	if err != nil {
+		return false, fmt.Errorf("finding MobileGateway is failed: %s", err)
+	}
+
+	for _, mgw := range searched.MobileGateways {
+		for _, iface := range mgw.Interfaces {
+			if iface.SwitchScope != types.Scopes.Shared && iface.SwitchID == id {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}

--- a/utils/query/wait.go
+++ b/utils/query/wait.go
@@ -1,0 +1,80 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// DefaultTimeoutDuration 被参照がなくなるまでのデフォルトタイムアウト
+	DefaultTimeoutDuration = time.Hour
+	// DefaultTick 被参照確認のデフォルト間隔
+	DefaultTick = 5 * time.Second
+)
+
+// DefaultCheckReferencedOption 被参照確認動作のデフォルトオプション
+var DefaultCheckReferencedOption = CheckReferencedOption{
+	Timeout: DefaultTimeoutDuration,
+	Tick:    DefaultTick,
+}
+
+// CheckReferencedOption 被参照確認動作のオプション
+type CheckReferencedOption struct {
+	// Timeout 被参照がなくなるまでのタイムアウト
+	Timeout time.Duration
+	// Tick 被参照確認の間隔
+	Tick time.Duration
+}
+
+func (c *CheckReferencedOption) init() {
+	if c.Timeout <= 0 {
+		c.Timeout = DefaultTimeoutDuration
+	}
+	if c.Tick <= 0 {
+		c.Tick = DefaultTick
+	}
+}
+
+// WaitWhileReferenced 参照されている間待ち合わせを行う
+func waitWhileReferenced(ctx context.Context, option CheckReferencedOption, f func() (bool, error)) error {
+	option.init()
+
+	if option.Timeout > 0 {
+		c, cancel := context.WithTimeout(ctx, option.Timeout)
+		defer cancel()
+		ctx = c
+	}
+
+	t := time.NewTicker(option.Tick)
+	defer t.Stop()
+
+	// initial call
+	if found, err := f(); !found || err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-t.C:
+			if found, err := f(); !found || err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}

--- a/utils/query/wait_test.go
+++ b/utils/query/wait_test.go
@@ -1,0 +1,114 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testChecker struct {
+	_called int
+	f       func(called int) (bool, error)
+	mu      sync.Mutex
+}
+
+func (c *testChecker) isExists() (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c._called++
+	return c.f(c._called)
+}
+
+func (c *testChecker) called() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c._called
+}
+
+func TestWaitWhileReferenced_called(t *testing.T) {
+	checker := &testChecker{
+		f: func(called int) (bool, error) {
+			if called == 2 {
+				return false, nil
+			}
+			return true, nil
+		},
+	}
+	err := waitWhileReferenced(context.Background(), CheckReferencedOption{Tick: time.Millisecond, Timeout: time.Second}, checker.isExists)
+	if err != nil {
+		t.Error(err)
+	}
+
+	require.Equal(t, 2, checker.called())
+}
+
+func TestWaitWhileReferenced_contextCanceled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	checker := &testChecker{
+		f: func(c int) (bool, error) {
+			return true, nil
+		},
+	}
+
+	err := waitWhileReferenced(ctx, CheckReferencedOption{Tick: time.Millisecond, Timeout: time.Second}, checker.isExists)
+	if err.Error() != "context deadline exceeded" {
+		t.Errorf("unexpected error: expected: %s, actual: %s", "context deadline exceeded", err)
+	}
+
+	if checker.called() < 2 {
+		t.Error("check func was not called when retry")
+	}
+}
+
+func TestWaitWhileReferenced_checkFuncReturnsError(t *testing.T) {
+	checker := &testChecker{
+		f: func(called int) (bool, error) {
+			if called == 2 {
+				return false, errors.New("dummy")
+			}
+			return true, nil
+		},
+	}
+
+	err := waitWhileReferenced(context.Background(), CheckReferencedOption{Tick: time.Millisecond, Timeout: time.Second}, checker.isExists)
+	require.Equal(t, errors.New("dummy"), err)
+	require.Equal(t, 2, checker.called())
+}
+
+func TestWaitWhileReferenced_optionTimeout(t *testing.T) {
+	checker := &testChecker{
+		f: func(called int) (bool, error) {
+			return true, nil
+		},
+	}
+
+	err := waitWhileReferenced(context.Background(), CheckReferencedOption{Tick: time.Millisecond, Timeout: 10 * time.Millisecond}, checker.isExists)
+	if err.Error() != "context deadline exceeded" {
+		t.Errorf("unexpected error: expected: %s, actual: %s", "context deadline exceeded", err)
+	}
+
+	if checker.called() < 2 {
+		t.Error("check func was not called when retry")
+	}
+}


### PR DESCRIPTION
fixes #517 

terraform-provider-sakuracloudから以下の処理を取り込む
https://github.com/sacloud/terraform-provider-sakuracloud/blob/841c6c7d24a3958a07bb026410aaa9a26ef977e7/sakuracloud/deletion_waiter.go

### 実装

以下2つに分割して取り込む

- utils/queryパッケージに他リソースから参照されているかの判定処理/待ち処理を実装
- utils/cleanupパッケージに上記の判定&待ち、削除処理を実装