### PR TITLE
Remove omitempty JSON tag from a monitor API response

### DIFF
--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -2319,7 +2319,6 @@ func (f *fieldsDef) MonitorTime() *dsl.FieldDesc {
 		Type: meta.TypeTime,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2330,7 +2329,6 @@ func (f *fieldsDef) MonitorCPUTime() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2341,7 +2339,6 @@ func (f *fieldsDef) MonitorDiskRead() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2352,7 +2349,6 @@ func (f *fieldsDef) MonitorDiskWrite() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2363,7 +2359,6 @@ func (f *fieldsDef) MonitorRouterIn() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2374,7 +2369,6 @@ func (f *fieldsDef) MonitorRouterOut() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2385,7 +2379,6 @@ func (f *fieldsDef) MonitorInterfaceSend() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2396,7 +2389,6 @@ func (f *fieldsDef) MonitorInterfaceReceive() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2407,7 +2399,6 @@ func (f *fieldsDef) MonitorFreeDiskSize() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2418,7 +2409,6 @@ func (f *fieldsDef) MonitorDatabaseTotalMemorySize() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2429,7 +2419,6 @@ func (f *fieldsDef) MonitorDatabaseUsedMemorySize() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2440,7 +2429,6 @@ func (f *fieldsDef) MonitorDatabaseTotalDisk1Size() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2451,7 +2439,6 @@ func (f *fieldsDef) MonitorDatabaseUsedDisk1Size() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2462,7 +2449,6 @@ func (f *fieldsDef) MonitorDatabaseTotalDisk2Size() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2473,7 +2459,6 @@ func (f *fieldsDef) MonitorDatabaseUsedDisk2Size() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2484,7 +2469,6 @@ func (f *fieldsDef) MonitorDatabaseBinlogUsedSizeKiB() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2495,7 +2479,6 @@ func (f *fieldsDef) MonitorDatabaseDelayTimeSec() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2506,7 +2489,6 @@ func (f *fieldsDef) MonitorResponseTimeSec() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2517,7 +2499,6 @@ func (f *fieldsDef) MonitorUplinkBPS() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2528,7 +2509,6 @@ func (f *fieldsDef) MonitorDownlinkBPS() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2539,7 +2519,6 @@ func (f *fieldsDef) MonitorActiveConnections() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2550,7 +2529,6 @@ func (f *fieldsDef) MonitorConnectionsPerSec() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2561,7 +2539,6 @@ func (f *fieldsDef) MonitorLocalRouterReceiveBytesPerSec() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }
