### PR TITLE
Fixed incorrect definition of ProxyLB certificate setting request mapping

### DIFF
--- a/v2/internal/define/proxylb.go
+++ b/v2/internal/define/proxylb.go
@@ -341,6 +341,9 @@ var (
 				fields.Def("PrivateKey", meta.TypeString),
 			},
 		},
+		Tags: &dsl.FieldTags{
+			MapConv: "PrimaryCert",
+		},
 	}
 
 	proxyLBAdditionalCerts = &dsl.FieldDesc{

--- a/v2/sacloud/transformer_test.go
+++ b/v2/sacloud/transformer_test.go
@@ -147,3 +147,36 @@ const simJSONWithNumber = `
   "is_ok": true
 }
 `
+
+func TestTransformer_transformSetCertificatesArgs(t *testing.T) {
+	op := &ProxyLBOp{}
+
+	cert := &ProxyLBPrimaryCert{
+		ServerCertificate:       "aaa",
+		IntermediateCertificate: "bbb",
+		PrivateKey:              "ccc",
+	}
+
+	ret, err := op.transformSetCertificatesArgs(types.ID(1),
+		&ProxyLBSetCertificatesRequest{
+			PrimaryCerts:    cert,
+			AdditionalCerts: []*ProxyLBAdditionalCert{},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ret.ProxyLB.PrimaryCert == nil {
+		t.Fatal("ProxyLB.PrimaryCert is nil")
+	}
+	if ret.ProxyLB.PrimaryCert.ServerCertificate != cert.ServerCertificate {
+		t.Fatal("ProxyLB.PrimaryCert has unexpected value: ServerCertificate")
+	}
+	if ret.ProxyLB.PrimaryCert.IntermediateCertificate != cert.IntermediateCertificate {
+		t.Fatal("ProxyLB.PrimaryCert has unexpected value: IntermediateCertificate")
+	}
+	if ret.ProxyLB.PrimaryCert.PrivateKey != cert.PrivateKey {
+		t.Fatal("ProxyLB.PrimaryCert has unexpected value: PrivateKey")
+	}
+}

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -20092,7 +20092,7 @@ func (o *ProxyLBAdditionalCert) SetCertificateCommonName(v string) {
 
 // ProxyLBSetCertificatesRequest represents API parameter/response structure
 type ProxyLBSetCertificatesRequest struct {
-	PrimaryCerts    *ProxyLBPrimaryCert
+	PrimaryCerts    *ProxyLBPrimaryCert      `mapconv:"PrimaryCert"`
 	AdditionalCerts []*ProxyLBAdditionalCert `mapconv:"[]AdditionalCerts, recursive"`
 }
 
@@ -20104,7 +20104,7 @@ func (o *ProxyLBSetCertificatesRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ProxyLBSetCertificatesRequest) setDefaults() interface{} {
 	return &struct {
-		PrimaryCerts    *ProxyLBPrimaryCert
+		PrimaryCerts    *ProxyLBPrimaryCert      `mapconv:"PrimaryCert"`
 		AdditionalCerts []*ProxyLBAdditionalCert `mapconv:"[]AdditionalCerts, recursive"`
 	}{
 		PrimaryCerts:    o.GetPrimaryCerts(),


### PR DESCRIPTION
エンハンスドロードバランサの証明書設定において、libsacloudのパラメータからAPIリクエストに変換する部分に誤りがあったのを修正。

#### 修正前の定義
```go
type ProxyLBSetCertificatesRequest struct {
	PrimaryCerts    *ProxyLBPrimaryCert // mapconvタグがないためPrimaryCertsというフィールドに変換しようとする
	AdditionalCerts []*ProxyLBAdditionalCert `mapconv:"[]AdditionalCerts, recursive"`
}
```

#### 修正後の定義
```go
type ProxyLBSetCertificatesRequest struct {
	PrimaryCerts    *ProxyLBPrimaryCert      `mapconv:"PrimaryCert"`
	AdditionalCerts []*ProxyLBAdditionalCert `mapconv:"[]AdditionalCerts, recursive"`
}
```