### PR TITLE
utils: ArchiveBuilder

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/leodido/go-urn v1.1.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.1.2
+	github.com/sacloud/ftps v1.0.0
 	github.com/stretchr/testify v1.2.2
 	github.com/uber-go/atomic v1.4.0 // indirect
 	go.uber.org/atomic v1.4.0 // indirect

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -28,6 +28,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sacloud/ftps v1.0.0 h1:RFIOwGby8ZDqdSccA7Tm9kJdm9QVAxADvxmMINBGLZw=
+github.com/sacloud/ftps v1.0.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/uber-go/atomic v1.4.0 h1:yOuPqEq4ovnhEjpHmfFwsqBXDYbQeT6Nb0bwD6XnD5o=

--- a/v2/utils/builder/archive/blank_archive_builder.go
+++ b/v2/utils/builder/archive/blank_archive_builder.go
@@ -1,0 +1,82 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/sacloud/ftps"
+	"github.com/sacloud/libsacloud/v2/pkg/size"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// BlankArchiveBuilder ブランクアーカイブの作成〜FTPSでのファイルアップロードを行う
+type BlankArchiveBuilder struct {
+	Name         string
+	Description  string
+	Tags         types.Tags
+	IconID       types.ID
+	SizeGB       int
+	SourceReader io.Reader
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (b *BlankArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"Name":         b.Name == "",
+		"SizeGB":       b.SizeGB == 0,
+		"SourceReader": b.SourceReader == nil,
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	return nil
+}
+
+// Build ブランクアーカイブの作成〜FTPSでのファイルアップロードを行う
+func (b *BlankArchiveBuilder) Build(ctx context.Context, zone string) (*sacloud.Archive, error) {
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	archive, ftpServer, err := b.Client.Archive.CreateBlank(ctx, zone,
+		&sacloud.ArchiveCreateBlankRequest{
+			Name:        b.Name,
+			Description: b.Description,
+			Tags:        b.Tags,
+			IconID:      b.IconID,
+			SizeMB:      b.SizeGB * size.GiB,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	// upload sources via FTPS
+	ftpsClient := ftps.NewClient(ftpServer.User, ftpServer.Password, ftpServer.HostName)
+
+	if err := ftpsClient.UploadReader("data.raw", b.SourceReader); err != nil {
+		return archive, fmt.Errorf("uploading file via FTPS is failed: %s", err)
+	}
+
+	// reload
+	return b.Client.Archive.Read(ctx, zone, archive.ID)
+}

--- a/v2/utils/builder/archive/blank_archive_builder_test.go
+++ b/v2/utils/builder/archive/blank_archive_builder_test.go
@@ -1,0 +1,70 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+func TestBlankArchiveBuilder_Build(t *testing.T) {
+	if !testutil.IsAccTest() {
+		t.Skip("TestBlankArchiveBuilder_Build only exec when running an Acceptance Test")
+	}
+
+	testZone := testutil.TestZone()
+	testutil.Run(t, &testutil.CRUDTestCase{
+		SetupAPICallerFunc: func() sacloud.APICaller {
+			return testutil.SingletonAPICaller()
+		},
+		Parallel:          true,
+		IgnoreStartupWait: true,
+		Create: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				source := bytes.NewBufferString("dummy")
+
+				builder := &BlankArchiveBuilder{
+					Name:         testutil.ResourceName("archive-from-shared-builder"),
+					Description:  "description",
+					Tags:         types.Tags{"tag1", "tag2"},
+					SizeGB:       20,
+					SourceReader: source,
+					Client:       NewAPIClient(caller),
+				}
+				return builder.Build(ctx, testZone)
+			},
+		},
+		Read: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				return sacloud.NewArchiveOp(caller).Read(ctx, testZone, ctx.ID)
+			},
+			CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, value interface{}) error {
+				archive := value.(*sacloud.Archive)
+				return testutil.DoAsserts(
+					testutil.AssertNotNilFunc(t, archive, "Archive"),
+				)
+			},
+		},
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+				return sacloud.NewArchiveOp(caller).Delete(ctx, testZone, ctx.ID)
+			},
+		},
+	})
+}

