### PR TITLE
Added DefaultZone field to profile and helper

### DIFF
--- a/v2/helper/api/caller.go
+++ b/v2/helper/api/caller.go
@@ -35,6 +35,7 @@ type CallerOptions struct {
 	AccessTokenSecret string
 
 	APIRootURL     string
+	DefaultZone    string
 	AcceptLanguage string
 
 	HTTPClient *http.Client
@@ -141,6 +142,10 @@ func newCaller(opts *CallerOptions) sacloud.APICaller {
 		setup.DefaultPollingInterval = defaultInterval
 		// update default polling intervals: libsacloud/utils/builder
 		builder.DefaultNICUpdateWaitDuration = defaultInterval
+	}
+
+	if opts.DefaultZone != "" {
+		sacloud.APIDefaultZone = opts.DefaultZone
 	}
 
 	if opts.APIRootURL != "" {

--- a/v2/sacloud/profile/profile.go
+++ b/v2/sacloud/profile/profile.go
@@ -155,6 +155,9 @@ type ConfigValue struct {
 	// APIRootURL APIのルートURL
 	APIRootURL string `json:",omitempty"`
 
+	// DefaultZone グローバルリソースAPIを呼ぶ際に指定するゾーン
+	DefaultZone string `json:",omitempty"`
+
 	// TraceMode トレースモード
 	TraceMode string `json:",omitempty"`
 	// FakeMode フェイクモード有効化


### PR DESCRIPTION
closes #597 

https://github.com/sacloud/terraform-provider-sakuracloud/pull/769 の移設。

- プロファイル値にDefaultZoneを保持する
- helper/apiでDefaultZoneをパラメータとして受け取り可能に