### PR TITLE
Fix mobile gateway builder: call xxxOp.Config after configuring interfaces

### DIFF
--- a/v2/helper/builder/mobilegateway/builder_test.go
+++ b/v2/helper/builder/mobilegateway/builder_test.go
@@ -37,7 +37,7 @@ func getSetupOption() *builder.RetryableSetupParameter {
 	}
 }
 
-func TestBuilder_Build(t *testing.T) {
+func TestMobileGatewayBuilder_Build(t *testing.T) {
 	var switchID types.ID
 	var testZone = testutil.TestZone()
 


### PR DESCRIPTION
fixes #589 

モバイルゲートウェイ 向けのビルダーでインターフェース設定を反映させるためにxxxOp.Configの呼び出しを行うようにする。

Note:従来はこの呼び出しは不要だったが、#587 の対応以降にSIMルート設定でエラーが出るようになったため明示的にxxxOp.Configを呼ぶようにする。