--- a/v2/utils/builder/archive/director.go
+++ b/v2/utils/builder/archive/director.go
@@ -1,0 +1,106 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"io"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// Builder アーカイブビルダーが持つ共通インターフェース
+type Builder interface {
+	Build(ctx context.Context, zone string) (*sacloud.Archive, error)
+	Validate(ctx context.Context, zone string) error
+}
+
+// Director パラメータに応じて適切なアーカイブビルダーを返す
+type Director struct {
+	Name        string
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+	SizeGB      int
+
+	// for blank builder
+	SourceReader io.Reader
+
+	// for standard builder
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
+
+	// transfer archive builder
+	SourceArchiveZone string
+
+	// for shared archive builder
+	SourceSharedKey types.ArchiveShareKey
+
+	Client *APIClient
+}
+
+// パラメータに応じて適切なアーカイブビルダーを返す
+//
+// Note: 他ゾーンからの転送の場合、転送元/先でゾーンが同一でもエラーとならない。
+// このためDirectorでは転送元/先ゾーンを意識せずにSourceArchiveZoneが指定されていた場合は
+// 一律でTransferArchiveBuilderを返す。
+//
+// もしこの挙動で問題が発生する場合は呼び出し側で適切にビルダーを切り替える実装を行う必要がある。
+func (d *Director) Builder() Builder {
+	if d.SourceReader != nil {
+		return &BlankArchiveBuilder{
+			Name:         d.Name,
+			Description:  d.Description,
+			Tags:         d.Tags,
+			IconID:       d.IconID,
+			SizeGB:       d.SizeGB,
+			SourceReader: d.SourceReader,
+			Client:       d.Client,
+		}
+	}
+	if d.SourceSharedKey.String() != "" {
+		return &FromSharedArchiveBuilder{
+			Name:            d.Name,
+			Description:     d.Description,
+			Tags:            d.Tags,
+			IconID:          d.IconID,
+			SourceSharedKey: d.SourceSharedKey,
+			Client:          d.Client,
+		}
+	}
+
+	if d.SourceArchiveZone != "" {
+		return &TransferArchiveBuilder{
+			Name:              d.Name,
+			Description:       d.Description,
+			Tags:              d.Tags,
+			IconID:            d.IconID,
+			SourceArchiveID:   d.SourceArchiveID,
+			SourceArchiveZone: d.SourceArchiveZone,
+			Client:            nil,
+		}
+	}
+
+	return &StandardArchiveBuilder{
+		Name:            d.Name,
+		Description:     d.Description,
+		Tags:            d.Tags,
+		IconID:          d.IconID,
+		SourceDiskID:    d.SourceDiskID,
+		SourceArchiveID: d.SourceArchiveID,
+		Client:          d.Client,
+	}
+}

