### PR TITLE
Fix converting StartupScript parameters to naked types

### DIFF
--- a/v2/internal/define/models.go
+++ b/v2/internal/define/models.go
@@ -206,12 +206,13 @@ func (m *modelsDef) diskEdit() *dsl.Model {
 			{
 				Name: "Notes",
 				Type: &dsl.Model{
-					Name:    "DiskEditNote",
-					IsArray: true,
-					Fields:  noteFields,
+					Name:      "DiskEditNote",
+					NakedType: meta.Static([]*naked.DiskEditNote{}),
+					IsArray:   true,
+					Fields:    noteFields,
 				},
 				Tags: &dsl.FieldTags{
-					MapConv: ",omitempty,recursive",
+					MapConv: "[]Notes,omitempty,recursive",
 					JSON:    ",omitempty",
 				},
 			},

--- a/v2/internal/dsl/envelope.go
+++ b/v2/internal/dsl/envelope.go
@@ -99,9 +99,15 @@ func RequestEnvelope(descs ...*EnvelopePayloadDesc) *EnvelopeType {
 func RequestEnvelopeFromModel(model *Model) *EnvelopeType {
 	var descs []*EnvelopePayloadDesc
 	for _, field := range model.Fields {
+		t := field.Type
+		if m, ok := t.(*Model); ok {
+			if m.HasNakedType() {
+				t = m.NakedType
+			}
+		}
 		descs = append(descs, &EnvelopePayloadDesc{
 			Name: field.Name,
-			Type: field.Type,
+			Type: t,
 			Tags: field.Tags,
 		})
 	}

--- a/v2/sacloud/zz_envelopes.go
+++ b/v2/sacloud/zz_envelopes.go
@@ -653,17 +653,17 @@ type diskCreateResponseEnvelope struct {
 
 // diskConfigRequestEnvelope is envelop of API request
 type diskConfigRequestEnvelope struct {
-	Background          bool                `json:",omitempty" mapconv:",omitempty"`
-	Password            string              `json:",omitempty" mapconv:",omitempty"`
-	SSHKey              *DiskEditSSHKey     `json:",omitempty" mapconv:",omitempty,recursive"`
-	SSHKeys             []*DiskEditSSHKey   `json:",omitempty" mapconv:"[]SSHKeys,omitempty,recursive"`
-	DisablePWAuth       bool                `json:",omitempty" mapconv:",omitempty"`
-	EnableDHCP          bool                `json:",omitempty" mapconv:",omitempty"`
-	ChangePartitionUUID bool                `json:",omitempty" mapconv:",omitempty"`
-	HostName            string              `json:",omitempty" mapconv:",omitempty"`
-	Notes               []*DiskEditNote     `json:",omitempty" mapconv:",omitempty,recursive"`
-	UserIPAddress       string              `json:",omitempty" mapconv:",omitempty"`
-	UserSubnet          *DiskEditUserSubnet `json:",omitempty" mapconv:",omitempty"`
+	Background          bool                  `json:",omitempty" mapconv:",omitempty"`
+	Password            string                `json:",omitempty" mapconv:",omitempty"`
+	SSHKey              *DiskEditSSHKey       `json:",omitempty" mapconv:",omitempty,recursive"`
+	SSHKeys             []*DiskEditSSHKey     `json:",omitempty" mapconv:"[]SSHKeys,omitempty,recursive"`
+	DisablePWAuth       bool                  `json:",omitempty" mapconv:",omitempty"`
+	EnableDHCP          bool                  `json:",omitempty" mapconv:",omitempty"`
+	ChangePartitionUUID bool                  `json:",omitempty" mapconv:",omitempty"`
+	HostName            string                `json:",omitempty" mapconv:",omitempty"`
+	Notes               []*naked.DiskEditNote `json:",omitempty" mapconv:"[]Notes,omitempty,recursive"`
+	UserIPAddress       string                `json:",omitempty" mapconv:",omitempty"`
+	UserSubnet          *DiskEditUserSubnet   `json:",omitempty" mapconv:",omitempty"`
 }
 
 // diskCreateWithConfigRequestEnvelope is envelop of API request

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -7317,7 +7317,7 @@ type DiskEditRequest struct {
 	EnableDHCP          bool                `json:",omitempty" mapconv:",omitempty"`
 	ChangePartitionUUID bool                `json:",omitempty" mapconv:",omitempty"`
 	HostName            string              `json:",omitempty" mapconv:",omitempty"`
-	Notes               []*DiskEditNote     `json:",omitempty" mapconv:",omitempty,recursive"`
+	Notes               []*DiskEditNote     `json:",omitempty" mapconv:"[]Notes,omitempty,recursive"`
 	UserIPAddress       string              `json:",omitempty" mapconv:",omitempty"`
 	UserSubnet          *DiskEditUserSubnet `json:",omitempty" mapconv:",omitempty"`
 }
@@ -7338,7 +7338,7 @@ func (o *DiskEditRequest) setDefaults() interface{} {
 		EnableDHCP          bool                `json:",omitempty" mapconv:",omitempty"`
 		ChangePartitionUUID bool                `json:",omitempty" mapconv:",omitempty"`
 		HostName            string              `json:",omitempty" mapconv:",omitempty"`
-		Notes               []*DiskEditNote     `json:",omitempty" mapconv:",omitempty,recursive"`
+		Notes               []*DiskEditNote     `json:",omitempty" mapconv:"[]Notes,omitempty,recursive"`
 		UserIPAddress       string              `json:",omitempty" mapconv:",omitempty"`
 		UserSubnet          *DiskEditUserSubnet `json:",omitempty" mapconv:",omitempty"`
 	}{


### PR DESCRIPTION
fixes #546 

リクエストエンベロープをモデル定義から作成するケース(リクエストJSON直下に値が来るケース)において、dsl.FieldDescにnaked型の情報を登録してもnaked型への変換コードが出力されない。

これは上記ケース向けのDSLヘルパー`RequestEnvelopeFromModel`においてnaked型指定を無視していたため。このPRではnaked側指定されていた場合はそちらを利用するように修正する。

この修正によりスタートアップスクリプトへのパラメータ指定時にAPIキーが欠落してしまう問題が修正される。
