### PR TITLE
Added helper func: ConfigValue.EnableXXXTrace()

### DIFF
--- a/v2/sacloud/profile/profile.go
+++ b/v2/sacloud/profile/profile.go
@@ -32,6 +32,12 @@ const (
 	DirectoryNameEnvOld = "USACLOUD_PROFILE_DIR"
 	// DefaultProfileName デフォルトのプロファイル名
 	DefaultProfileName = "default"
+
+	// EnableAPITraceWord TraceModeに設定する、APIトレースを有効化するためのキーワード
+	EnableAPITraceWord = "api"
+
+	// EnableHTTPTraceWord TraceModeに設定する、HTTPトレースを有効化するためのキーワード
+	EnableHTTPTraceWord = "http"
 )
 
 var (
@@ -155,6 +161,36 @@ type ConfigValue struct {
 	FakeMode bool `json:",omitempty"`
 	// FakeStorePath フェイクモードでのファイルストアパス
 	FakeStorePath string `json:",omitempty"`
+}
+
+func (o *ConfigValue) traceModeValue() string {
+	return strings.ToLower(strings.TrimSpace(o.TraceMode))
+}
+
+func (o *ConfigValue) EnableHTTPTrace() bool {
+	traceMode := o.traceModeValue()
+	if traceMode == "" {
+		return false
+	}
+
+	// TraceModeが"api"の場合はfalseにする(TraceMode=1などの場合はAPI/HTTP両方が有効になる)
+	if traceMode == EnableAPITraceWord {
+		return false
+	}
+	return true
+}
+
+func (o *ConfigValue) EnableAPITrace() bool {
+	traceMode := o.traceModeValue()
+	if traceMode == "" {
+		return false
+	}
+
+	// TraceModeが"http"の場合はfalseにする(TraceMode=1などの場合はAPI/HTTP両方が有効になる)
+	if traceMode == EnableHTTPTraceWord {
+		return false
+	}
+	return true
 }
 
 // Save プロファイルコンフィグを保存

--- a/v2/sacloud/profile/profile_test.go
+++ b/v2/sacloud/profile/profile_test.go
@@ -685,3 +685,62 @@ func TestList(t *testing.T) {
 		require.EqualValues(t, "test2", profiles[2])
 	})
 }
+
+func TestConfigValue_TraceMode(t *testing.T) {
+	cases := []struct {
+		in                *ConfigValue
+		expectHTTPEnabled bool
+		expectAPIEnabled  bool
+	}{
+		{
+			in:                &ConfigValue{},
+			expectHTTPEnabled: false,
+			expectAPIEnabled:  false,
+		},
+		{
+			in:                &ConfigValue{TraceMode: " "},
+			expectHTTPEnabled: false,
+			expectAPIEnabled:  false,
+		},
+		{
+			in:                &ConfigValue{TraceMode: "api"},
+			expectHTTPEnabled: false,
+			expectAPIEnabled:  true,
+		},
+		{
+			in:                &ConfigValue{TraceMode: "API"},
+			expectHTTPEnabled: false,
+			expectAPIEnabled:  true,
+		},
+		{
+			in:                &ConfigValue{TraceMode: "aPi"},
+			expectHTTPEnabled: false,
+			expectAPIEnabled:  true,
+		},
+		{
+			in:                &ConfigValue{TraceMode: "http"},
+			expectHTTPEnabled: true,
+			expectAPIEnabled:  false,
+		},
+		{
+			in:                &ConfigValue{TraceMode: "HTTP"},
+			expectHTTPEnabled: true,
+			expectAPIEnabled:  false,
+		},
+		{
+			in:                &ConfigValue{TraceMode: "HtTp"},
+			expectHTTPEnabled: true,
+			expectAPIEnabled:  false,
+		},
+		{
+			in:                &ConfigValue{TraceMode: "1"},
+			expectHTTPEnabled: true,
+			expectAPIEnabled:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		require.Equal(t, tc.expectHTTPEnabled, tc.in.EnableHTTPTrace(), tc.in)
+		require.Equal(t, tc.expectAPIEnabled, tc.in.EnableAPITrace(), tc.in)
+	}
+}


### PR DESCRIPTION
closes #620 

usacloud v1から移設。TraceModeの内容からAPIトレース/HTTPトレースの有効化指定を判定する。