--- a/v2/utils/builder/archive/director_test.go
+++ b/v2/utils/builder/archive/director_test.go
@@ -1,0 +1,96 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDirector_Builder(t *testing.T) {
+	dummySource := bytes.NewBufferString("dummy")
+
+	cases := []struct {
+		msg string
+		in  *Director
+		out Builder
+	}{
+		{
+			msg: "BlankBuilder",
+			in: &Director{
+				Name:         "blank",
+				SizeGB:       20,
+				SourceReader: dummySource,
+			},
+			out: &BlankArchiveBuilder{
+				Name:         "blank",
+				SizeGB:       20,
+				SourceReader: dummySource,
+			},
+		},
+		{
+			msg: "FromSharedArchiveBuilder",
+			in: &Director{
+				Name:            "shared",
+				SourceSharedKey: "is1a:0000:xxxx",
+			},
+			out: &FromSharedArchiveBuilder{
+				Name:            "shared",
+				SourceSharedKey: "is1a:0000:xxxx",
+			},
+		},
+		{
+			msg: "TransferArchiveBuilder",
+			in: &Director{
+				Name:              "transfer",
+				SourceArchiveID:   1,
+				SourceArchiveZone: "is1a",
+			},
+			out: &TransferArchiveBuilder{
+				Name:              "transfer",
+				SourceArchiveID:   1,
+				SourceArchiveZone: "is1a",
+			},
+		},
+		{
+			msg: "StandardArchiveBuilder_with_ArchiveID",
+			in: &Director{
+				Name:            "standard-with-archive-id",
+				SourceArchiveID: 1,
+			},
+			out: &StandardArchiveBuilder{
+				Name:            "standard-with-archive-id",
+				SourceArchiveID: 1,
+			},
+		},
+		{
+			msg: "StandardArchiveBuilder_with_DiskID",
+			in: &Director{
+				Name:         "standard-with-disk-id",
+				SourceDiskID: 1,
+			},
+			out: &StandardArchiveBuilder{
+				Name:         "standard-with-disk-id",
+				SourceDiskID: 1,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		require.EqualValues(t, tc.out, tc.in.Builder(), tc.msg)
+	}
+}

--- a/v2/utils/builder/archive/standard_archive_builder.go
+++ b/v2/utils/builder/archive/standard_archive_builder.go
@@ -1,0 +1,79 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// StandardArchiveBuilder 同一アカウント/同一ゾーンのディスク/アーカイブからアーカイブの作成を行う
+type StandardArchiveBuilder struct {
+	Name            string
+	Description     string
+	Tags            types.Tags
+	IconID          types.ID
+	SourceDiskID    types.ID
+	SourceArchiveID types.ID
+
+	Client *APIClient
+}
+
+// Validate 設定値の検証
+func (b *StandardArchiveBuilder) Validate(ctx context.Context, zone string) error {
+	requiredValues := map[string]bool{
+		"Name":                            b.Name == "",
+		"SourceDiskID or SourceArchiveID": b.SourceArchiveID.IsEmpty() && b.SourceDiskID.IsEmpty(),
+	}
+	for key, empty := range requiredValues {
+		if empty {
+			return fmt.Errorf("%s is required", key)
+		}
+	}
+	return nil
+}
+
+// Build 同一アカウント/同一ゾーンのディスク/アーカイブからアーカイブの作成を行う
+func (b *StandardArchiveBuilder) Build(ctx context.Context, zone string) (*sacloud.Archive, error) {
+	if err := b.Validate(ctx, zone); err != nil {
+		return nil, err
+	}
+
+	archive, err := b.Client.Archive.Create(ctx, zone,
+		&sacloud.ArchiveCreateRequest{
+			Name:            b.Name,
+			Description:     b.Description,
+			Tags:            b.Tags,
+			IconID:          b.IconID,
+			SourceDiskID:    b.SourceDiskID,
+			SourceArchiveID: b.SourceArchiveID,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	lastState, err := sacloud.WaiterForReady(func() (interface{}, error) {
+		return b.Client.Archive.Read(ctx, zone, archive.ID)
+	}).WaitForState(ctx)
+
+	var ret *sacloud.Archive
+	if lastState != nil {
+		ret = lastState.(*sacloud.Archive)
+	}
+	return ret, err
+}

--- a/v2/utils/builder/archive/standard_archive_builder_test.go
+++ b/v2/utils/builder/archive/standard_archive_builder_test.go
@@ -1,0 +1,83 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/sacloud/libsacloud/v2/utils/query"
+)
+
+func TestStandardArchiveBuilder_Build(t *testing.T) {
+	testZone := testutil.TestZone()
+	var sourceArchive *sacloud.Archive
+
+	testutil.Run(t, &testutil.CRUDTestCase{
+		SetupAPICallerFunc: func() sacloud.APICaller {
+			return testutil.SingletonAPICaller()
+		},
+		Parallel:          true,
+		IgnoreStartupWait: true,
+		Setup: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+			archiveOp := sacloud.NewArchiveOp(caller)
+			source, err := query.FindArchiveByOSType(ctx, archiveOp, testZone, ostype.CentOS)
+			if err != nil {
+				return err
+			}
+			sourceArchive = source
+			return nil
+		},
+		Create: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				builder := &StandardArchiveBuilder{
+					Name:            testutil.ResourceName("standard-archive-builder"),
+					Description:     "description",
+					Tags:            types.Tags{"tag1", "tag2"},
+					SourceArchiveID: sourceArchive.ID,
+					Client:          NewAPIClient(caller),
+				}
+				return builder.Build(ctx, testZone)
+			},
+		},
+		Read: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
+				return sacloud.NewArchiveOp(caller).Read(ctx, testZone, ctx.ID)
+			},
+			CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, value interface{}) error {
+				archive := value.(*sacloud.Archive)
+				return testutil.DoAsserts(
+					testutil.AssertNotNilFunc(t, archive, "Archive"),
+				)
+			},
+		},
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) error {
+				archiveOp := sacloud.NewArchiveOp(caller)
+
+				_, err := sacloud.WaiterForReady(func() (interface{}, error) {
+					return archiveOp.Read(ctx, testZone, ctx.ID)
+				}).WaitForState(ctx)
+				if err != nil {
+					return err
+				}
+				return archiveOp.Delete(ctx, testZone, ctx.ID)
+			},
+		},
+	})
+}


### PR DESCRIPTION
アーカイブビルダーとして以下を追加。

- StandardArchiveBuilder: 同一アカウント/同一ゾーンのディスク/アーカイブからアーカイブ作成を行う
- BlankArchiveBuilder: 指定のファイルをFTPSでアップロードしてアーカイブ作成を行う

Note: 依存としてgithub.com/sacloud/ftpsを追加している。  