### PR TITLE
Added IMEI field to SIMInfo

### DIFF
--- a/v2/helper/builder/sim/builder.go
+++ b/v2/helper/builder/sim/builder.go
@@ -132,13 +132,13 @@ func (b *Builder) Update(ctx context.Context, id types.ID) (*sacloud.SIM, error)
 	}
 
 	// Unlock -> ロックされている、かつIMEIが空か前と変わっている場合
-	if sim.Info.IMEILock && (b.IMEI == "" || b.IMEI != sim.Info.ConnectedIMEI) {
+	if sim.Info.IMEILock && (b.IMEI == "" || b.IMEI != sim.Info.IMEI) {
 		if err := b.Client.SIM.IMEIUnlock(ctx, sim.ID); err != nil {
 			return nil, err
 		}
 	}
 	// Lock -> IMEIが変わっている場合は上でアンロックされた状態になっているはず
-	if b.IMEI != "" && b.IMEI != sim.Info.ConnectedIMEI {
+	if b.IMEI != "" && b.IMEI != sim.Info.IMEI {
 		if err := b.Client.SIM.IMEILock(ctx, sim.ID, &sacloud.SIMIMEILockRequest{IMEI: b.IMEI}); err != nil {
 			return nil, err
 		}

--- a/v2/internal/define/models.go
+++ b/v2/internal/define/models.go
@@ -1274,6 +1274,7 @@ func (m *modelsDef) simInfoFields() []*dsl.FieldDesc {
 	return []*dsl.FieldDesc{
 		fields.Def("ICCID", meta.TypeString),
 		fields.Def("IMSI", meta.TypeStringSlice),
+		fields.Def("IMEI", meta.TypeString),
 		fields.Def("IP", meta.TypeString),
 		fields.Def("SessionStatus", meta.TypeString),
 		fields.Def("IMEILock", meta.TypeFlag),

--- a/v2/sacloud/fake/ops_sim.go
+++ b/v2/sacloud/fake/ops_sim.go
@@ -165,7 +165,7 @@ func (o *SIMOp) IMEILock(ctx context.Context, id types.ID, param *sacloud.SIMIME
 		return errors.New("SIM[%d] is already locked with IMEI")
 	}
 	value.Info.IMEILock = true
-	value.Info.ConnectedIMEI = param.IMEI
+	value.Info.IMEI = param.IMEI
 	putSIM(sacloud.APIDefaultZone, value)
 	return nil
 }
@@ -180,7 +180,7 @@ func (o *SIMOp) IMEIUnlock(ctx context.Context, id types.ID) error {
 		return errors.New("SIM[%d] is not locked with IMEI")
 	}
 	value.Info.IMEILock = false
-	value.Info.ConnectedIMEI = ""
+	value.Info.IMEI = ""
 	putSIM(sacloud.APIDefaultZone, value)
 	return nil
 }

--- a/v2/sacloud/naked/sim.go
+++ b/v2/sacloud/naked/sim.go
@@ -48,6 +48,7 @@ type SIMStatus struct {
 type SIMInfo struct {
 	ICCID                      string           `json:"iccid,omitempty" yaml:"iccid,omitempty" structs:",omitempty"`
 	IMSI                       []string         `json:"imsi,omitempty" yaml:"imsi,omitempty" structs:",omitempty"`
+	IMEI                       string           `json:"imei,omitempty" yaml:"imei,omitempty" structs:",omitempty"`
 	IP                         string           `json:"ip,omitempty" yaml:"ip,omitempty" structs:",omitempty"`
 	SessionStatus              string           `json:"session_status,omitempty" yaml:"session_status,omitempty" structs:",omitempty"`
 	IMEILock                   bool             `json:"imei_lock" yaml:"imei_lock"`

--- a/v2/sacloud/test/sim_op_test.go
+++ b/v2/sacloud/test/sim_op_test.go
@@ -111,6 +111,7 @@ func TestSIMOpCRUD(t *testing.T) {
 					simInfo := v.(*sacloud.SIMInfo)
 					return testutil.DoAsserts(
 						testutil.AssertTrueFunc(t, simInfo.IMEILock, "SIMInfo.IMEILock"),
+						testutil.AssertEqualFunc(t, "123456789012345", simInfo.IMEI, "SIMInfo.IMEI"),
 					)
 				},
 				SkipExtractID: true,
@@ -128,6 +129,7 @@ func TestSIMOpCRUD(t *testing.T) {
 					simInfo := v.(*sacloud.SIMInfo)
 					return testutil.DoAsserts(
 						testutil.AssertFalseFunc(t, simInfo.IMEILock, "SIMInfo.IMEILock"),
+						testutil.AssertEqualFunc(t, "", simInfo.IMEI, "SIMInfo.IMEI"),
 					)
 				},
 				SkipExtractID: true,

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -15849,6 +15849,7 @@ func (o *MobileGatewaySIMRouteParam) SetPrefix(v string) {
 type MobileGatewaySIMInfo struct {
 	ICCID                      string
 	IMSI                       []string
+	IMEI                       string
 	IP                         string
 	SessionStatus              string
 	IMEILock                   bool
@@ -15873,6 +15874,7 @@ func (o *MobileGatewaySIMInfo) setDefaults() interface{} {
 	return &struct {
 		ICCID                      string
 		IMSI                       []string
+		IMEI                       string
 		IP                         string
 		SessionStatus              string
 		IMEILock                   bool
@@ -15888,6 +15890,7 @@ func (o *MobileGatewaySIMInfo) setDefaults() interface{} {
 	}{
 		ICCID:                      o.GetICCID(),
 		IMSI:                       o.GetIMSI(),
+		IMEI:                       o.GetIMEI(),
 		IP:                         o.GetIP(),
 		SessionStatus:              o.GetSessionStatus(),
 		IMEILock:                   o.GetIMEILock(),
@@ -15921,6 +15924,16 @@ func (o *MobileGatewaySIMInfo) GetIMSI() []string {
 // SetIMSI sets value to IMSI
 func (o *MobileGatewaySIMInfo) SetIMSI(v []string) {
 	o.IMSI = v
+}
+
+// GetIMEI returns value of IMEI
+func (o *MobileGatewaySIMInfo) GetIMEI() string {
+	return o.IMEI
+}
+
+// SetIMEI sets value to IMEI
+func (o *MobileGatewaySIMInfo) SetIMEI(v string) {
+	o.IMEI = v
 }
 
 // GetIP returns value of IP
@@ -22542,6 +22555,7 @@ func (o *SIM) SetModifiedAt(v time.Time) {
 type SIMInfo struct {
 	ICCID                      string
 	IMSI                       []string
+	IMEI                       string
 	IP                         string
 	SessionStatus              string
 	IMEILock                   bool
@@ -22566,6 +22580,7 @@ func (o *SIMInfo) setDefaults() interface{} {
 	return &struct {
 		ICCID                      string
 		IMSI                       []string
+		IMEI                       string
 		IP                         string
 		SessionStatus              string
 		IMEILock                   bool
@@ -22581,6 +22596,7 @@ func (o *SIMInfo) setDefaults() interface{} {
 	}{
 		ICCID:                      o.GetICCID(),
 		IMSI:                       o.GetIMSI(),
+		IMEI:                       o.GetIMEI(),
 		IP:                         o.GetIP(),
 		SessionStatus:              o.GetSessionStatus(),
 		IMEILock:                   o.GetIMEILock(),
@@ -22614,6 +22630,16 @@ func (o *SIMInfo) GetIMSI() []string {
 // SetIMSI sets value to IMSI
 func (o *SIMInfo) SetIMSI(v []string) {
 	o.IMSI = v
+}
+
+// GetIMEI returns value of IMEI
+func (o *SIMInfo) GetIMEI() string {
+	return o.IMEI
+}
+
+// SetIMEI sets value to IMEI
+func (o *SIMInfo) SetIMEI(v string) {
+	o.IMEI = v
 }
 
 // GetIP returns value of IP


### PR DESCRIPTION
follow up #616 

SIMの詳細情報に`IMEI`フィールドを追加する。
builderでのIMEI変更検知にも`ConnectedIMEI`の代わりに`IMEI`を利用する。