@@ -2572,7 +2549,6 @@ func (f *fieldsDef) MonitorLocalRouterSendBytesPerSec() *dsl.FieldDesc {
 		Type: meta.TypeFloat64,
 		Tags: &dsl.FieldTags{
 			MapConv: ",omitempty",
-			JSON:    ",omitempty",
 		},
 	}
 }

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -5923,8 +5923,8 @@ func (o *CPUTimeActivity) SetValues(v []*MonitorCPUTimeValue) {
 
 // MonitorCPUTimeValue represents API parameter/response structure
 type MonitorCPUTimeValue struct {
-	Time    time.Time `json:",omitempty" mapconv:",omitempty"`
-	CPUTime float64   `json:",omitempty" mapconv:",omitempty"`
+	Time    time.Time `mapconv:",omitempty"`
+	CPUTime float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -5935,8 +5935,8 @@ func (o *MonitorCPUTimeValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorCPUTimeValue) setDefaults() interface{} {
 	return &struct {
-		Time    time.Time `json:",omitempty" mapconv:",omitempty"`
-		CPUTime float64   `json:",omitempty" mapconv:",omitempty"`
+		Time    time.Time `mapconv:",omitempty"`
+		CPUTime float64   `mapconv:",omitempty"`
 	}{
 		Time:    o.GetTime(),
 		CPUTime: o.GetCPUTime(),
@@ -6054,9 +6054,9 @@ func (o *DiskActivity) SetValues(v []*MonitorDiskValue) {
 
 // MonitorDiskValue represents API parameter/response structure
 type MonitorDiskValue struct {
-	Time  time.Time `json:",omitempty" mapconv:",omitempty"`
-	Read  float64   `json:",omitempty" mapconv:",omitempty"`
-	Write float64   `json:",omitempty" mapconv:",omitempty"`
+	Time  time.Time `mapconv:",omitempty"`
+	Read  float64   `mapconv:",omitempty"`
+	Write float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -6067,9 +6067,9 @@ func (o *MonitorDiskValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorDiskValue) setDefaults() interface{} {
 	return &struct {
-		Time  time.Time `json:",omitempty" mapconv:",omitempty"`
-		Read  float64   `json:",omitempty" mapconv:",omitempty"`
-		Write float64   `json:",omitempty" mapconv:",omitempty"`
+		Time  time.Time `mapconv:",omitempty"`
+		Read  float64   `mapconv:",omitempty"`
+		Write float64   `mapconv:",omitempty"`
 	}{
 		Time:  o.GetTime(),
 		Read:  o.GetRead(),
@@ -6146,9 +6146,9 @@ func (o *InterfaceActivity) SetValues(v []*MonitorInterfaceValue) {
 
 // MonitorInterfaceValue represents API parameter/response structure
 type MonitorInterfaceValue struct {
-	Time    time.Time `json:",omitempty" mapconv:",omitempty"`
-	Receive float64   `json:",omitempty" mapconv:",omitempty"`
-	Send    float64   `json:",omitempty" mapconv:",omitempty"`
+	Time    time.Time `mapconv:",omitempty"`
+	Receive float64   `mapconv:",omitempty"`
+	Send    float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -6159,9 +6159,9 @@ func (o *MonitorInterfaceValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorInterfaceValue) setDefaults() interface{} {
 	return &struct {
-		Time    time.Time `json:",omitempty" mapconv:",omitempty"`
-		Receive float64   `json:",omitempty" mapconv:",omitempty"`
-		Send    float64   `json:",omitempty" mapconv:",omitempty"`
+		Time    time.Time `mapconv:",omitempty"`
+		Receive float64   `mapconv:",omitempty"`
+		Send    float64   `mapconv:",omitempty"`
 	}{
 		Time:    o.GetTime(),
 		Receive: o.GetReceive(),
@@ -6238,15 +6238,15 @@ func (o *DatabaseActivity) SetValues(v []*MonitorDatabaseValue) {
 
 // MonitorDatabaseValue represents API parameter/response structure
 type MonitorDatabaseValue struct {
-	Time              time.Time `json:",omitempty" mapconv:",omitempty"`
-	TotalMemorySize   float64   `json:",omitempty" mapconv:",omitempty"`
-	UsedMemorySize    float64   `json:",omitempty" mapconv:",omitempty"`
-	TotalDisk1Size    float64   `json:",omitempty" mapconv:",omitempty"`
-	UsedDisk1Size     float64   `json:",omitempty" mapconv:",omitempty"`
-	TotalDisk2Size    float64   `json:",omitempty" mapconv:",omitempty"`
-	UsedDisk2Size     float64   `json:",omitempty" mapconv:",omitempty"`
-	BinlogUsedSizeKiB float64   `json:",omitempty" mapconv:",omitempty"`
-	DelayTimeSec      float64   `json:",omitempty" mapconv:",omitempty"`
+	Time              time.Time `mapconv:",omitempty"`
+	TotalMemorySize   float64   `mapconv:",omitempty"`
+	UsedMemorySize    float64   `mapconv:",omitempty"`
+	TotalDisk1Size    float64   `mapconv:",omitempty"`
+	UsedDisk1Size     float64   `mapconv:",omitempty"`
+	TotalDisk2Size    float64   `mapconv:",omitempty"`
+	UsedDisk2Size     float64   `mapconv:",omitempty"`
+	BinlogUsedSizeKiB float64   `mapconv:",omitempty"`
+	DelayTimeSec      float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -6257,15 +6257,15 @@ func (o *MonitorDatabaseValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorDatabaseValue) setDefaults() interface{} {
 	return &struct {
-		Time              time.Time `json:",omitempty" mapconv:",omitempty"`
-		TotalMemorySize   float64   `json:",omitempty" mapconv:",omitempty"`
-		UsedMemorySize    float64   `json:",omitempty" mapconv:",omitempty"`
-		TotalDisk1Size    float64   `json:",omitempty" mapconv:",omitempty"`
-		UsedDisk1Size     float64   `json:",omitempty" mapconv:",omitempty"`
-		TotalDisk2Size    float64   `json:",omitempty" mapconv:",omitempty"`
-		UsedDisk2Size     float64   `json:",omitempty" mapconv:",omitempty"`
-		BinlogUsedSizeKiB float64   `json:",omitempty" mapconv:",omitempty"`
-		DelayTimeSec      float64   `json:",omitempty" mapconv:",omitempty"`
+		Time              time.Time `mapconv:",omitempty"`
+		TotalMemorySize   float64   `mapconv:",omitempty"`
+		UsedMemorySize    float64   `mapconv:",omitempty"`
+		TotalDisk1Size    float64   `mapconv:",omitempty"`
+		UsedDisk1Size     float64   `mapconv:",omitempty"`
+		TotalDisk2Size    float64   `mapconv:",omitempty"`
+		UsedDisk2Size     float64   `mapconv:",omitempty"`
+		BinlogUsedSizeKiB float64   `mapconv:",omitempty"`
+		DelayTimeSec      float64   `mapconv:",omitempty"`
 	}{
 		Time:              o.GetTime(),
 		TotalMemorySize:   o.GetTotalMemorySize(),
@@ -11651,9 +11651,9 @@ func (o *RouterActivity) SetValues(v []*MonitorRouterValue) {
 
 // MonitorRouterValue represents API parameter/response structure
 type MonitorRouterValue struct {
-	Time time.Time `json:",omitempty" mapconv:",omitempty"`
-	In   float64   `json:",omitempty" mapconv:",omitempty"`
-	Out  float64   `json:",omitempty" mapconv:",omitempty"`
+	Time time.Time `mapconv:",omitempty"`
+	In   float64   `mapconv:",omitempty"`
+	Out  float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -11664,9 +11664,9 @@ func (o *MonitorRouterValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorRouterValue) setDefaults() interface{} {
 	return &struct {
-		Time time.Time `json:",omitempty" mapconv:",omitempty"`
-		In   float64   `json:",omitempty" mapconv:",omitempty"`
-		Out  float64   `json:",omitempty" mapconv:",omitempty"`
+		Time time.Time `mapconv:",omitempty"`
+		In   float64   `mapconv:",omitempty"`
+		Out  float64   `mapconv:",omitempty"`
 	}{
 		Time: o.GetTime(),
 		In:   o.GetIn(),
@@ -14559,9 +14559,9 @@ func (o *LocalRouterActivity) SetValues(v []*MonitorLocalRouterValue) {
 
 // MonitorLocalRouterValue represents API parameter/response structure
 type MonitorLocalRouterValue struct {
-	Time               time.Time `json:",omitempty" mapconv:",omitempty"`
-	ReceiveBytesPerSec float64   `json:",omitempty" mapconv:",omitempty"`
-	SendBytesPerSec    float64   `json:",omitempty" mapconv:",omitempty"`
+	Time               time.Time `mapconv:",omitempty"`
+	ReceiveBytesPerSec float64   `mapconv:",omitempty"`
+	SendBytesPerSec    float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -14572,9 +14572,9 @@ func (o *MonitorLocalRouterValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorLocalRouterValue) setDefaults() interface{} {
 	return &struct {
-		Time               time.Time `json:",omitempty" mapconv:",omitempty"`
-		ReceiveBytesPerSec float64   `json:",omitempty" mapconv:",omitempty"`
-		SendBytesPerSec    float64   `json:",omitempty" mapconv:",omitempty"`
+		Time               time.Time `mapconv:",omitempty"`
+		ReceiveBytesPerSec float64   `mapconv:",omitempty"`
+		SendBytesPerSec    float64   `mapconv:",omitempty"`
 	}{
 		Time:               o.GetTime(),
 		ReceiveBytesPerSec: o.GetReceiveBytesPerSec(),
@@ -17000,8 +17000,8 @@ func (o *FreeDiskSizeActivity) SetValues(v []*MonitorFreeDiskSizeValue) {
 
 // MonitorFreeDiskSizeValue represents API parameter/response structure
 type MonitorFreeDiskSizeValue struct {
-	Time         time.Time `json:",omitempty" mapconv:",omitempty"`
-	FreeDiskSize float64   `json:",omitempty" mapconv:",omitempty"`
+	Time         time.Time `mapconv:",omitempty"`
+	FreeDiskSize float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -17012,8 +17012,8 @@ func (o *MonitorFreeDiskSizeValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorFreeDiskSizeValue) setDefaults() interface{} {
 	return &struct {
-		Time         time.Time `json:",omitempty" mapconv:",omitempty"`
-		FreeDiskSize float64   `json:",omitempty" mapconv:",omitempty"`
+		Time         time.Time `mapconv:",omitempty"`
+		FreeDiskSize float64   `mapconv:",omitempty"`
 	}{
 		Time:         o.GetTime(),
 		FreeDiskSize: o.GetFreeDiskSize(),
@@ -20243,9 +20243,9 @@ func (o *ConnectionActivity) SetValues(v []*MonitorConnectionValue) {
 
 // MonitorConnectionValue represents API parameter/response structure
 type MonitorConnectionValue struct {
-	Time              time.Time `json:",omitempty" mapconv:",omitempty"`
-	ActiveConnections float64   `json:",omitempty" mapconv:",omitempty"`
-	ConnectionsPerSec float64   `json:",omitempty" mapconv:",omitempty"`
+	Time              time.Time `mapconv:",omitempty"`
+	ActiveConnections float64   `mapconv:",omitempty"`
+	ConnectionsPerSec float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -20256,9 +20256,9 @@ func (o *MonitorConnectionValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorConnectionValue) setDefaults() interface{} {
 	return &struct {
-		Time              time.Time `json:",omitempty" mapconv:",omitempty"`
-		ActiveConnections float64   `json:",omitempty" mapconv:",omitempty"`
-		ConnectionsPerSec float64   `json:",omitempty" mapconv:",omitempty"`
+		Time              time.Time `mapconv:",omitempty"`
+		ActiveConnections float64   `mapconv:",omitempty"`
+		ConnectionsPerSec float64   `mapconv:",omitempty"`
 	}{
 		Time:              o.GetTime(),
 		ActiveConnections: o.GetActiveConnections(),
@@ -23223,9 +23223,9 @@ func (o *LinkActivity) SetValues(v []*MonitorLinkValue) {
 
 // MonitorLinkValue represents API parameter/response structure
 type MonitorLinkValue struct {
-	Time        time.Time `json:",omitempty" mapconv:",omitempty"`
-	UplinkBPS   float64   `json:",omitempty" mapconv:",omitempty"`
-	DownlinkBPS float64   `json:",omitempty" mapconv:",omitempty"`
+	Time        time.Time `mapconv:",omitempty"`
+	UplinkBPS   float64   `mapconv:",omitempty"`
+	DownlinkBPS float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -23236,9 +23236,9 @@ func (o *MonitorLinkValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorLinkValue) setDefaults() interface{} {
 	return &struct {
-		Time        time.Time `json:",omitempty" mapconv:",omitempty"`
-		UplinkBPS   float64   `json:",omitempty" mapconv:",omitempty"`
-		DownlinkBPS float64   `json:",omitempty" mapconv:",omitempty"`
+		Time        time.Time `mapconv:",omitempty"`
+		UplinkBPS   float64   `mapconv:",omitempty"`
+		DownlinkBPS float64   `mapconv:",omitempty"`
 	}{
 		Time:        o.GetTime(),
 		UplinkBPS:   o.GetUplinkBPS(),
@@ -24379,8 +24379,8 @@ func (o *ResponseTimeSecActivity) SetValues(v []*MonitorResponseTimeSecValue) {
 
 // MonitorResponseTimeSecValue represents API parameter/response structure
 type MonitorResponseTimeSecValue struct {
-	Time            time.Time `json:",omitempty" mapconv:",omitempty"`
-	ResponseTimeSec float64   `json:",omitempty" mapconv:",omitempty"`
+	Time            time.Time `mapconv:",omitempty"`
+	ResponseTimeSec float64   `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -24391,8 +24391,8 @@ func (o *MonitorResponseTimeSecValue) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MonitorResponseTimeSecValue) setDefaults() interface{} {
 	return &struct {
-		Time            time.Time `json:",omitempty" mapconv:",omitempty"`
-		ResponseTimeSec float64   `json:",omitempty" mapconv:",omitempty"`
+		Time            time.Time `mapconv:",omitempty"`
+		ResponseTimeSec float64   `mapconv:",omitempty"`
 	}{
 		Time:            o.GetTime(),
 		ResponseTimeSec: o.GetResponseTimeSec(),


### PR DESCRIPTION
fixes #647 

クライアント側でJSON出力する際にフィールドの値が0の場合でも項目を出力するためにmonitor系APIのレスポンスのフィールドタグから`json:",omitempty"`を除外する。  
