### PR TITLE
Fix goroutine handling

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277/go.mod h1:2X8KaoNd1J0lZ
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=

--- a/utils/query/referenced_test.go
+++ b/utils/query/referenced_test.go
@@ -1,0 +1,88 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckReferenced_withTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	caller := testutil.SingletonAPICaller()
+	var f referenceFindFunc = func(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+		time.Sleep(10 * time.Millisecond)
+		return false, ctx.Err()
+	}
+
+	_, err := checkReferenced(ctx, caller, []string{"tk1v"}, types.ID(0), []referenceFindFunc{f, f})
+	require.Error(t, err)
+	require.EqualValues(t, "context deadline exceeded", err.Error())
+}
+
+func TestCheckReferenced_withMultipleZone(t *testing.T) {
+	ctx := context.Background()
+	caller := testutil.SingletonAPICaller()
+	var mu sync.Mutex
+	called := 0
+
+	f := func(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		called++
+		return false, nil
+	}
+
+	zones := []string{"1", "2", "3"}
+	funcs := []referenceFindFunc{f, f, f}
+	result, err := checkReferenced(ctx, caller, zones, types.ID(0), funcs)
+	require.Equal(t, len(zones)*len(funcs), called)
+	require.Equal(t, result, false)
+	require.NoError(t, err)
+}
+
+func TestCheckReferenced_shortCircuit(t *testing.T) {
+	ctx := context.Background()
+	caller := testutil.SingletonAPICaller()
+	var mu sync.Mutex
+	called := 0
+
+	f := func(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		called++
+		if called == 2 {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	zones := []string{"1", "2", "3"}
+	funcs := []referenceFindFunc{f, f, f}
+	result, err := checkReferenced(ctx, caller, zones, types.ID(0), funcs)
+
+	require.Equal(t, 2, called)
+	require.Equal(t, result, true)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
fixes #524 

queryパッケージの`checkReferenced`を非同期 ->同期処理にする。
今後処理が膨らむケースがあれば再度非同期にすることを検討する。