### PR TITLE
Fix creating mobile-gateway

### DIFF
--- a/v2/internal/define/mobile_gateway.go
+++ b/v2/internal/define/mobile_gateway.go
@@ -375,7 +375,7 @@ var (
 					MapConv: "Remark.Plan.ID/Plan.ID",
 				},
 				Type:  meta.TypeID,
-				Value: `types.ID(1)`,
+				Value: `types.ID(2)`,
 			},
 			{
 				Name: "SwitchID",

--- a/v2/sacloud/test/mobile_gateway_op_test.go
+++ b/v2/sacloud/test/mobile_gateway_op_test.go
@@ -116,17 +116,24 @@ func TestMobileGatewayOpCRUD(t *testing.T) {
 			{
 				Func: func(ctx *testutil.CRUDTestContext, caller sacloud.APICaller) (interface{}, error) {
 					mgwOp := sacloud.NewMobileGatewayOp(caller)
-					return mgwOp.Update(ctx, testZone, ctx.ID, &sacloud.MobileGatewayUpdateRequest{
+					mgs, err := mgwOp.UpdateSettings(ctx, testZone, ctx.ID, &sacloud.MobileGatewayUpdateSettingsRequest{
 						Settings: &sacloud.MobileGatewaySetting{
 							Interfaces: []*sacloud.MobileGatewayInterfaceSetting{
 								{
 									IPAddress:      []string{"192.168.2.11"},
-									NetworkMaskLen: 24,
+									NetworkMaskLen: 16,
 									Index:          1,
 								},
 							},
 						},
 					})
+					if err != nil {
+						return nil, err
+					}
+					if err := mgwOp.Config(ctx, testZone, ctx.ID); err != nil {
+						return nil, err
+					}
+					return mgs, nil
 				},
 				CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, i interface{}) error {
 					mgw := i.(*sacloud.MobileGateway)
@@ -134,7 +141,7 @@ func TestMobileGatewayOpCRUD(t *testing.T) {
 						testutil.AssertNotNilFunc(t, mgw.Settings.Interfaces, "MobileGateway.Settings.Interfaces"),
 						testutil.AssertEqualFunc(t, 1, mgw.Settings.Interfaces[0].Index, "MobileGateway.Settings.Interfaces.Index"),
 						testutil.AssertEqualFunc(t, "192.168.2.11", mgw.Settings.Interfaces[0].IPAddress[0], "MobileGateway.Settings.Interfaces.IPAddress"),
-						testutil.AssertEqualFunc(t, 24, mgw.Settings.Interfaces[0].NetworkMaskLen, "MobileGateway.Settings.Interfaces.NetworkMaskLen"),
+						testutil.AssertEqualFunc(t, 16, mgw.Settings.Interfaces[0].NetworkMaskLen, "MobileGateway.Settings.Interfaces.NetworkMaskLen"),
 					)
 				},
 				SkipExtractID: true,

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -14712,7 +14712,7 @@ func (o *MobileGatewayCreateRequest) setDefaults() interface{} {
 		IconID:      o.GetIconID(),
 		Settings:    o.GetSettings(),
 		Class:       "mobilegateway",
-		PlanID:      types.ID(1),
+		PlanID:      types.ID(2),
 		SwitchID:    "shared",
 	}
 }


### PR DESCRIPTION
fixes #582 

モバイルゲートウェイ作成時にPlan.IDに`2`を指定する。