### PR TITLE
Set empty slice when additional certs is nil

### DIFF
--- a/v2/sacloud/naked/proxylb.go
+++ b/v2/sacloud/naked/proxylb.go
@@ -191,6 +191,16 @@ type ProxyLBCertificates struct {
 	AdditionalCerts ProxyLBAdditionalCerts `yaml:"additional_certs"`
 }
 
+// MarshalJSON nullの場合に空配列を出力するための実装
+func (s ProxyLBCertificates) MarshalJSON() ([]byte, error) {
+	if s.AdditionalCerts == nil {
+		s.AdditionalCerts = make([]*ProxyLBCertificate, 0)
+	}
+	type alias ProxyLBCertificates
+	tmp := alias(s)
+	return json.Marshal(&tmp)
+}
+
 // UnmarshalJSON UnmarshalJSON(AdditionalCertsが空の場合に空文字を返す問題への対応)
 func (p *ProxyLBAdditionalCerts) UnmarshalJSON(data []byte) error {
 	targetData := strings.Replace(strings.Replace(string(data), " ", "", -1), "\n", "", -1)

--- a/v2/sacloud/naked/proxylb_test.go
+++ b/v2/sacloud/naked/proxylb_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package naked
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestProxyLBCertificates_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		in     *ProxyLBCertificates
+		expect string
+	}{
+		{
+			in: &ProxyLBCertificates{
+				PrimaryCert: &ProxyLBCertificate{
+					ServerCertificate:       "aaa",
+					IntermediateCertificate: "bbb",
+					PrivateKey:              "ccc",
+				},
+			},
+			expect: `{"PrimaryCert":{"ServerCertificate":"aaa","IntermediateCertificate":"bbb","PrivateKey":"ccc"},"AdditionalCerts":[]}`,
+		},
+		{
+			in: &ProxyLBCertificates{
+				PrimaryCert: &ProxyLBCertificate{
+					ServerCertificate:       "aaa",
+					IntermediateCertificate: "bbb",
+					PrivateKey:              "ccc",
+				},
+				AdditionalCerts: ProxyLBAdditionalCerts{
+					{
+						ServerCertificate:       "aaa",
+						IntermediateCertificate: "bbb",
+						PrivateKey:              "ccc",
+					},
+				},
+			},
+			expect: `{"PrimaryCert":{"ServerCertificate":"aaa","IntermediateCertificate":"bbb","PrivateKey":"ccc"},"AdditionalCerts":[{"ServerCertificate":"aaa","IntermediateCertificate":"bbb","PrivateKey":"ccc"}]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		data, err := json.Marshal(tc.in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(data) != tc.expect {
+			t.Fatalf("got unexpected JSON: expected: %s got: %s", tc.expect, data)
+		}
+	}
+}


### PR DESCRIPTION
fixes #643 

`ProxyLBCertificates .AdditionalCerts`がnilの場合に`[]`をJSON出力するようにMarshalJSONを実装