### PR TITLE
Fix: parameter conversion when creating a LoadBalancer

### DIFF
--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -702,6 +702,10 @@ func (f *fieldsDef) LoadBalancerVIPServers() *dsl.FieldDesc {
 				f.LoadBalancerServerHealthCheck(),
 			},
 		},
+		Tags: &dsl.FieldTags{
+			MapConv:  "[]Servers,recursive",
+			Validate: "min=0,max=40",
+		},
 	}
 }
 

--- a/v2/sacloud/test/load_balancer_op_test.go
+++ b/v2/sacloud/test/load_balancer_op_test.go
@@ -358,6 +358,7 @@ var (
 			{
 				VirtualIPAddress: "192.168.0.111",
 				Port:             80,
+				Servers:          sacloud.LoadBalancerServers{},
 			},
 		},
 	}
@@ -375,21 +376,24 @@ var (
 				VirtualIPAddress: "192.168.0.111",
 				Port:             80,
 				DelayLoop:        10, // default value
+				Servers:          []*sacloud.LoadBalancerServer{},
 			},
 		},
 	}
 	updateLoadBalancerToMin2Param = &sacloud.LoadBalancerUpdateRequest{
-		Name: testutil.ResourceName("lb-to-min2"),
+		Name:               testutil.ResourceName("lb-to-min2"),
+		VirtualIPAddresses: sacloud.LoadBalancerVirtualIPAddresses{},
 	}
 	updateLoadBalancerToMin2Expected = &sacloud.LoadBalancer{
-		Name:           updateLoadBalancerToMin2Param.Name,
-		Availability:   types.Availabilities.Available,
-		PlanID:         createLoadBalancerParam.PlanID,
-		InstanceStatus: types.ServerInstanceStatuses.Up,
-		DefaultRoute:   createLoadBalancerParam.DefaultRoute,
-		NetworkMaskLen: createLoadBalancerParam.NetworkMaskLen,
-		IPAddresses:    createLoadBalancerParam.IPAddresses,
-		VRID:           createLoadBalancerParam.VRID,
+		Name:               updateLoadBalancerToMin2Param.Name,
+		Availability:       types.Availabilities.Available,
+		PlanID:             createLoadBalancerParam.PlanID,
+		InstanceStatus:     types.ServerInstanceStatuses.Up,
+		DefaultRoute:       createLoadBalancerParam.DefaultRoute,
+		NetworkMaskLen:     createLoadBalancerParam.NetworkMaskLen,
+		IPAddresses:        createLoadBalancerParam.IPAddresses,
+		VRID:               createLoadBalancerParam.VRID,
+		VirtualIPAddresses: sacloud.LoadBalancerVirtualIPAddresses{},
 	}
 )
 

--- a/v2/sacloud/transformer_test.go
+++ b/v2/sacloud/transformer_test.go
@@ -1,0 +1,52 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sacloud
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+func TestTransformer_transformLoadBalancerCreateArgs(t *testing.T) {
+	op := &LoadBalancerOp{}
+
+	ret, err := op.transformCreateArgs(&LoadBalancerCreateRequest{
+		VirtualIPAddresses: LoadBalancerVirtualIPAddresses{
+			{
+				VirtualIPAddress: "192.168.0.1",
+				Servers: LoadBalancerServers{
+					{
+						IPAddress: "192.168.0.11",
+						Port:      80,
+						Enabled:   true,
+						HealthCheck: &LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+							Path:         "/",
+							ResponseCode: 200,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := ret.Appliance.Settings.LoadBalancer[0].Servers[0].HealthCheck.Status
+	if v != types.StringNumber(200) {
+		t.Fatal("unexpected value:", v)
+	}
+}

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -12869,12 +12869,12 @@ func (o *LoadBalancer) SetInterfaces(v []*InterfaceView) {
 
 // LoadBalancerVirtualIPAddress represents API parameter/response structure
 type LoadBalancerVirtualIPAddress struct {
-	VirtualIPAddress string             `validate:"ipv4"`
-	Port             types.StringNumber `validate:"min=1,max=65535"`
-	DelayLoop        types.StringNumber `mapconv:",default=10" validate:"min=0,max=10000"`
-	SorryServer      string             `validate:"omitempty,ipv4"`
-	Description      string             `validate:"min=0,max=512"`
-	Servers          LoadBalancerServers
+	VirtualIPAddress string              `validate:"ipv4"`
+	Port             types.StringNumber  `validate:"min=1,max=65535"`
+	DelayLoop        types.StringNumber  `mapconv:",default=10" validate:"min=0,max=10000"`
+	SorryServer      string              `validate:"omitempty,ipv4"`
+	Description      string              `validate:"min=0,max=512"`
+	Servers          LoadBalancerServers `mapconv:"[]Servers,recursive" validate:"min=0,max=40"`
 }
 
 // Validate validates by field tags
@@ -12885,12 +12885,12 @@ func (o *LoadBalancerVirtualIPAddress) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LoadBalancerVirtualIPAddress) setDefaults() interface{} {
 	return &struct {
-		VirtualIPAddress string             `validate:"ipv4"`
-		Port             types.StringNumber `validate:"min=1,max=65535"`
-		DelayLoop        types.StringNumber `mapconv:",default=10" validate:"min=0,max=10000"`
-		SorryServer      string             `validate:"omitempty,ipv4"`
-		Description      string             `validate:"min=0,max=512"`
-		Servers          LoadBalancerServers
+		VirtualIPAddress string              `validate:"ipv4"`
+		Port             types.StringNumber  `validate:"min=1,max=65535"`
+		DelayLoop        types.StringNumber  `mapconv:",default=10" validate:"min=0,max=10000"`
+		SorryServer      string              `validate:"omitempty,ipv4"`
+		Description      string              `validate:"min=0,max=512"`
+		Servers          LoadBalancerServers `mapconv:"[]Servers,recursive" validate:"min=0,max=40"`
 	}{
 		VirtualIPAddress: o.GetVirtualIPAddress(),
 		Port:             o.GetPort(),


### PR DESCRIPTION
closes #608 
related: #594 

ロードバランサ作成時のパラメータ変換処理誤りを修正