### PR TITLE
mapconv: support for value filters

### DIFF
--- a/v2/pkg/mapconv/mapconv.go
+++ b/v2/pkg/mapconv/mapconv.go
@@ -16,6 +16,7 @@ package mapconv
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 
@@ -23,17 +24,23 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
-const defaultMapConvTag = "mapconv"
+// DefaultMapConvTag デフォルトのmapconvタグ名
+const DefaultMapConvTag = "mapconv"
 
 // DecoderConfig mapconvでの変換の設定
 type DecoderConfig struct {
-	TagName string
+	TagName     string
+	FilterFuncs map[string]FilterFunc
 }
+
+// FilterFunc mapconvでの変換時に適用するフィルタ
+type FilterFunc func(v interface{}) (interface{}, error)
 
 // TagInfo mapconvタグの情報
 type TagInfo struct {
 	Ignore       bool
 	SourceFields []string
+	Filters      []string
 	DefaultValue interface{}
 	OmitEmpty    bool
 	Recursive    bool
@@ -74,6 +81,18 @@ func (d *Decoder) ConvertTo(source interface{}, dest interface{}) error {
 				if tags.DefaultValue != nil {
 					value = tags.DefaultValue
 				}
+			}
+
+			for _, filter := range tags.Filters {
+				filterFunc, ok := d.Config.FilterFuncs[filter]
+				if !ok {
+					return fmt.Errorf("filter %s not exists", filter)
+				}
+				filtered, err := filterFunc(value)
+				if err != nil {
+					return fmt.Errorf("failed to apply the filter: %s", err)
+				}
+				value = filtered
 			}
 
 			if tags.Squash {
@@ -162,6 +181,18 @@ func (d *Decoder) ConvertFrom(source interface{}, dest interface{}) error {
 				continue
 			}
 
+			for _, filter := range tags.Filters {
+				filterFunc, ok := d.Config.FilterFuncs[filter]
+				if !ok {
+					return fmt.Errorf("filter %s not exists", filter)
+				}
+				filtered, err := filterFunc(value)
+				if err != nil {
+					return fmt.Errorf("failed to apply the filter: %s", err)
+				}
+				value = filtered
+			}
+
 			if tags.Recursive {
 				t := reflect.TypeOf(f.Value())
 				if t.Kind() == reflect.Slice {
@@ -210,23 +241,24 @@ func (d *Decoder) ConvertFrom(source interface{}, dest interface{}) error {
 
 // ConvertTo converts struct which input by mapconv to plain models
 func ConvertTo(source interface{}, dest interface{}) error {
-	decoder := &Decoder{Config: &DecoderConfig{TagName: defaultMapConvTag}}
+	decoder := &Decoder{Config: &DecoderConfig{TagName: DefaultMapConvTag}}
 	return decoder.ConvertTo(source, dest)
 }
 
 // ConvertFrom converts struct which input by mapconv from plain models
 func ConvertFrom(source interface{}, dest interface{}) error {
-	decoder := &Decoder{Config: &DecoderConfig{TagName: defaultMapConvTag}}
+	decoder := &Decoder{Config: &DecoderConfig{TagName: DefaultMapConvTag}}
 	return decoder.ConvertFrom(source, dest)
 }
 
 // ParseMapConvTag mapconvタグを文字列で受け取りパースしてTagInfoを返す
 func (d *Decoder) ParseMapConvTag(tagBody string) TagInfo {
 	tokens := strings.Split(tagBody, ",")
-	key := tokens[0]
+	key := strings.TrimSpace(tokens[0])
 
 	keys := strings.Split(key, "/")
 	var defaultValue interface{}
+	var filters []string
 	var ignore, omitEmpty, recursive, squash, isSlice bool
 
 	for _, k := range keys {
@@ -244,6 +276,8 @@ func (d *Decoder) ParseMapConvTag(tagBody string) TagInfo {
 			continue
 		}
 
+		token = strings.TrimSpace(token)
+
 		switch {
 		case strings.HasPrefix(token, "omitempty"):
 			omitEmpty = true
@@ -251,6 +285,11 @@ func (d *Decoder) ParseMapConvTag(tagBody string) TagInfo {
 			recursive = true
 		case strings.HasPrefix(token, "squash"):
 			squash = true
+		case strings.HasPrefix(token, "filters"):
+			keyValue := strings.Split(token, "=")
+			if len(keyValue) > 1 {
+				filters = strings.Split(strings.Join(keyValue[1:], ""), " ")
+			}
 		case strings.HasPrefix(token, "default"):
 			keyValue := strings.Split(token, "=")
 			if len(keyValue) > 1 {
@@ -266,5 +305,6 @@ func (d *Decoder) ParseMapConvTag(tagBody string) TagInfo {
 		Recursive:    recursive,
 		Squash:       squash,
 		IsSlice:      isSlice,
+		Filters:      filters,
 	}
 }


### PR DESCRIPTION
closes #625 
mapconvで値の変換を行う`filters`をサポートする。

 ### 利用例

```go
// mapconv.Decoderにフィルタを登録しておく
var decoder = &Decoder{Config: &DecoderConfig{
	TagName: DefaultMapConvTag,
	FilterFuncs: map[string]FilterFunc{
		"toUpper":  func(v interface{}) (interface{}, error) {
			return strings.ToUpper(v.(string)), nil
		},
	},
}}

type Source struct {
	Field string `mapconv:",filters=toUpper"` // toUpperフィルタを適用する
}

type Dest struct {
	Field string
}

func Example() {
	src := &Source{ Field: "example"}
	dest := &Dest{}

	if err := decoder.ConvertTo(src, dest); err != nil {
		panic(err)
	}

	fmt.Println(dest.Field)
	// Output:
	// EXAMPLE
}

```

- mapconvの`ConvertTo`/`ConvertFrom`両方で利用可能。
- `filters`は空白区切りで複数指定可能。この場合、タグで指定した順にフィルタが適用される。
例: `mapconv:",filters=foo bar baz"` // fooフィルタ + barフィルタ + bazフィルタ
- 指定の名前のフィルタが見つからない場合はエラーとなる
- フィルタがエラーを返した場合は`ConvertTo`/ConvertFrom`とも処理を中断し即時エラーを返す