### PR TITLE
Improve tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ default: gen fmt set-license goimports lint test
 
 .PHONY: tests
 test:
-	TESTACC= go test ./... $(TESTARGS) -v -timeout=120m -parallel=8 ;
+	TESTACC= go test ./... $(TESTARGS) -v -timeout=120m -parallel=8 -race;
 
 .PHONY: testacc
 testacc:

--- a/sacloud/fake/pool_test.go
+++ b/sacloud/fake/pool_test.go
@@ -22,6 +22,8 @@ import (
 
 func TestNextSubnet(t *testing.T) {
 	DataStore = NewInMemoryStore()
+	// internal init
+	vp = initValuePool(DataStore)
 
 	first := pool().nextSubnet(24)
 	require.Equal(t, "24.0.1.0", first.networkAddress)


### PR DESCRIPTION
- Use -race flag at unit testing
  unit testに-raceフラグを追加

- Use internal init on sacloud/fake/pool_test.go. 
  go test -count=2を利用した場合にパッケージスコープの値のテストがうまくいかないケースがあったのを修正