### PR TITLE
Startup Script Parameters

### DIFF
--- a/v2/internal/define/models.go
+++ b/v2/internal/define/models.go
@@ -91,6 +91,14 @@ func (m *modelsDef) diskEdit() *dsl.Model {
 			},
 		},
 		{
+			Name: "APIKeyID",
+			Type: meta.TypeID,
+			Tags: &dsl.FieldTags{
+				MapConv: "APIKey.ID,omitempty",
+				JSON:    ",omitempty",
+			},
+		},
+		{
 			Name: "Variables",
 			Type: meta.Static(map[string]interface{}{}),
 			Tags: &dsl.FieldTags{
@@ -100,7 +108,7 @@ func (m *modelsDef) diskEdit() *dsl.Model {
 		},
 	}
 
-	userSubnetFdields := []*dsl.FieldDesc{
+	userSubnetFields := []*dsl.FieldDesc{
 		{
 			Name: "DefaultRoute",
 			Type: meta.TypeString,
@@ -219,7 +227,7 @@ func (m *modelsDef) diskEdit() *dsl.Model {
 				Name: "UserSubnet",
 				Type: &dsl.Model{
 					Name:   "DiskEditUserSubnet",
-					Fields: userSubnetFdields,
+					Fields: userSubnetFields,
 				},
 				Tags: &dsl.FieldTags{
 					MapConv: ",omitempty",

--- a/v2/sacloud/naked/disk_edit.go
+++ b/v2/sacloud/naked/disk_edit.go
@@ -25,7 +25,7 @@ type DiskEdit struct {
 	EnableDHCP          bool              `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // DHCPの有効化
 	ChangePartitionUUID bool              `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // パーティションのUUID変更
 	HostName            string            `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // ホスト名
-	Notes               []DiskEditNote    `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // スタートアップスクリプト
+	Notes               []*DiskEditNote   `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // スタートアップスクリプト
 	UserIPAddress       string            `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // IPアドレス
 	UserSubnet          *UserSubnet       `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // デフォルトルート/サブネットマスク長
 	Background          bool              `json:",omitempty" yaml:",omitempty" structs:",omitempty"` // バックグラウンド実行
@@ -40,5 +40,10 @@ type DiskEditSSHKey struct {
 // DiskEditNote ディスクの修正で指定するスタートアップスクリプト
 type DiskEditNote struct {
 	ID        types.ID               `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	APIKey    *APIKey                `json:",omitempty" yaml:"api_key,omitempty" structs:",omitempty"`
 	Variables map[string]interface{} `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+}
+
+type APIKey struct {
+	ID types.ID `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 }

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -7519,6 +7519,7 @@ func (o *DiskEditSSHKey) SetPublicKey(v string) {
 // DiskEditNote represents API parameter/response structure
 type DiskEditNote struct {
 	ID        types.ID               `json:",omitempty" mapconv:",omitempty"`
+	APIKeyID  types.ID               `json:",omitempty" mapconv:"APIKey.ID,omitempty"`
 	Variables map[string]interface{} `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -7531,9 +7532,11 @@ func (o *DiskEditNote) Validate() error {
 func (o *DiskEditNote) setDefaults() interface{} {
 	return &struct {
 		ID        types.ID               `json:",omitempty" mapconv:",omitempty"`
+		APIKeyID  types.ID               `json:",omitempty" mapconv:"APIKey.ID,omitempty"`
 		Variables map[string]interface{} `json:",omitempty" mapconv:",omitempty"`
 	}{
 		ID:        o.GetID(),
+		APIKeyID:  o.GetAPIKeyID(),
 		Variables: o.GetVariables(),
 	}
 }
@@ -7546,6 +7549,16 @@ func (o *DiskEditNote) GetID() types.ID {
 // SetID sets value to ID
 func (o *DiskEditNote) SetID(v types.ID) {
 	o.ID = v
+}
+
+// GetAPIKeyID returns value of APIKeyID
+func (o *DiskEditNote) GetAPIKeyID() types.ID {
+	return o.APIKeyID
+}
+
+// SetAPIKeyID sets value to APIKeyID
+func (o *DiskEditNote) SetAPIKeyID(v types.ID) {
+	o.APIKeyID = v
 }
 
 // GetVariables returns value of Variables

--- a/v2/utils/builder/disk/builder_test.go
+++ b/v2/utils/builder/disk/builder_test.go
@@ -70,7 +70,9 @@ func TestDiskFromUnixRequest_Validate(t *testing.T) {
 				PlanID: types.DiskPlans.SSD,
 				SizeGB: 1,
 				EditParameter: &UnixEditRequest{
-					NoteIDs: []types.ID{1},
+					Notes: []*sacloud.DiskEditNote{
+						{ID: 1},
+					},
 				},
 				Client: &APIClient{
 					DiskPlan: &dummyDiskPlanReader{

--- a/v2/utils/builder/server/builder_test.go
+++ b/v2/utils/builder/server/builder_test.go
@@ -469,10 +469,10 @@ func getBlackBoxTestBuilder(switchID types.ID) *Builder {
 					//SSHKeys   []string
 					//SSHKeyIDs []types.ID
 					IsNotesEphemeral: true,
-					Notes: []string{
+					NoteContents: []string{
 						`libsacloud-startup-script-for-builder`,
 					},
-					//NoteIDs          []types.ID
+					//Notes          []*sacloud.DiskEditNote{},
 				},
 				Client: disk.NewBuildersAPIClient(testutil.SingletonAPICaller()),
 			},

--- a/v2/utils/builder/server/example_test.go
+++ b/v2/utils/builder/server/example_test.go
@@ -91,8 +91,8 @@ func Example_builder() {
 					//GenerateSSHKeyPassPhrase:  "",                                 // 生成する公開鍵のパスフレーズ
 					//GenerateSSHKeyDescription: "",                                 // 生成する公開鍵の説明
 					//IsNotesEphemeral:          false,                              // Notesで指定したスタートアップスクリプトをサーバ作成後に削除するか
-					//Notes:                     []string{note1, note2},             // スタートアップスクリプト(文字列で指定)
-					//NoteIDs:                   []types.ID{types.ID(123456789012)}, // スタートアップスクリプト(IDで指定)
+					//NoteContents:              []string{note1, note2},             // スタートアップスクリプト(文字列で指定)
+					//Notes:                     []*sacloud.DiskEditNote{ID:types.ID(123456789012)}, // スタートアップスクリプト(ID+パラメータで指定)
 				},
 				// IconID:          0,
 			},


### PR DESCRIPTION
from https://github.com/sacloud/terraform-provider-sakuracloud/issues/730

コントロールパネルからのサーバ作成時、APIリクエストパラメータで以下のようにAPIキーのIDや置き換え用パラメータを指定できる。

```json
{
  "Disk": {
    ...
  },
  "Config": {
    "Password": "xxx",
    "HostName": "xxx",
    "ChangePartitionUUID": false,
    "Notes": [
      {
        "ID": "000000000001",
        "APIKey": {
          "ID": "000000000002"
        },
        "Variables": {
          "default_zone": "tk1v"
        }
      }
    ],
    "EnableDHCP": false
  }
}
```

libsacloudでは元々`Variables`は指定可能となっていたため、このPRでは`APIKeyID`を指定可能にする。

### libsacloud利用例

```go
func Example_editDisk() {
	caller := sacloud.NewClient("token", "secret")
	diskOp := sacloud.NewDiskOp(caller)

	ctx := context.Background()
	err := diskOp.Config(ctx, "is1a", types.ID(xxxx), &sacloud.DiskEditRequest{
		Background: true,
		Password:   "xxxx",
		Notes: []*sacloud.DiskEditNote{
			{
				ID: types.ID(xxxx),
				APIKeyID: types.ID(xxxx),
				Variables: map[string]interface{}{
					"foo": "bar",
				},
			},
		},
	})
	if err != nil {
		panic(err)
	}
}
```

### その他変更点 

DiskBuilderでのディスクの修正パラメータの指定方法が変更される。
**この部分はbreaking-changeとなる。**

旧:
```go
type UnixEditRequest struct {
	...
	Notes     []string
	NoteIDs   []types.ID
}
```

新:
```go
type UnixEditRequest struct {
	...
	NoteContents     []string
	Notes            []*sacloud.DiskEditNote
}
```

### 実装メモ

- APIキーの一覧/参照はAPI経由だとできない
- コントロールパネルからディスク(のみ)の作成を行う場合、ディスクの修正はできるもののスタートアップスクリプトの指定はできない
- コントロールパネルからディスクの修正/再インストールを行う場合はスタートアップスクリプトの指定が可能
- APIから`APIKey`と`Variables`の指定は可能