### PR TITLE
Update definitions of GitHub Action to actions/checkout@v2 and actions/setup-go@v2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,18 +7,16 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
         with:
           go-version: 1.14
-
-      - name: Set up Go environemnt variables
-        run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
 
       - name: Setup tools
         run: | 
@@ -37,18 +35,16 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-18.04]
     steps:
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
         with:
           go-version: 1.14
-
-      - name: Set up Go environemnt variables
-        run: |
-          echo "::set-env name=GOPATH::$(go env GOPATH)"
-          echo "::add-path::$(go env GOPATH)/bin"
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
 
       - name: Setup tools
         run: | 


### PR DESCRIPTION
closes #641 

actions/setup-go@v2を利用することで`set-env`や`add-path`を回避する。