### PR TITLE
Fix ChangePlan failures in ProxyLB

### DIFF
--- a/v2/internal/define/proxylb.go
+++ b/v2/internal/define/proxylb.go
@@ -56,7 +56,7 @@ var proxyLBAPI = &dsl.Resource{
 		{
 			ResourceName: proxyLBAPIName,
 			Name:         "ChangePlan",
-			PathFormat:   dsl.DefaultPathFormatWithID,
+			PathFormat:   dsl.IDAndSuffixPathFormat("plan"),
 			Method:       http.MethodPut,
 			RequestEnvelope: dsl.RequestEnvelope(&dsl.EnvelopePayloadDesc{
 				Type: proxyLBNakedType,

--- a/v2/internal/define/proxylb.go
+++ b/v2/internal/define/proxylb.go
@@ -59,7 +59,7 @@ var proxyLBAPI = &dsl.Resource{
 			PathFormat:   dsl.IDAndSuffixPathFormat("plan"),
 			Method:       http.MethodPut,
 			RequestEnvelope: dsl.RequestEnvelope(&dsl.EnvelopePayloadDesc{
-				Type: proxyLBNakedType,
+				Type: proxyLBChangePlanNakedType,
 				Name: "CommonServiceItem",
 			}),
 			Arguments: dsl.Arguments{
@@ -157,6 +157,7 @@ var proxyLBAPI = &dsl.Resource{
 var (
 	proxyLBNakedType               = meta.Static(naked.ProxyLB{})
 	proxyLBUpdateSettingsNakedType = meta.Static(naked.ProxyLBSettingsUpdate{})
+	proxyLBChangePlanNakedType     = meta.Static(naked.ProxyLBPlanChange{})
 	proxyLBCertificatesNakedType   = meta.Static(naked.ProxyLBCertificates{})
 
 	proxyLBView = &dsl.Model{

--- a/v2/sacloud/naked/proxylb.go
+++ b/v2/sacloud/naked/proxylb.go
@@ -41,6 +41,11 @@ type ProxyLB struct {
 	ServiceClass types.EProxyLBPlan `json:",omitempty" yaml:"service_class,omitempty" structs:",omitempty"`
 }
 
+// ProxyLBPlanChange エンハンスドロードバランサのプラン変更
+type ProxyLBPlanChange struct {
+	ServiceClass types.EProxyLBPlan `yaml:"service_class"`
+}
+
 // ProxyLBSettingsUpdate エンハンスドロードバランサ
 type ProxyLBSettingsUpdate struct {
 	Settings     *ProxyLBSettings `json:",omitempty" yaml:"settings,omitempty" structs:",omitempty"`

--- a/v2/sacloud/zz_api_ops.go
+++ b/v2/sacloud/zz_api_ops.go
@@ -8366,7 +8366,7 @@ func (o *ProxyLBOp) ChangePlan(ctx context.Context, id types.ID, param *ProxyLBC
 		"param":      param,
 	}
 
-	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}", pathBuildParameter)
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/plan", pathBuildParameter)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/sacloud/zz_envelopes.go
+++ b/v2/sacloud/zz_envelopes.go
@@ -2012,7 +2012,7 @@ type proxyLBUpdateSettingsResponseEnvelope struct {
 
 // proxyLBChangePlanRequestEnvelope is envelop of API request
 type proxyLBChangePlanRequestEnvelope struct {
-	CommonServiceItem *naked.ProxyLB `json:",omitempty"`
+	CommonServiceItem *naked.ProxyLBPlanChange `json:",omitempty"`
 }
 
 // proxyLBChangePlanResponseEnvelope is envelop of API response


### PR DESCRIPTION
エンハンスドLBのChangePlanが動作しなかったため、以下2点を修正しました。

#### 1. リクエストパスの修正 [ref](https://developer.sakura.ad.jp/cloud/api/1.1/appliance/#put_commonserviceitem_commonserviceitemid_plan)

`PUT /commonserviceitem/:id` -> `PUT /commonserviceitem/:id/plan` 

#### 2. リクエストボディの修正

リクエストボディに `Description` 等の余分なパラメータが含まれると不正と判定されて更新に失敗するため、ServiceClassのみが送られるようにしました。

**変更前**

```json
{
  "CommonServiceItem": {
    "Description": "",
    "Tags": [],
    "ServiceClass": "cloud/proxylb/plain/500"
  }
}
```

**変更後**

```json
{
  "CommonServiceItem": {
    "ServiceClass": "cloud/proxylb/plain/500"
  }
}
```