### PR TITLE
Supports appliance status API for the Database Appliance

### DIFF
--- a/v2/internal/define/database.go
+++ b/v2/internal/define/database.go
@@ -215,6 +215,20 @@ var (
 				},
 			},
 			{
+				Name: "MariaDBStatus",
+				Type: meta.TypeString,
+				Tags: &dsl.FieldTags{
+					MapConv: "SettingsResponse.DBConf.MariaDB.Status",
+				},
+			},
+			{
+				Name: "PostgresStatus",
+				Type: meta.TypeString,
+				Tags: &dsl.FieldTags{
+					MapConv: "SettingsResponse.DBConf.Postgres.Status",
+				},
+			},
+			{
 				Name: "IsFatal",
 				Type: meta.TypeFlag,
 				Tags: &dsl.FieldTags{

--- a/v2/internal/define/database.go
+++ b/v2/internal/define/database.go
@@ -278,7 +278,7 @@ var (
 		Fields: []*dsl.FieldDesc{
 			fields.Def("Name", meta.TypeString),
 			fields.Def("Data", meta.TypeString),
-			fields.Def("Size", meta.TypeInt),
+			fields.Def("Size", meta.TypeStringNumber),
 		},
 	}
 	databaseStatusBackupHistoryView = &dsl.Model{

--- a/v2/sacloud/customize_model.go
+++ b/v2/sacloud/customize_model.go
@@ -19,12 +19,12 @@ import "github.com/sacloud/libsacloud/v2/sacloud/types"
 // BandWidthAt 指定インデックスのNICの帯域幅を算出
 //
 // 不明な場合は-1を、制限なしの場合は0を、以外の場合はMbps単位で返す
-func (s *Server) BandWidthAt(index int) int {
-	if len(s.Interfaces) <= index {
+func (o *Server) BandWidthAt(index int) int {
+	if len(o.Interfaces) <= index {
 		return -1
 	}
 
-	nic := s.Interfaces[index]
+	nic := o.Interfaces[index]
 
 	switch nic.UpstreamType {
 	case types.UpstreamNetworkTypes.None:
@@ -38,12 +38,12 @@ func (s *Server) BandWidthAt(index int) int {
 		//
 
 		// 専有ホストの場合は制限なし
-		if !s.PrivateHostID.IsEmpty() {
+		if !o.PrivateHostID.IsEmpty() {
 			return 0
 		}
 
 		// メモリに応じた制限
-		memory := s.GetMemoryGB()
+		memory := o.GetMemoryGB()
 		switch {
 		case memory < 32:
 			return 1000
@@ -59,4 +59,21 @@ func (s *Server) BandWidthAt(index int) int {
 	default:
 		return -1
 	}
+}
+
+// GetInstanceStatus データベース(サービス)ステータスを返すためのアダプター実装
+// PostgreSQLまたはMariaDBのステータス(詳細は以下)をInstanceStatusにラップして返す
+//    ステータス: GET /appliance/:id/status -> Appliance.ResponseStatus.DBConf.{MariaDB | postgres}.status
+// 主にStateWaiterで利用する。
+func (o *DatabaseStatus) GetInstanceStatus() types.EServerInstanceStatus {
+	if o.MariaDBStatus == "running" || o.PostgresStatus == "running" {
+		return types.ServerInstanceStatuses.Up
+	}
+	return types.ServerInstanceStatuses.Unknown
+}
+
+// SetInstanceStatus データベース(サービス)ステータスを返すためのアダプター実装
+// accessor.InstanceStatusを満たすためのスタブ実装
+func (o *DatabaseStatus) SetInstanceStatus(types.EServerInstanceStatus) {
+	// noop
 }

--- a/v2/sacloud/fake/ops_database.go
+++ b/v2/sacloud/fake/ops_database.go
@@ -278,8 +278,9 @@ func (o *DatabaseOp) Status(ctx context.Context, zone string, id types.ID) (*sac
 	}
 
 	return &sacloud.DatabaseStatus{
-		Status:  value.InstanceStatus,
-		IsFatal: true,
+		Status:        value.InstanceStatus,
+		IsFatal:       false,
+		MariaDBStatus: "running",
 		Version: &sacloud.DatabaseVersionInfo{
 			LastModified: value.ModifiedAt.String(),
 			CommitHash:   "foobar",

--- a/v2/sacloud/naked/database.go
+++ b/v2/sacloud/naked/database.go
@@ -155,9 +155,9 @@ type DatabaseStatusVersion struct {
 
 // DatabaseLog データベースログ
 type DatabaseLog struct {
-	Name string `json:"name,omitempty" yaml:"name,omitempty" structs:",omitempty"`
-	Data string `json:"data,omitempty" yaml:"data,omitempty" structs:",omitempty"`
-	Size int    `json:"size,omitempty" yaml:"size,omitempty" structs:",omitempty"`
+	Name string             `json:"name,omitempty" yaml:"name,omitempty" structs:",omitempty"`
+	Data string             `json:"data,omitempty" yaml:"data,omitempty" structs:",omitempty"`
+	Size types.StringNumber `json:"size,omitempty" yaml:"size,omitempty" structs:",omitempty"`
 }
 
 // IsSystemdLog systemcltのログか判定

--- a/v2/sacloud/naked/database.go
+++ b/v2/sacloud/naked/database.go
@@ -127,14 +127,21 @@ type DatabaseStatus struct {
 
 // DatabaseStatusDBConf データベース設定
 type DatabaseStatusDBConf struct {
-	Version *DatabaseStatusVersion `json:"version,omitempty" yaml:"version,omitempty" structs:",omitempty"`
-	Log     []*DatabaseLog         `json:"log,omitempty" yaml:"log,omitempty" structs:",omitempty"`
-	Backup  *DatabaseBackupInfo    `json:"backup,omitempty" yaml:"backup,omitempty" structs:",omitempty"`
+	Version  *DatabaseStatusVersion    `json:"version,omitempty" yaml:"version,omitempty" structs:",omitempty"`
+	Log      []*DatabaseLog            `json:"log,omitempty" yaml:"log,omitempty" structs:",omitempty"`
+	Backup   *DatabaseBackupInfo       `json:"backup,omitempty" yaml:"backup,omitempty" structs:",omitempty"`
+	MariaDB  *DatabaseStatusMariaDB    `json:",omitempty" yaml:"maria_db,omitempty" structs:",omitempty"`
+	Postgres *DatabaseStatusPostgreSQL `json:"postgres,omitempty" yaml:"postgres,omitempty" structs:",omitempty"`
 
 	// 以下フィールドはサポートしない
 	// Replication
-	// MariaDB
-	// Postgress
+}
+
+type DatabaseStatusMariaDB struct {
+	Status string `json:"status,omitempty"`
+}
+type DatabaseStatusPostgreSQL struct {
+	Status string `json:"status,omitempty"`
 }
 
 // DatabaseStatusVersion データベース設定バージョン情報

--- a/v2/sacloud/state.go
+++ b/v2/sacloud/state.go
@@ -30,6 +30,10 @@ type StateWaiter interface {
 	WaitForState(context.Context) (interface{}, error)
 	// AsyncWaitForState リソースが指定の状態になるまで待つ
 	AsyncWaitForState(context.Context) (compCh <-chan interface{}, progressCh <-chan interface{}, errorCh <-chan error)
+	// SetPollingTimeout ポーリングタイムアウトを指定
+	SetPollingTimeout(d time.Duration)
+	// SetPollingInterval ポーリングタイムアウトを指定
+	SetPollingInterval(d time.Duration)
 }
 
 var (
@@ -37,6 +41,9 @@ var (
 	DefaultStatePollingTimeout = 20 * time.Minute
 	// DefaultStatePollingInterval StatePollWaiterでのデフォルトポーリング間隔
 	DefaultStatePollingInterval = 5 * time.Second
+
+	// DefaultDBStatusPollingInterval データベースアプライアンスのステータス取得ポーリング間隔
+	DefaultDBStatusPollingInterval = 30 * time.Second
 )
 
 // StateReadFunc StatePollWaiterにより利用される、対象リソースの状態を取得するためのfunc
@@ -144,6 +151,16 @@ func (w *StatePollingWaiter) defaults() {
 	if w.PollingInterval == time.Duration(0) {
 		w.PollingInterval = DefaultStatePollingInterval
 	}
+}
+
+// SetPollingTimeout ポーリングタイムアウトを指定
+func (w *StatePollingWaiter) SetPollingTimeout(timeout time.Duration) {
+	w.Timeout = timeout
+}
+
+// SetPollingInterval ポーリングタイムアウトを指定
+func (w *StatePollingWaiter) SetPollingInterval(d time.Duration) {
+	w.PollingInterval = d
 }
 
 // WaitForState リソースが指定の状態になるまで待つ

--- a/v2/sacloud/test/database_op_test.go
+++ b/v2/sacloud/test/database_op_test.go
@@ -17,6 +17,8 @@ package test
 import (
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/utils/wait"
+
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -299,7 +301,11 @@ var (
 
 func testDatabaseCreate(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 	client := sacloud.NewDatabaseOp(caller)
-	return client.Create(ctx, testZone, createDatabaseParam)
+	db, err := client.Create(ctx, testZone, createDatabaseParam)
+	if err != nil {
+		return nil, err
+	}
+	return wait.UntilDatabaseIsUp(ctx, client, testZone, db.ID)
 }
 
 func testDatabaseRead(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -6336,11 +6336,13 @@ func (o *MonitorDatabaseValue) SetDelayTimeSec(v float64) {
 
 // DatabaseStatus represents API parameter/response structure
 type DatabaseStatus struct {
-	Status  types.EServerInstanceStatus `mapconv:"SettingsResponse.Status"`
-	IsFatal bool                        `mapconv:"SettingsResponse.IsFatal"`
-	Version *DatabaseVersionInfo        `mapconv:"SettingsResponse.DBConf.Version,recursive"`
-	Logs    []*DatabaseLog              `mapconv:"SettingsResponse.DBConf.[]Log,recursive"`
-	Backups []*DatabaseBackupHistory    `mapconv:"SettingsResponse.DBConf.Backup.[]History,recursive"`
+	Status         types.EServerInstanceStatus `mapconv:"SettingsResponse.Status"`
+	MariaDBStatus  string                      `mapconv:"SettingsResponse.DBConf.MariaDB.Status"`
+	PostgresStatus string                      `mapconv:"SettingsResponse.DBConf.Postgres.Status"`
+	IsFatal        bool                        `mapconv:"SettingsResponse.IsFatal"`
+	Version        *DatabaseVersionInfo        `mapconv:"SettingsResponse.DBConf.Version,recursive"`
+	Logs           []*DatabaseLog              `mapconv:"SettingsResponse.DBConf.[]Log,recursive"`
+	Backups        []*DatabaseBackupHistory    `mapconv:"SettingsResponse.DBConf.Backup.[]History,recursive"`
 }
 
 // Validate validates by field tags
@@ -6351,17 +6353,21 @@ func (o *DatabaseStatus) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *DatabaseStatus) setDefaults() interface{} {
 	return &struct {
-		Status  types.EServerInstanceStatus `mapconv:"SettingsResponse.Status"`
-		IsFatal bool                        `mapconv:"SettingsResponse.IsFatal"`
-		Version *DatabaseVersionInfo        `mapconv:"SettingsResponse.DBConf.Version,recursive"`
-		Logs    []*DatabaseLog              `mapconv:"SettingsResponse.DBConf.[]Log,recursive"`
-		Backups []*DatabaseBackupHistory    `mapconv:"SettingsResponse.DBConf.Backup.[]History,recursive"`
+		Status         types.EServerInstanceStatus `mapconv:"SettingsResponse.Status"`
+		MariaDBStatus  string                      `mapconv:"SettingsResponse.DBConf.MariaDB.Status"`
+		PostgresStatus string                      `mapconv:"SettingsResponse.DBConf.Postgres.Status"`
+		IsFatal        bool                        `mapconv:"SettingsResponse.IsFatal"`
+		Version        *DatabaseVersionInfo        `mapconv:"SettingsResponse.DBConf.Version,recursive"`
+		Logs           []*DatabaseLog              `mapconv:"SettingsResponse.DBConf.[]Log,recursive"`
+		Backups        []*DatabaseBackupHistory    `mapconv:"SettingsResponse.DBConf.Backup.[]History,recursive"`
 	}{
-		Status:  o.GetStatus(),
-		IsFatal: o.GetIsFatal(),
-		Version: o.GetVersion(),
-		Logs:    o.GetLogs(),
-		Backups: o.GetBackups(),
+		Status:         o.GetStatus(),
+		MariaDBStatus:  o.GetMariaDBStatus(),
+		PostgresStatus: o.GetPostgresStatus(),
+		IsFatal:        o.GetIsFatal(),
+		Version:        o.GetVersion(),
+		Logs:           o.GetLogs(),
+		Backups:        o.GetBackups(),
 	}
 }
 
@@ -6373,6 +6379,26 @@ func (o *DatabaseStatus) GetStatus() types.EServerInstanceStatus {
 // SetStatus sets value to Status
 func (o *DatabaseStatus) SetStatus(v types.EServerInstanceStatus) {
 	o.Status = v
+}
+
+// GetMariaDBStatus returns value of MariaDBStatus
+func (o *DatabaseStatus) GetMariaDBStatus() string {
+	return o.MariaDBStatus
+}
+
+// SetMariaDBStatus sets value to MariaDBStatus
+func (o *DatabaseStatus) SetMariaDBStatus(v string) {
+	o.MariaDBStatus = v
+}
+
+// GetPostgresStatus returns value of PostgresStatus
+func (o *DatabaseStatus) GetPostgresStatus() string {
+	return o.PostgresStatus
+}
+
+// SetPostgresStatus sets value to PostgresStatus
+func (o *DatabaseStatus) SetPostgresStatus(v string) {
+	o.PostgresStatus = v
 }
 
 // GetIsFatal returns value of IsFatal

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -6534,7 +6534,7 @@ func (o *DatabaseVersionInfo) SetExpire(v string) {
 type DatabaseLog struct {
 	Name string
 	Data string
-	Size int
+	Size types.StringNumber
 }
 
 // Validate validates by field tags
@@ -6547,7 +6547,7 @@ func (o *DatabaseLog) setDefaults() interface{} {
 	return &struct {
 		Name string
 		Data string
-		Size int
+		Size types.StringNumber
 	}{
 		Name: o.GetName(),
 		Data: o.GetData(),
@@ -6576,12 +6576,12 @@ func (o *DatabaseLog) SetData(v string) {
 }
 
 // GetSize returns value of Size
-func (o *DatabaseLog) GetSize() int {
+func (o *DatabaseLog) GetSize() types.StringNumber {
 	return o.Size
 }
 
 // SetSize sets value to Size
-func (o *DatabaseLog) SetSize(v int) {
+func (o *DatabaseLog) SetSize(v types.StringNumber) {
 	o.Size = v
 }
 


### PR DESCRIPTION
データベースアプライアンスでのステータスAPIを拡充し、各種待ち処理で利用する。

### 詳細

現在AvailabilityとInstanceStatusで作成完了を判定しているのに加え、`GET /appliance/:id/status`でDBMS上のステータスを取得して判定に利用するようにする。

これに伴いsacloud.StateWaiterなどの待ち処理の公開インターフェースを一部変更するが、直接利用される頻度は少ないものなため既存クライアントへの影響は軽微と思われる。

### 対象

- utils/waiter
- builder/database
- sacloud/StateWaiter

Note: `GET /appliance/:id/status`での利用を想定しsacloud.StateWaiterでポーリング間隔とタイムアウトを(キャストなしで)設定可能にした。これによりレスポンスタイムの大きなリクエストを待ち処理で利用しやすくする狙い。

Note: 本来はステータス用にsacloud.WaiterForUpなどのファクトリーを増やすべきだが、今回はステータスのモデルをカスタマイズして既存のファクトリーで利用できる形にしている。
https://github.com/sacloud/libsacloud/blob/591de1c8f2b95d83d2700e66dabb8f6021eabad9/v2/sacloud/customize_model.go#L64-L73

同様なユースケースが増えてきたらこの部分は修正する。