### PR TITLE
Fix mapconv - use method instead of func

### DIFF
--- a/v2/helper/service/disk/create_request_test.go
+++ b/v2/helper/service/disk/create_request_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package disk
 
 import (

--- a/v2/pkg/mapconv/decoder_test.go
+++ b/v2/pkg/mapconv/decoder_test.go
@@ -1,0 +1,61 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mapconv
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapConvDecoder_inheritsDecoderConfig(t *testing.T) {
+	in := &Nest1{
+		Nest2: &Nest2{Field: "foo"},
+	}
+	expect := &Dest{
+		Field: "FOO",
+	}
+
+	decoder := &Decoder{
+		Config: &DecoderConfig{
+			TagName: DefaultMapConvTag,
+			FilterFuncs: map[string]FilterFunc{
+				"test": func(v interface{}) (interface{}, error) {
+					s := v.(string)
+					return strings.ToUpper(s), nil
+				},
+			},
+		},
+	}
+
+	out := &Dest{}
+	if err := decoder.ConvertTo(in, out); err != nil {
+		t.Fatal(err)
+	}
+	require.EqualValues(t, expect, out)
+}
+
+type Nest1 struct {
+	Nest2 *Nest2 `mapconv:",squash"`
+}
+
+type Nest2 struct {
+	Field string `mapconv:",filters=test"`
+}
+
+type Dest struct {
+	Field string
+}

--- a/v2/pkg/mapconv/mapconv.go
+++ b/v2/pkg/mapconv/mapconv.go
@@ -96,12 +96,12 @@ func (d *Decoder) ConvertTo(source interface{}, dest interface{}) error {
 			}
 
 			if tags.Squash {
-				d := Map(make(map[string]interface{}))
-				err := ConvertTo(value, &d)
+				dest := Map(make(map[string]interface{}))
+				err := d.ConvertTo(value, &dest)
 				if err != nil {
 					return err
 				}
-				for k, v := range d {
+				for k, v := range dest {
 					destMap.Set(k, v)
 				}
 				continue
@@ -113,7 +113,7 @@ func (d *Decoder) ConvertTo(source interface{}, dest interface{}) error {
 				for _, v := range values {
 					if structs.IsStruct(v) {
 						destMap := Map(make(map[string]interface{}))
-						if err := ConvertTo(v, &destMap); err != nil {
+						if err := d.ConvertTo(v, &destMap); err != nil {
 							return err
 						}
 						dest = append(dest, destMap)
@@ -208,11 +208,11 @@ func (d *Decoder) ConvertFrom(source interface{}, dest interface{}) error {
 						dest = append(dest, v)
 						continue
 					}
-					d := reflect.New(t).Interface()
-					if err := ConvertFrom(v, d); err != nil {
+					dt := reflect.New(t).Interface()
+					if err := d.ConvertFrom(v, dt); err != nil {
 						return err
 					}
-					dest = append(dest, d)
+					dest = append(dest, dt)
 				}
 
 				if dest != nil {


### PR DESCRIPTION
fixes #632 

mapconv.Decoderから再帰処理を行う際にfuncを呼んできたのをDecoderのmethodコールに修正する。