### PR TITLE
アーカイブ共有API

### DIFF
--- a/v2/internal/define/archive.go
+++ b/v2/internal/define/archive.go
@@ -128,6 +128,36 @@ var archiveAPI = &dsl.Resource{
 				}, // sacloudパッケージ内のcustomized_envelopeで設定される
 			},
 		},
+		// CreateFromShared
+		{
+			ResourceName: archiveAPIName,
+			Name:         "CreateFromShared",
+			PathFormat:   dsl.DefaultPathFormat + "/{{.sourceArchiveID}}/to/zone/{{.zoneID}}",
+			Method:       http.MethodPost,
+			RequestEnvelope: dsl.RequestEnvelope(&dsl.EnvelopePayloadDesc{
+				Name: names.ResourceFieldName(archiveAPIName, dsl.PayloadForms.Singular),
+				Type: archiveNakedType,
+			}),
+			ResponseEnvelope: dsl.ResponseEnvelope(
+				&dsl.EnvelopePayloadDesc{
+					Name: names.ResourceFieldName(archiveAPIName, dsl.PayloadForms.Singular),
+					Type: archiveNakedType,
+				},
+			),
+			Arguments: dsl.Arguments{
+				&dsl.Argument{Name: "sourceArchiveID", Type: meta.TypeID},
+				&dsl.Argument{Name: "zoneID", Type: meta.TypeID},
+				dsl.MappableArgument("param", archiveCreateFromSharedParam, names.ResourceFieldName(archiveAPIName, dsl.PayloadForms.Singular)),
+			},
+			Results: dsl.Results{
+				{
+					SourceField: names.ResourceFieldName(archiveAPIName, dsl.PayloadForms.Singular),
+					DestField:   archiveView.Name,
+					IsPlural:    false,
+					Model:       archiveView,
+				},
+			},
+		},
 	},
 }
 
@@ -205,6 +235,18 @@ var (
 		NakedType: meta.Static(naked.ArchiveShareInfo{}),
 		Fields: []*dsl.FieldDesc{
 			fields.Def("SharedKey", meta.Static(types.ArchiveShareKey(""))),
+		},
+	}
+
+	archiveCreateFromSharedParam = &dsl.Model{
+		Name:      names.CreateParameterName(archiveAPIName) + "FromShared",
+		NakedType: archiveNakedType,
+		Fields: []*dsl.FieldDesc{
+			fields.Name(),
+			fields.Description(),
+			fields.Tags(),
+			fields.IconID(),
+			fields.Def("SourceSharedKey", meta.Static(types.ArchiveShareKey(""))),
 		},
 	}
 )

--- a/v2/internal/define/archive.go
+++ b/v2/internal/define/archive.go
@@ -17,6 +17,8 @@ package define
 import (
 	"net/http"
 
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+
 	"github.com/sacloud/libsacloud/v2/internal/define/names"
 	"github.com/sacloud/libsacloud/v2/internal/define/ops"
 	"github.com/sacloud/libsacloud/v2/internal/dsl"
@@ -95,6 +97,37 @@ var archiveAPI = &dsl.Resource{
 
 		// closeFTP
 		ops.CloseFTP(archiveAPIName),
+
+		// Share
+		&dsl.Operation{
+			ResourceName: archiveAPIName,
+			Name:         "Share",
+			PathFormat:   dsl.IDAndSuffixPathFormat("ftp"),
+			Method:       http.MethodPut,
+			RequestEnvelope: dsl.RequestEnvelope(
+				&dsl.EnvelopePayloadDesc{
+					Name: "Shared", // sacloudパッケージ内でMarshalJSON時に設定される
+					Type: meta.TypeFlag,
+				},
+			),
+			Arguments: dsl.Arguments{
+				dsl.ArgumentID,
+			},
+			ResponseEnvelope: dsl.ResponseEnvelope(
+				&dsl.EnvelopePayloadDesc{
+					Name: "ArchiveShareInfo",
+					Type: meta.Static(naked.ArchiveShareInfo{}),
+				},
+			),
+			Results: dsl.Results{
+				{
+					SourceField: "ArchiveShareInfo",
+					DestField:   "ArchiveShareInfo",
+					IsPlural:    false,
+					Model:       archiveShareInfo,
+				}, // sacloudパッケージ内のcustomized_envelopeで設定される
+			},
+		},
 	},
 }
 
@@ -164,6 +197,14 @@ var (
 			fields.Description(),
 			fields.Tags(),
 			fields.IconID(),
+		},
+	}
+
+	archiveShareInfo = &dsl.Model{
+		Name:      "ArchiveShareInfo",
+		NakedType: meta.Static(naked.ArchiveShareInfo{}),
+		Fields: []*dsl.FieldDesc{
+			fields.Def("SharedKey", meta.Static(types.ArchiveShareKey(""))),
 		},
 	}
 )

--- a/v2/sacloud/customize_envelope.go
+++ b/v2/sacloud/customize_envelope.go
@@ -223,3 +223,33 @@ func (s mobileGatewayFindRequestEnvelope) MarshalJSON() ([]byte, error) {
 	tmp.Filter[search.Key("Class")] = "mobilegateway"
 	return json.Marshal(tmp)
 }
+
+/*
+ * for Shared Archive
+ */
+
+func (s archiveShareRequestEnvelope) MarshalJSON() ([]byte, error) {
+	type alias archiveShareRequestEnvelope
+	tmp := alias(s)
+	tmp.Shared = true
+	return json.Marshal(tmp)
+}
+
+// UnmarshalJSON APIからの戻り値でレスポンスボディ直下にデータを持つことへの対応
+func (s *archiveShareResponseEnvelope) UnmarshalJSON(data []byte) error {
+	type alias archiveShareResponseEnvelope
+
+	var tmp alias
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+
+	var nakedData naked.ArchiveShareInfo
+	if err := json.Unmarshal(data, &nakedData); err != nil {
+		return err
+	}
+	tmp.ArchiveShareInfo = &nakedData
+
+	*s = archiveShareResponseEnvelope(tmp)
+	return nil
+}

