### PR TITLE
Set sacloud.DefaultDBStatusPollingInterval when running unit tests

### DIFF
--- a/v2/sacloud/testutil/util.go
+++ b/v2/sacloud/testutil/util.go
@@ -77,6 +77,7 @@ func SingletonAPICaller() *sacloud.Client {
 	accTestOnce.Do(func() {
 		if !IsAccTest() {
 			sacloud.DefaultStatePollingInterval = 100 * time.Millisecond
+			sacloud.DefaultDBStatusPollingInterval = 10 * time.Millisecond
 			fake.SwitchFactoryFuncToFake()
 			os.Setenv("SAKURACLOUD_ACCESS_TOKEN", "dummy")
 			os.Setenv("SAKURACLOUD_ACCESS_TOKEN_SECRET", "dummy")


### PR DESCRIPTION
単体テスト実行時にポーリング間隔(DBアプライアンスのステータス監視用)を短く設定しテスト時間を短縮する。
