### PR TITLE
Allow empty struct at mapconv

### DIFF
--- a/v2/pkg/mapconv/map.go
+++ b/v2/pkg/mapconv/map.go
@@ -152,7 +152,8 @@ func (m *Map) Get(key string) (interface{}, error) {
 			}
 			return values, nil
 		default:
-			return nil, fmt.Errorf("key %q(part of %q) is not map[string]interface{} or []map[string]interface{}", k, key)
+			// 対象がオブジェクト(value)、かつフィールドが全て空(nil)の場合にここに到達する
+			return nil, nil
 		}
 	}
 


### PR DESCRIPTION
from https://github.com/sacloud/terraform-provider-sakuracloud/issues/750

mapconv.Mapで値を持たない構造体を処理する際にエラーにしないようにする。

===

mapconv.Mapでは以下のようなパターンではエラーを返していた。

```go
type A struct {
	Foo *B `structs:",omitempty"`
}

type B struct {
	Bar *C `structs:",omitempty"`
}

type C struct {
	Baz interface{} `structs:",omitempty"`
}

func TestMap_GetWithEmptyStruct(t *testing.T) {
	cases := []struct {
		in     interface{}
		expect interface{}
	}{
		{in: &A{Foo: &B{Bar: &C{Baz: "FooBarBaz"}}}, expect: "FooBarBaz"},
		{in: &A{Foo: &B{Bar: &C{}}}, expect: nil},
		{in: &A{Foo: &B{}}, expect: nil},
	}
	for _, tc := range cases {
		m := Map(structs.Map(tc.in))
		got, err := m.Get("Foo.Bar.Baz")// 2つ目以降のパターンだとここでエラーが返る
		if err != nil {
			t.Fatal(err) 
		}
		if got != tc.expect {
			t.Fatalf("got unexpected value: expected: %v actual:%v", tc.expect, got)
		}
	}
}
```

これは、mapconv.Mapでは対象のネストしたフィールドがmap[string]interface{}、[]interface{}、または[]map[string]interface{}であることを期待しており、これ以外の型となっていた場合にエラーとしていることが原因。

https://github.com/sacloud/libsacloud/blob/145eee7d3765704ba5bc463d73cc79ac9f26ae28/v2/pkg/mapconv/map.go#L110-L156

しかし、https://github.com/sacloud/terraform-provider-sakuracloud/issues/750#issuecomment-670407980 のようなケースでは上記のエラーパターンに引っかかってしまう。(対象のネストしたフィールドがinterface{}となる)

このためこのPRでエラーとしないように修正した。