--- a/v2/sacloud/fake/ops_archive.go
+++ b/v2/sacloud/fake/ops_archive.go
@@ -160,6 +160,7 @@ func (o *ArchiveOp) CloseFTP(ctx context.Context, zone string, id types.ID) erro
 	return nil
 }
 
+// Share is fake implementation
 func (o *ArchiveOp) Share(ctx context.Context, zone string, id types.ID) (*sacloud.ArchiveShareInfo, error) {
 	value, err := o.Read(ctx, zone, id)
 	if err != nil {
@@ -172,4 +173,27 @@ func (o *ArchiveOp) Share(ctx context.Context, zone string, id types.ID) (*saclo
 	return &sacloud.ArchiveShareInfo{
 		SharedKey: types.ArchiveShareKey(fmt.Sprintf("%s:%s:%s", zone, id.String(), "xxx")),
 	}, nil
+}
+
+// CreateFromShared is fake implementation
+func (o *ArchiveOp) CreateFromShared(ctx context.Context, zone string, sourceArchiveID types.ID, zoneID types.ID, param *sacloud.ArchiveCreateRequestFromShared) (*sacloud.Archive, error) {
+	result := &sacloud.Archive{}
+
+	copySameNameField(param, result)
+	fill(result, fillID, fillCreatedAt, fillScope)
+
+	result.DisplayOrder = int64(random(100))
+	result.Availability = types.Availabilities.Transferring
+	result.DiskPlanID = types.DiskPlans.HDD
+	result.DiskPlanName = "標準プラン"
+	result.DiskPlanStorageClass = "iscsi9999"
+
+	putArchive(zone, result)
+
+	id := result.ID
+	startDiskCopy(o.key, zone, func() (interface{}, error) {
+		return o.Read(context.Background(), zone, id)
+	})
+
+	return result, nil
 }

--- a/v2/sacloud/fake/ops_archive.go
+++ b/v2/sacloud/fake/ops_archive.go
@@ -159,3 +159,17 @@ func (o *ArchiveOp) CloseFTP(ctx context.Context, zone string, id types.ID) erro
 	putArchive(zone, value)
 	return nil
 }
+
+func (o *ArchiveOp) Share(ctx context.Context, zone string, id types.ID) (*sacloud.ArchiveShareInfo, error) {
+	value, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	value.SetAvailability(types.Availabilities.Uploading)
+	putArchive(zone, value)
+
+	return &sacloud.ArchiveShareInfo{
+		SharedKey: types.ArchiveShareKey(fmt.Sprintf("%s:%s:%s", zone, id.String(), "xxx")),
+	}, nil
+}

--- a/v2/sacloud/naked/archive.go
+++ b/v2/sacloud/naked/archive.go
@@ -66,3 +66,13 @@ type SourceArchiveInfo struct {
 type OriginalArchive struct {
 	ID types.ID `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
 }
+
+// SharedArchiveCreateRequest 共有アーカイブ作成リクエスト
+type SharedArchiveCreateRequest struct {
+	Shared bool `yaml:"shared"`
+}
+
+// ArchiveShareInfo 共有アーカイブ作成レスポンス
+type ArchiveShareInfo struct {
+	SharedKey types.ArchiveShareKey `yaml:"shared_key"`
+}

--- a/v2/sacloud/naked/archive.go
+++ b/v2/sacloud/naked/archive.go
@@ -22,27 +22,28 @@ import (
 
 // Archive アーカイブ
 type Archive struct {
-	ID              types.ID            `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
-	Name            string              `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
-	Description     string              `yaml:"description"`
-	Tags            types.Tags          `yaml:"tags"`
-	Icon            *Icon               `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
-	CreatedAt       *time.Time          `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
-	ModifiedAt      *time.Time          `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
-	Availability    types.EAvailability `json:",omitempty" yaml:"availability,omitempty" structs:",omitempty"`
-	DisplayOrder    int                 `json:",omitempty" yaml:"display_order,omitempty" structs:",omitempty"`
-	ServiceClass    string              `json:",omitempty" yaml:"service_class,omitempty" structs:",omitempty"`
-	SizeMB          int                 `json:",omitempty" yaml:"size_mb,omitempty" structs:",omitempty"`
-	MigratedMB      int                 `json:",omitempty" yaml:"migrated_mb,omitempty" structs:",omitempty"`
-	JobStatus       *MigrationJobStatus `json:",omitempty" yaml:"job_status,omitempty" structs:",omitempty"`
-	Plan            *DiskPlan           `json:",omitempty" yaml:"plan,omitempty" structs:",omitempty"`
-	SourceDisk      *Disk               `json:",omitempty" yaml:"source_disk,omitempty" structs:",omitempty"`
-	SourceArchive   *Archive            `json:",omitempty" yaml:"source_archive,omitempty" structs:",omitempty"`
-	BundleInfo      *BundleInfo         `json:",omitempty" yaml:"bundle_info,omitempty" structs:",omitempty"`
-	Storage         *Storage            `json:",omitempty" yaml:"storage,omitempty" structs:",omitempty"`
-	Scope           types.EScope        `json:",omitempty" yaml:"scope,omitempty" structs:",omitempty"`
-	OriginalArchive *OriginalArchive    `json:",omitempty" yaml:"original_archive,omitempty" structs:",omitempty"`
-	SourceInfo      *SourceArchive      `json:",omitempty" yaml:"source_info,omitempty" structs:",omitempty"`
+	ID              types.ID              `json:",omitempty" yaml:"id,omitempty" structs:",omitempty"`
+	Name            string                `json:",omitempty" yaml:"name,omitempty" structs:",omitempty"`
+	Description     string                `yaml:"description"`
+	Tags            types.Tags            `yaml:"tags"`
+	Icon            *Icon                 `json:",omitempty" yaml:"icon,omitempty" structs:",omitempty"`
+	CreatedAt       *time.Time            `json:",omitempty" yaml:"created_at,omitempty" structs:",omitempty"`
+	ModifiedAt      *time.Time            `json:",omitempty" yaml:"modified_at,omitempty" structs:",omitempty"`
+	Availability    types.EAvailability   `json:",omitempty" yaml:"availability,omitempty" structs:",omitempty"`
+	DisplayOrder    int                   `json:",omitempty" yaml:"display_order,omitempty" structs:",omitempty"`
+	ServiceClass    string                `json:",omitempty" yaml:"service_class,omitempty" structs:",omitempty"`
+	SizeMB          int                   `json:",omitempty" yaml:"size_mb,omitempty" structs:",omitempty"`
+	MigratedMB      int                   `json:",omitempty" yaml:"migrated_mb,omitempty" structs:",omitempty"`
+	JobStatus       *MigrationJobStatus   `json:",omitempty" yaml:"job_status,omitempty" structs:",omitempty"`
+	Plan            *DiskPlan             `json:",omitempty" yaml:"plan,omitempty" structs:",omitempty"`
+	SourceDisk      *Disk                 `json:",omitempty" yaml:"source_disk,omitempty" structs:",omitempty"`
+	SourceArchive   *Archive              `json:",omitempty" yaml:"source_archive,omitempty" structs:",omitempty"`
+	BundleInfo      *BundleInfo           `json:",omitempty" yaml:"bundle_info,omitempty" structs:",omitempty"`
+	Storage         *Storage              `json:",omitempty" yaml:"storage,omitempty" structs:",omitempty"`
+	Scope           types.EScope          `json:",omitempty" yaml:"scope,omitempty" structs:",omitempty"`
+	OriginalArchive *OriginalArchive      `json:",omitempty" yaml:"original_archive,omitempty" structs:",omitempty"`
+	SourceInfo      *SourceArchive        `json:",omitempty" yaml:"source_info,omitempty" structs:",omitempty"`
+	SourceSharedKey types.ArchiveShareKey `json:",omitempty" yaml:"source_shared_key,omitempty" structs:",omitempty"`
 }
 
 // SourceArchive 他ゾーンから転送したアーカイブの情報

--- a/v2/sacloud/stub/zz_api_stubs.go
+++ b/v2/sacloud/stub/zz_api_stubs.go
@@ -81,17 +81,24 @@ type ArchiveShareStubResult struct {
 	Err              error
 }
 
+// ArchiveCreateFromSharedStubResult is expected values of the CreateFromShared operation
+type ArchiveCreateFromSharedStubResult struct {
+	Archive *sacloud.Archive
+	Err     error
+}
+
 // ArchiveStub is for trace ArchiveOp operations
 type ArchiveStub struct {
-	FindStubResult        *ArchiveFindStubResult
-	CreateStubResult      *ArchiveCreateStubResult
-	CreateBlankStubResult *ArchiveCreateBlankStubResult
-	ReadStubResult        *ArchiveReadStubResult
-	UpdateStubResult      *ArchiveUpdateStubResult
-	DeleteStubResult      *ArchiveDeleteStubResult
-	OpenFTPStubResult     *ArchiveOpenFTPStubResult
-	CloseFTPStubResult    *ArchiveCloseFTPStubResult
-	ShareStubResult       *ArchiveShareStubResult
+	FindStubResult             *ArchiveFindStubResult
+	CreateStubResult           *ArchiveCreateStubResult
+	CreateBlankStubResult      *ArchiveCreateBlankStubResult
+	ReadStubResult             *ArchiveReadStubResult
+	UpdateStubResult           *ArchiveUpdateStubResult
+	DeleteStubResult           *ArchiveDeleteStubResult
+	OpenFTPStubResult          *ArchiveOpenFTPStubResult
+	CloseFTPStubResult         *ArchiveCloseFTPStubResult
+	ShareStubResult            *ArchiveShareStubResult
+	CreateFromSharedStubResult *ArchiveCreateFromSharedStubResult
 }
 
 // NewArchiveStub creates new ArchiveStub instance
@@ -169,6 +176,14 @@ func (s *ArchiveStub) Share(ctx context.Context, zone string, id types.ID) (*sac
 		log.Fatal("ArchiveStub.ShareStubResult is not set")
 	}
 	return s.ShareStubResult.ArchiveShareInfo, s.ShareStubResult.Err
+}
+
+// CreateFromShared is API call with trace log
+func (s *ArchiveStub) CreateFromShared(ctx context.Context, zone string, sourceArchiveID types.ID, zoneID types.ID, param *sacloud.ArchiveCreateRequestFromShared) (*sacloud.Archive, error) {
+	if s.CreateFromSharedStubResult == nil {
+		log.Fatal("ArchiveStub.CreateFromSharedStubResult is not set")
+	}
+	return s.CreateFromSharedStubResult.Archive, s.CreateFromSharedStubResult.Err
 }
 
 /*************************************************

--- a/v2/sacloud/stub/zz_api_stubs.go
+++ b/v2/sacloud/stub/zz_api_stubs.go
@@ -75,6 +75,12 @@ type ArchiveCloseFTPStubResult struct {
 	Err error
 }
 
+// ArchiveShareStubResult is expected values of the Share operation
+type ArchiveShareStubResult struct {
+	ArchiveShareInfo *sacloud.ArchiveShareInfo
+	Err              error
+}
+
 // ArchiveStub is for trace ArchiveOp operations
 type ArchiveStub struct {
 	FindStubResult        *ArchiveFindStubResult
@@ -85,6 +91,7 @@ type ArchiveStub struct {
 	DeleteStubResult      *ArchiveDeleteStubResult
 	OpenFTPStubResult     *ArchiveOpenFTPStubResult
 	CloseFTPStubResult    *ArchiveCloseFTPStubResult
+	ShareStubResult       *ArchiveShareStubResult
 }
 
 // NewArchiveStub creates new ArchiveStub instance
@@ -154,6 +161,14 @@ func (s *ArchiveStub) CloseFTP(ctx context.Context, zone string, id types.ID) er
 		log.Fatal("ArchiveStub.CloseFTPStubResult is not set")
 	}
 	return s.CloseFTPStubResult.Err
+}
+
+// Share is API call with trace log
+func (s *ArchiveStub) Share(ctx context.Context, zone string, id types.ID) (*sacloud.ArchiveShareInfo, error) {
+	if s.ShareStubResult == nil {
+		log.Fatal("ArchiveStub.ShareStubResult is not set")
+	}
+	return s.ShareStubResult.ArchiveShareInfo, s.ShareStubResult.Err
 }
 
 /*************************************************

--- a/v2/sacloud/trace/zz_api_tracer.go
+++ b/v2/sacloud/trace/zz_api_tracer.go
@@ -473,6 +473,43 @@ func (t *ArchiveTracer) Share(ctx context.Context, zone string, id types.ID) (*s
 	return resultArchiveShareInfo, err
 }
 
+// CreateFromShared is API call with trace log
+func (t *ArchiveTracer) CreateFromShared(ctx context.Context, zone string, sourceArchiveID types.ID, zoneID types.ID, param *sacloud.ArchiveCreateRequestFromShared) (*sacloud.Archive, error) {
+	log.Println("[TRACE] ArchiveAPI.CreateFromShared start")
+	targetArguments := struct {
+		Argzone            string
+		ArgsourceArchiveID types.ID                                `json:"sourceArchiveID"`
+		ArgzoneID          types.ID                                `json:"zoneID"`
+		Argparam           *sacloud.ArchiveCreateRequestFromShared `json:"param"`
+	}{
+		Argzone:            zone,
+		ArgsourceArchiveID: sourceArchiveID,
+		ArgzoneID:          zoneID,
+		Argparam:           param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ArchiveAPI.CreateFromShared end")
+	}()
+
+	resultArchive, err := t.Internal.CreateFromShared(ctx, zone, sourceArchiveID, zoneID, param)
+	targetResults := struct {
+		Archive *sacloud.Archive
+		Error   error
+	}{
+		Archive: resultArchive,
+		Error:   err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultArchive, err
+}
+
 /*************************************************
 * AuthStatusTracer
 *************************************************/

--- a/v2/sacloud/trace/zz_api_tracer.go
+++ b/v2/sacloud/trace/zz_api_tracer.go
@@ -440,6 +440,39 @@ func (t *ArchiveTracer) CloseFTP(ctx context.Context, zone string, id types.ID) 
 	return err
 }
 
