### PR TITLE
Fix running godoc

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -67,8 +67,8 @@ fmt:
 
 .PHONY: godoc
 godoc:
-	@echo "URL: http://localhost:6060/pkg/github.com/sacloud/libsacloud/"; \
-	docker run -it --rm -v $$PWD:/go/src/github.com/sacloud/libsacloud -p 6060:6060 golang:1.12 godoc -http=:6060
+	@echo "booting godoc server..." ; \
+	docker run -it --rm -v $$PWD:/go/src/github.com/sacloud/libsacloud/v2 -p 6060:6060 golang:1.14 sh -c "go get golang.org/x/tools/cmd/godoc; echo 'URL: http://localhost:6060/pkg/github.com/sacloud/libsacloud/v2/'; godoc -http=:6060"
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
`make godoc`が動作しない問題を修正

- `golang:1.14`イメージへ差し替え
- ボリューム指定でv2ディレクトリを指すように修正