### PR TITLE
New response format of public/price API

### DIFF
--- a/v2/internal/define/service_class.go
+++ b/v2/internal/define/service_class.go
@@ -64,6 +64,13 @@ var (
 			fields.Def("Daily", meta.TypeInt),
 			fields.Def("Hourly", meta.TypeInt),
 			fields.Def("Monthly", meta.TypeInt),
+			fields.Def("PerUse", meta.TypeInt),
+			fields.Def("Basic", meta.TypeInt),
+			fields.Def("Traffic", meta.TypeInt),
+			fields.Def("DocomoTraffic", meta.TypeInt),
+			fields.Def("KddiTraffic", meta.TypeInt),
+			fields.Def("SbTraffic", meta.TypeInt),
+			fields.Def("SimSheet", meta.TypeInt),
 			fields.Def("Zone", meta.TypeString),
 		},
 	}

--- a/v2/sacloud/naked/service_class.go
+++ b/v2/sacloud/naked/service_class.go
@@ -14,7 +14,11 @@
 
 package naked
 
-import "github.com/sacloud/libsacloud/v2/sacloud/types"
+import (
+	"encoding/json"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
 
 // ServiceClass 料金
 type ServiceClass struct {
@@ -28,9 +32,31 @@ type ServiceClass struct {
 
 // Price 価格
 type Price struct {
-	Base    int    `yaml:"base"`    // 基本料金
-	Daily   int    `yaml:"daily"`   // 日単位料金
-	Hourly  int    `yaml:"hourly"`  // 時間単位料金
-	Monthly int    `yaml:"monthly"` // 分単位料金
-	Zone    string `yaml:"zone"`    // ゾーン
+	Base          int    `yaml:"base"`           // 基本料金
+	Daily         int    `yaml:"daily"`          // 日単位料金
+	Hourly        int    `yaml:"hourly"`         // 時間単位料金
+	Monthly       int    `yaml:"monthly"`        // 分単位料金
+	PerUse        int    `yaml:"per_use"`        // 自動バックアップ
+	Basic         int    `yaml:"basic"`          // AWS接続オプション: 基本料
+	Traffic       int    `yaml:"traffic"`        // AWS接続オプション: トラフィック課金
+	DocomoTraffic int    `yaml:"docomo_traffic"` // セキュアモバイルコネクト: Docomo
+	KddiTraffic   int    `yaml:"kddi_traffic"`   // セキュアモバイルコネクト: KDDI
+	SbTraffic     int    `yaml:"sb_traffic"`     // セキュアモバイルコネクト: SoftBank
+	SimSheet      int    `yaml:"sim_sheet"`      // SIM
+	Zone          string `yaml:"zone"`           // ゾーン
+}
+
+// UnmarshalJSON 配列/オブジェクトが混在することへの対応
+func (p *Price) UnmarshalJSON(b []byte) error {
+	if string(b) == "[]" {
+		return nil
+	}
+	type alias Price
+
+	var a alias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	*p = Price(a)
+	return nil
 }

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -21481,11 +21481,18 @@ func (o *ServiceClass) SetPrice(v *Price) {
 
 // Price represents API parameter/response structure
 type Price struct {
-	Base    int
-	Daily   int
-	Hourly  int
-	Monthly int
-	Zone    string
+	Base          int
+	Daily         int
+	Hourly        int
+	Monthly       int
+	PerUse        int
+	Basic         int
+	Traffic       int
+	DocomoTraffic int
+	KddiTraffic   int
+	SbTraffic     int
+	SimSheet      int
+	Zone          string
 }
 
 // Validate validates by field tags
@@ -21496,17 +21503,31 @@ func (o *Price) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *Price) setDefaults() interface{} {
 	return &struct {
-		Base    int
-		Daily   int
-		Hourly  int
-		Monthly int
-		Zone    string
+		Base          int
+		Daily         int
+		Hourly        int
+		Monthly       int
+		PerUse        int
+		Basic         int
+		Traffic       int
+		DocomoTraffic int
+		KddiTraffic   int
+		SbTraffic     int
+		SimSheet      int
+		Zone          string
 	}{
-		Base:    o.GetBase(),
-		Daily:   o.GetDaily(),
-		Hourly:  o.GetHourly(),
-		Monthly: o.GetMonthly(),
-		Zone:    o.GetZone(),
+		Base:          o.GetBase(),
+		Daily:         o.GetDaily(),
+		Hourly:        o.GetHourly(),
+		Monthly:       o.GetMonthly(),
+		PerUse:        o.GetPerUse(),
+		Basic:         o.GetBasic(),
+		Traffic:       o.GetTraffic(),
+		DocomoTraffic: o.GetDocomoTraffic(),
+		KddiTraffic:   o.GetKddiTraffic(),
+		SbTraffic:     o.GetSbTraffic(),
+		SimSheet:      o.GetSimSheet(),
+		Zone:          o.GetZone(),
 	}
 }
 
@@ -21548,6 +21569,76 @@ func (o *Price) GetMonthly() int {
 // SetMonthly sets value to Monthly
 func (o *Price) SetMonthly(v int) {
 	o.Monthly = v
+}
+
+// GetPerUse returns value of PerUse
+func (o *Price) GetPerUse() int {
+	return o.PerUse
+}
+
+// SetPerUse sets value to PerUse
+func (o *Price) SetPerUse(v int) {
+	o.PerUse = v
+}
+
+// GetBasic returns value of Basic
+func (o *Price) GetBasic() int {
+	return o.Basic
+}
+
+// SetBasic sets value to Basic
+func (o *Price) SetBasic(v int) {
+	o.Basic = v
+}
+
+// GetTraffic returns value of Traffic
+func (o *Price) GetTraffic() int {
+	return o.Traffic
+}
+
+// SetTraffic sets value to Traffic
+func (o *Price) SetTraffic(v int) {
+	o.Traffic = v
+}
+
+// GetDocomoTraffic returns value of DocomoTraffic
+func (o *Price) GetDocomoTraffic() int {
+	return o.DocomoTraffic
+}
+
+// SetDocomoTraffic sets value to DocomoTraffic
+func (o *Price) SetDocomoTraffic(v int) {
+	o.DocomoTraffic = v
+}
+
+// GetKddiTraffic returns value of KddiTraffic
+func (o *Price) GetKddiTraffic() int {
+	return o.KddiTraffic
+}
+
+// SetKddiTraffic sets value to KddiTraffic
+func (o *Price) SetKddiTraffic(v int) {
+	o.KddiTraffic = v
+}
+
+// GetSbTraffic returns value of SbTraffic
+func (o *Price) GetSbTraffic() int {
+	return o.SbTraffic
+}
+
+// SetSbTraffic sets value to SbTraffic
+func (o *Price) SetSbTraffic(v int) {
+	o.SbTraffic = v
+}
+
+// GetSimSheet returns value of SimSheet
+func (o *Price) GetSimSheet() int {
+	return o.SimSheet
+}
+
+// SetSimSheet sets value to SimSheet
+func (o *Price) SetSimSheet(v int) {
+	o.SimSheet = v
 }
 
 // GetZone returns value of Zone


### PR DESCRIPTION
closes #581 

v2にて`public/price` APIのレスポンスフォーマット変更に対応する。

Note: Price structに`Traffic`と`xxxTraffic`、`Base`と`Basic`など、名前から用途を判別/区別しにくい項目が混在しているが(sacloud配下のプロダクトで)利用箇所が少ないことから分かりやすさのために複雑にするよりも素のAPIレスポンスに合わせシンプルに実装するようにした。