+// Share is API call with trace log
+func (t *ArchiveTracer) Share(ctx context.Context, zone string, id types.ID) (*sacloud.ArchiveShareInfo, error) {
+	log.Println("[TRACE] ArchiveAPI.Share start")
+	targetArguments := struct {
+		Argzone string
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ArchiveAPI.Share end")
+	}()
+
+	resultArchiveShareInfo, err := t.Internal.Share(ctx, zone, id)
+	targetResults := struct {
+		ArchiveShareInfo *sacloud.ArchiveShareInfo
+		Error            error
+	}{
+		ArchiveShareInfo: resultArchiveShareInfo,
+		Error:            err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultArchiveShareInfo, err
+}
+
 /*************************************************
 * AuthStatusTracer
 *************************************************/

--- a/v2/sacloud/types/archive_share_key.go
+++ b/v2/sacloud/types/archive_share_key.go
@@ -1,0 +1,64 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import "strings"
+
+// ArchiveShareKey アーカイブ共有キー
+type ArchiveShareKey string
+
+// ArchiveShareKeyDelimiter アーカイブ共有キーのデリミタ
+const ArchiveShareKeyDelimiter = ":"
+
+// String ArchiveShareKey全体を表す文字列
+func (key ArchiveShareKey) String() string {
+	return string(key)
+}
+
+// Zone キーに含まれるゾーン名
+func (key ArchiveShareKey) Zone() string {
+	tokens := key.tokens()
+	if len(tokens) > 0 {
+		return tokens[0]
+	}
+	return ""
+}
+
+// SourceArchiveID 共有元となるアーカイブのID
+func (key ArchiveShareKey) SourceArchiveID() ID {
+	tokens := key.tokens()
+	if len(tokens) > 1 {
+		return StringID(tokens[1])
+	}
+	return ID(0)
+}
+
+// Token 認証キー本体
+func (key ArchiveShareKey) Token() string {
+	tokens := key.tokens()
+	if len(tokens) > 2 {
+		return tokens[2]
+	}
+	return ""
+}
+
+// ValidFormat 有効なキーフォーマットか
+func (key ArchiveShareKey) ValidFormat() bool {
+	return len(key.tokens()) == 3
+}
+
+func (key ArchiveShareKey) tokens() []string {
+	return strings.Split(key.String(), ArchiveShareKeyDelimiter)
+}

--- a/v2/sacloud/types/archive_share_key_test.go
+++ b/v2/sacloud/types/archive_share_key_test.go
@@ -1,0 +1,68 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestArchiveShareKey(t *testing.T) {
+	cases := []struct {
+		in    string
+		zone  string
+		id    ID
+		token string
+		valid bool
+	}{
+		{
+			in:    "zone:11111:token",
+			zone:  "zone",
+			id:    StringID("11111"),
+			token: "token",
+			valid: true,
+		},
+		{
+			in:    "zone:11111",
+			zone:  "zone",
+			id:    StringID("11111"),
+			token: "",
+			valid: false,
+		},
+		{
+			in:    "zone",
+			zone:  "zone",
+			id:    StringID(""),
+			token: "",
+			valid: false,
+		},
+		{
+			in:    "",
+			zone:  "",
+			id:    StringID(""),
+			token: "",
+			valid: false,
+		},
+	}
+
+	for _, tc := range cases {
+		key := ArchiveShareKey(tc.in)
+		require.Equal(t, key.Zone(), tc.zone)
+		require.Equal(t, key.SourceArchiveID(), tc.id)
+		require.Equal(t, key.Token(), tc.token)
+		require.Equal(t, key.ValidFormat(), tc.valid)
+	}
+}

--- a/v2/sacloud/zz_api_ops.go
+++ b/v2/sacloud/zz_api_ops.go
@@ -705,6 +705,45 @@ func (o *ArchiveOp) Share(ctx context.Context, zone string, id types.ID) (*Archi
 	return results.ArchiveShareInfo, nil
 }
 
+// CreateFromShared is API call
+func (o *ArchiveOp) CreateFromShared(ctx context.Context, zone string, sourceArchiveID types.ID, zoneID types.ID, param *ArchiveCreateRequestFromShared) (*Archive, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":         SakuraCloudAPIRoot,
+		"pathSuffix":      o.PathSuffix,
+		"pathName":        o.PathName,
+		"zone":            zone,
+		"sourceArchiveID": sourceArchiveID,
+		"zoneID":          zoneID,
+		"param":           param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.sourceArchiveID}}/to/zone/{{.zoneID}}", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformCreateFromSharedArgs(sourceArchiveID, zoneID, param)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformCreateFromSharedResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.Archive, nil
+}
+
 /*************************************************
 * AuthStatusOp
 *************************************************/

--- a/v2/sacloud/zz_api_ops.go
+++ b/v2/sacloud/zz_api_ops.go
@@ -668,6 +668,43 @@ func (o *ArchiveOp) CloseFTP(ctx context.Context, zone string, id types.ID) erro
 	return nil
 }
 
+// Share is API call
+func (o *ArchiveOp) Share(ctx context.Context, zone string, id types.ID) (*ArchiveShareInfo, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/ftp", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformShareArgs(id)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformShareResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.ArchiveShareInfo, nil
+}
+
 /*************************************************
 * AuthStatusOp
 *************************************************/

--- a/v2/sacloud/zz_api_transformers.go
+++ b/v2/sacloud/zz_api_transformers.go
@@ -224,6 +224,40 @@ func (o *ArchiveOp) transformOpenFTPResults(data []byte) (*archiveOpenFTPResult,
 	return results, nil
 }
 
+func (o *ArchiveOp) transformShareArgs(id types.ID) (*archiveShareRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+	}{
+		Arg0: arg0,
+	}
+
+	v := &archiveShareRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ArchiveOp) transformShareResults(data []byte) (*archiveShareResult, error) {
+	nakedResponse := &archiveShareResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &archiveShareResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *AuthStatusOp) transformReadResults(data []byte) (*authStatusReadResult, error) {
 	nakedResponse := &authStatusReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {

--- a/v2/sacloud/zz_api_transformers.go
+++ b/v2/sacloud/zz_api_transformers.go
@@ -258,6 +258,58 @@ func (o *ArchiveOp) transformShareResults(data []byte) (*archiveShareResult, err
 	return results, nil
 }
 
+func (o *ArchiveOp) transformCreateFromSharedArgs(sourceArchiveID types.ID, zoneID types.ID, param *ArchiveCreateRequestFromShared) (*archiveCreateFromSharedRequestEnvelope, error) {
+	if sourceArchiveID == types.ID(int64(0)) {
+		sourceArchiveID = types.ID(int64(0))
+	}
+	var arg0 interface{} = sourceArchiveID
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if zoneID == types.ID(int64(0)) {
+		zoneID = types.ID(int64(0))
+	}
+	var arg1 interface{} = zoneID
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	if param == nil {
+		param = &ArchiveCreateRequestFromShared{}
+	}
+	var arg2 interface{} = param
+	if v, ok := arg2.(argumentDefaulter); ok {
+		arg2 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{}
+		Arg2 interface{} `mapconv:"Archive,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+		Arg2: arg2,
+	}
+
+	v := &archiveCreateFromSharedRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *ArchiveOp) transformCreateFromSharedResults(data []byte) (*archiveCreateFromSharedResult, error) {
+	nakedResponse := &archiveCreateFromSharedResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &archiveCreateFromSharedResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *AuthStatusOp) transformReadResults(data []byte) (*authStatusReadResult, error) {
 	nakedResponse := &authStatusReadResponseEnvelope{}
 	if err := json.Unmarshal(data, nakedResponse); err != nil {

--- a/v2/sacloud/zz_apis.go
+++ b/v2/sacloud/zz_apis.go
@@ -36,6 +36,7 @@ type ArchiveAPI interface {
 	Delete(ctx context.Context, zone string, id types.ID) error
 	OpenFTP(ctx context.Context, zone string, id types.ID, openOption *OpenFTPRequest) (*FTPServer, error)
 	CloseFTP(ctx context.Context, zone string, id types.ID) error
+	Share(ctx context.Context, zone string, id types.ID) (*ArchiveShareInfo, error)
 }
 
 /*************************************************

--- a/v2/sacloud/zz_apis.go
+++ b/v2/sacloud/zz_apis.go
@@ -37,6 +37,7 @@ type ArchiveAPI interface {
 	OpenFTP(ctx context.Context, zone string, id types.ID, openOption *OpenFTPRequest) (*FTPServer, error)
 	CloseFTP(ctx context.Context, zone string, id types.ID) error
 	Share(ctx context.Context, zone string, id types.ID) (*ArchiveShareInfo, error)
+	CreateFromShared(ctx context.Context, zone string, sourceArchiveID types.ID, zoneID types.ID, param *ArchiveCreateRequestFromShared) (*Archive, error)
 }
 
 /*************************************************

--- a/v2/sacloud/zz_envelopes.go
+++ b/v2/sacloud/zz_envelopes.go
@@ -117,6 +117,19 @@ type archiveShareResponseEnvelope struct {
 	ArchiveShareInfo *naked.ArchiveShareInfo `json:",omitempty"`
 }
 
+// archiveCreateFromSharedRequestEnvelope is envelop of API request
+type archiveCreateFromSharedRequestEnvelope struct {
+	Archive *naked.Archive `json:",omitempty"`
+}
+
+// archiveCreateFromSharedResponseEnvelope is envelop of API response
+type archiveCreateFromSharedResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Archive *naked.Archive `json:",omitempty"`
+}
+
 // authStatusReadResponseEnvelope is envelop of API response
 type authStatusReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目

--- a/v2/sacloud/zz_envelopes.go
+++ b/v2/sacloud/zz_envelopes.go
@@ -104,6 +104,19 @@ type archiveOpenFTPResponseEnvelope struct {
 	FTPServer *naked.OpeningFTPServer `json:",omitempty"`
 }
 
+// archiveShareRequestEnvelope is envelop of API request
+type archiveShareRequestEnvelope struct {
+	Shared bool `json:",omitempty"`
+}
+
+// archiveShareResponseEnvelope is envelop of API response
+type archiveShareResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	ArchiveShareInfo *naked.ArchiveShareInfo `json:",omitempty"`
+}
+
 // authStatusReadResponseEnvelope is envelop of API response
 type authStatusReadResponseEnvelope struct {
 	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -1209,6 +1209,111 @@ func (o *ArchiveShareInfo) SetSharedKey(v types.ArchiveShareKey) {
 }
 
 /*************************************************
+* ArchiveCreateRequestFromShared
+*************************************************/
+
+// ArchiveCreateRequestFromShared represents API parameter/response structure
+type ArchiveCreateRequestFromShared struct {
+	Name            string `validate:"required"`
+	Description     string `validate:"min=0,max=512"`
+	Tags            types.Tags
+	IconID          types.ID `mapconv:"Icon.ID"`
+	SourceSharedKey types.ArchiveShareKey
+}
+
+// Validate validates by field tags
+func (o *ArchiveCreateRequestFromShared) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ArchiveCreateRequestFromShared) setDefaults() interface{} {
+	return &struct {
+		Name            string `validate:"required"`
+		Description     string `validate:"min=0,max=512"`
+		Tags            types.Tags
+		IconID          types.ID `mapconv:"Icon.ID"`
+		SourceSharedKey types.ArchiveShareKey
+	}{
+		Name:            o.GetName(),
+		Description:     o.GetDescription(),
+		Tags:            o.GetTags(),
+		IconID:          o.GetIconID(),
+		SourceSharedKey: o.GetSourceSharedKey(),
+	}
+}
+
+// GetName returns value of Name
+func (o *ArchiveCreateRequestFromShared) GetName() string {
+	return o.Name
+}
+
+// SetName sets value to Name
+func (o *ArchiveCreateRequestFromShared) SetName(v string) {
+	o.Name = v
+}
+
+// GetDescription returns value of Description
+func (o *ArchiveCreateRequestFromShared) GetDescription() string {
+	return o.Description
+}
+
+// SetDescription sets value to Description
+func (o *ArchiveCreateRequestFromShared) SetDescription(v string) {
+	o.Description = v
+}
+
+// GetTags returns value of Tags
+func (o *ArchiveCreateRequestFromShared) GetTags() types.Tags {
+	return o.Tags
+}
+
+// SetTags sets value to Tags
+func (o *ArchiveCreateRequestFromShared) SetTags(v types.Tags) {
+	o.Tags = v
+}
+
+// HasTag 指定のタグが存在する場合trueを返す
+func (o *ArchiveCreateRequestFromShared) HasTag(tag string) bool {
+	return accessor.HasTag(o, tag)
+}
+
+// AppendTag 指定のタグを追加
+func (o *ArchiveCreateRequestFromShared) AppendTag(tag string) {
+	accessor.AppendTag(o, tag)
+}
+
+// RemoveTag 指定のタグを削除
+func (o *ArchiveCreateRequestFromShared) RemoveTag(tag string) {
+	accessor.RemoveTag(o, tag)
+}
+
+// ClearTags タグを全クリア
+func (o *ArchiveCreateRequestFromShared) ClearTags() {
+	accessor.ClearTags(o)
+}
+
+// GetIconID returns value of IconID
+func (o *ArchiveCreateRequestFromShared) GetIconID() types.ID {
+	return o.IconID
+}
+
+// SetIconID sets value to IconID
+func (o *ArchiveCreateRequestFromShared) SetIconID(v types.ID) {
+	o.IconID = v
+}
+
+// GetSourceSharedKey returns value of SourceSharedKey
+func (o *ArchiveCreateRequestFromShared) GetSourceSharedKey() types.ArchiveShareKey {
+	return o.SourceSharedKey
+}
+
+// SetSourceSharedKey sets value to SourceSharedKey
+func (o *ArchiveCreateRequestFromShared) SetSourceSharedKey(v types.ArchiveShareKey) {
+	o.SourceSharedKey = v
+}
+
+/*************************************************
 * AuthStatus
 *************************************************/
 

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -1176,6 +1176,39 @@ func (o *OpenFTPRequest) SetChangePassword(v bool) {
 }
 
 /*************************************************
+* ArchiveShareInfo
+*************************************************/
+
+// ArchiveShareInfo represents API parameter/response structure
+type ArchiveShareInfo struct {
+	SharedKey types.ArchiveShareKey
+}
+
+// Validate validates by field tags
+func (o *ArchiveShareInfo) Validate() error {
+	return validator.New().Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ArchiveShareInfo) setDefaults() interface{} {
+	return &struct {
+		SharedKey types.ArchiveShareKey
+	}{
+		SharedKey: o.GetSharedKey(),
+	}
+}
+
+// GetSharedKey returns value of SharedKey
+func (o *ArchiveShareInfo) GetSharedKey() types.ArchiveShareKey {
+	return o.SharedKey
+}
+
+// SetSharedKey sets value to SharedKey
+func (o *ArchiveShareInfo) SetSharedKey(v types.ArchiveShareKey) {
+	o.SharedKey = v
+}
+
+/*************************************************
 * AuthStatus
 *************************************************/
 

--- a/v2/sacloud/zz_result.go
+++ b/v2/sacloud/zz_result.go
@@ -61,6 +61,13 @@ type archiveOpenFTPResult struct {
 	FTPServer *FTPServer `json:",omitempty" mapconv:"FTPServer,omitempty,recursive"`
 }
 
+// archiveShareResult represents the Result of API
+type archiveShareResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	ArchiveShareInfo *ArchiveShareInfo `json:",omitempty" mapconv:"ArchiveShareInfo,omitempty,recursive"`
+}
+
 // authStatusReadResult represents the Result of API
 type authStatusReadResult struct {
 	IsOk bool `json:",omitempty"` // is_ok

--- a/v2/sacloud/zz_result.go
+++ b/v2/sacloud/zz_result.go
@@ -68,6 +68,13 @@ type archiveShareResult struct {
 	ArchiveShareInfo *ArchiveShareInfo `json:",omitempty" mapconv:"ArchiveShareInfo,omitempty,recursive"`
 }
 
+// archiveCreateFromSharedResult represents the Result of API
+type archiveCreateFromSharedResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	Archive *Archive `json:",omitempty" mapconv:"Archive,omitempty,recursive"`
+}
+
 // authStatusReadResult represents the Result of API
 type authStatusReadResult struct {
 	IsOk bool `json:",omitempty"` // is_ok

--- a/v2/utils/builder/archive/api_client.go
+++ b/v2/utils/builder/archive/api_client.go
@@ -1,0 +1,31 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import "github.com/sacloud/libsacloud/v2/sacloud"
+
+// APIClient builderが利用するAPIクライアント
+type APIClient struct {
+	Archive sacloud.ArchiveAPI
+	Zone    sacloud.ZoneAPI
+}
+
+// NewAPIClient builderが利用するAPIクライアントを返す
+func NewAPIClient(caller sacloud.APICaller) *APIClient {
+	return &APIClient{
+		Archive: sacloud.NewArchiveOp(caller),
+		Zone:    sacloud.NewZoneOp(caller),
+	}
+}

--- a/v2/utils/builder/archive/builder.go
+++ b/v2/utils/builder/archive/builder.go
@@ -1,0 +1,86 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+// FromSharedArchiveBuilder 共有アーカイブからアーカイブの作成を行う
+type FromSharedArchiveBuilder struct {
+	Name            string
+	Description     string
+	Tags            types.Tags
+	IconID          types.ID
+	SourceSharedKey types.ArchiveShareKey
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (b *FromSharedArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"Name":            b.Name == "",
+		"SourceSharedKey": b.SourceSharedKey == "",
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	if !b.SourceSharedKey.ValidFormat() {
+		return fmt.Errorf("archive shared key is invalid format: key:%q", b.SourceSharedKey)
+	}
+	return nil
+}
+
+// Build 共有アーカイブからアーカイブの作成を行う
+func (b *FromSharedArchiveBuilder) Build(ctx context.Context, zone string) (*sacloud.Archive, error) {
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	zoneID, err := query.ZoneIDFromArchiveShareKey(ctx, b.Client.Zone, b.SourceSharedKey)
+	if err != nil {
+		return nil, err
+	}
+
+	archive, err := b.Client.Archive.CreateFromShared(ctx, zone, b.SourceSharedKey.SourceArchiveID(), zoneID,
+		&sacloud.ArchiveCreateRequestFromShared{
+			Name:            b.Name,
+			Description:     b.Description,
+			Tags:            b.Tags,
+			IconID:          b.IconID,
+			SourceSharedKey: b.SourceSharedKey,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	lastState, err := sacloud.WaiterForReady(func() (interface{}, error) {
+		return b.Client.Archive.Read(ctx, zone, archive.ID)
+	}).WaitForState(ctx)
+
+	var ret *sacloud.Archive
+	if lastState != nil {
+		ret = lastState.(*sacloud.Archive)
+	}
+	return ret, err
+}

--- a/v2/utils/builder/archive/builder_test.go
+++ b/v2/utils/builder/archive/builder_test.go
@@ -1,0 +1,118 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+func TestBuilder_Build(t *testing.T) {
+	var testZone = testutil.TestZone()
+	var sourceArchive *sacloud.Archive
+	var shareInfo *sacloud.ArchiveShareInfo
+
+	testutil.Run(t, &testutil.CRUDTestCase{
+		SetupAPICallerFunc: func() sacloud.APICaller {
+			return testutil.SingletonAPICaller()
+		},
+		Parallel:          true,
+		IgnoreStartupWait: true,
+		Setup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+			archiveOp := sacloud.NewArchiveOp(caller)
+			source, err := query.FindArchiveByOSType(ctx, archiveOp, testZone, ostype.CentOS)
+			if err != nil {
+				return err
+			}
+
+			created, err := archiveOp.Create(ctx, testZone, &sacloud.ArchiveCreateRequest{
+				SourceArchiveID: source.ID,
+				Name:            testutil.ResourceName("source-archive"),
+			})
+			if err != nil {
+				return err
+			}
+			sourceArchive = created
+			_, err = sacloud.WaiterForReady(func() (interface{}, error) {
+				return archiveOp.Read(ctx, testZone, sourceArchive.ID)
+			}).WaitForState(ctx)
+			if err != nil {
+				return err
+			}
+
+			si, err := archiveOp.Share(ctx, testZone, sourceArchive.ID)
+			if err != nil {
+				return err
+			}
+			shareInfo = si
+			return nil
+		},
+		Create: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				builder := &FromSharedArchiveBuilder{
+					Name:            testutil.ResourceName("archive-from-shared-builder"),
+					Description:     "description",
+					Tags:            types.Tags{"tag1", "tag2"},
+					SourceSharedKey: shareInfo.SharedKey,
+					Client:          NewAPIClient(caller),
+				}
+				return builder.Build(ctx, testZone)
+			},
+		},
+		Read: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				return sacloud.NewArchiveOp(caller).Read(ctx, testZone, ctx.ID)
+			},
+			CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, value interface{}) error {
+				archive := value.(*sacloud.Archive)
+				return testutil.DoAsserts(
+					testutil.AssertNotNilFunc(t, archive, "Archive"),
+				)
+			},
+		},
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+				archiveOp := sacloud.NewArchiveOp(caller)
+
+				_, err := sacloud.WaiterForReady(func() (interface{}, error) {
+					return archiveOp.Read(ctx, testZone, ctx.ID)
+				}).WaitForState(ctx)
+				if err != nil {
+					return err
+				}
+				if err := archiveOp.Delete(ctx, testZone, ctx.ID); err != nil {
+					return err
+				}
+
+				if sourceArchive != nil {
+					if sourceArchive.Availability.IsUploading() {
+						if err := archiveOp.CloseFTP(ctx, testZone, sourceArchive.ID); err != nil {
+							return err
+						}
+					}
+					if err := archiveOp.Delete(ctx, testZone, sourceArchive.ID); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		},
+	})
+}

--- a/v2/utils/query/archive_share_key.go
+++ b/v2/utils/query/archive_share_key.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package query
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/search"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// ZoneIDFromArchiveShareKey アーカイブ共有キーから対応するゾーンIDを取得
+func ZoneIDFromArchiveShareKey(ctx context.Context, zoneAPI sacloud.ZoneAPI, key types.ArchiveShareKey) (types.ID, error) {
+	if !key.ValidFormat() {
+		return types.ID(0), fmt.Errorf("archive share key is invalid format: key:%q", key.String())
+	}
+
+	searched, err := zoneAPI.Find(ctx, &sacloud.FindCondition{
+		Filter: search.Filter{
+			search.Key("Name"): search.ExactMatch(key.Zone()),
+		},
+		Include: []string{"ID"},
+	})
+	if err != nil {
+		return types.ID(0), err
+	}
+	if searched.Count == 0 {
+		return types.ID(0), fmt.Errorf("zone %q is not found", key.Zone())
+	}
+	return searched.Zones[0].ID, nil
+}


### PR DESCRIPTION
fixes #535 

アーカイブ共有APIを追加する。

#### アーカイブ共有の開始:

```go

caller := sacloud.NewClient("token", "secret")
archiveOp := sacloud.NewArchiveOp(caller)

shareInfo, err := archiveOp.Share(context.Background(), "is1a", types.ID(111111111111))
if err != nil {
    panic(err)
}
fmt.Printf("ShareKey: %s", shareInfo.SharedKey)
```

#### 共有アーカイブからアーカイブ作成(低レベルAPI)

```go
caller := sacloud.NewClient("token", "secret")
op := sacloud.NewArchiveOp(caller)

created, err := op.CreateFromShared(context.Background(), "is1b", types.ID(111111), types.ID(31002), &sacloud.ArchiveCreateRequestFromShared{
	Name:            "example",
	Description:     "desc",
	Tags:            types.Tags{"tag1", "tag2"},
	SourceSharedKey: "is1a:111111:xxxxx",
})
if err != nil {
	panic(err)
}

fmt.Printf("Result: %#+v", created)

```

#### 共有アーカイブからアーカイブ作成(高レベルAPI)

```go
import (
	"github.com/sacloud/libsacloud/v2/sacloud"
	"github.com/sacloud/libsacloud/v2/sacloud/types"
	archiveBuilder "github.com/sacloud/libsacloud/v2/utils/builder/archive"
)

func main() {
	caller := sacloud.NewClient("token", "secret")
	builder := &archiveBuilder.FromSharedArchiveBuilder{
		Name:            "example",
		Description:     "description",
		Tags:            types.Tags{"tag1", "tag2"},
		SourceSharedKey: "is1a:1111111:xxxxx",
		Client:          archiveBuilder.NewAPIClient(caller),
	}
	archive, err := builder.Build(ctx, testZone)
	if err != nil {
		panic(err)
	}
	fmt.Printf("%v", archive)
}
```