### PR TITLE
Disk: Added ServerName field / Set Disk.Storage by fake driver

### DIFF
--- a/v2/internal/define/disk.go
+++ b/v2/internal/define/disk.go
@@ -279,6 +279,7 @@ var (
 			fields.BundleInfo(),
 			fields.Storage(),
 			fields.ServerID(),
+			fields.ServerName(),
 			fields.IconID(),
 			fields.CreatedAt(),
 			fields.ModifiedAt(),

--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -460,6 +460,16 @@ func (f *fieldsDef) ServerID() *dsl.FieldDesc {
 	}
 }
 
+func (f *fieldsDef) ServerName() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "ServerName",
+		Tags: &dsl.FieldTags{
+			MapConv: "Server.Name,omitempty",
+		},
+		Type: meta.TypeString,
+	}
+}
+
 func (f *fieldsDef) PrivateHostHostName() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "HostName",

--- a/v2/sacloud/fake/ops_disk.go
+++ b/v2/sacloud/fake/ops_disk.go
@@ -242,6 +242,7 @@ func (o *DiskOp) ConnectToServer(ctx context.Context, zone string, id types.ID, 
 	server.Disks = append(server.Disks, connectedDisk)
 	putServer(zone, server)
 	value.ServerID = serverID
+	value.ServerName = server.Name
 	putDisk(zone, value)
 
 	return nil
@@ -280,6 +281,7 @@ func (o *DiskOp) DisconnectFromServer(ctx context.Context, zone string, id types
 	server.Disks = disks
 	putServer(zone, server)
 	value.ServerID = types.ID(0)
+	value.ServerName = ""
 	putDisk(zone, value)
 
 	return nil

--- a/v2/sacloud/fake/ops_disk.go
+++ b/v2/sacloud/fake/ops_disk.go
@@ -46,6 +46,11 @@ func (o *DiskOp) Create(ctx context.Context, zone string, param *sacloud.DiskCre
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt, fillDiskPlan)
 
+	result.Storage = &sacloud.Storage{
+		ID:   types.ID(123456789012),
+		Name: "dummy",
+	}
+
 	if result.Connection == types.EDiskConnection("") {
 		result.Connection = types.DiskConnections.VirtIO
 	}

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -6723,6 +6723,7 @@ type Disk struct {
 	BundleInfo                *BundleInfo         `json:",omitempty" mapconv:",omitempty,recursive"`
 	Storage                   *Storage            `json:",omitempty" mapconv:",omitempty,recursive"`
 	ServerID                  types.ID            `mapconv:"Server.ID,omitempty"`
+	ServerName                string              `mapconv:"Server.Name,omitempty"`
 	IconID                    types.ID            `mapconv:"Icon.ID"`
 	CreatedAt                 time.Time
 	ModifiedAt                time.Time
@@ -6757,6 +6758,7 @@ func (o *Disk) setDefaults() interface{} {
 		BundleInfo                *BundleInfo         `json:",omitempty" mapconv:",omitempty,recursive"`
 		Storage                   *Storage            `json:",omitempty" mapconv:",omitempty,recursive"`
 		ServerID                  types.ID            `mapconv:"Server.ID,omitempty"`
+		ServerName                string              `mapconv:"Server.Name,omitempty"`
 		IconID                    types.ID            `mapconv:"Icon.ID"`
 		CreatedAt                 time.Time
 		ModifiedAt                time.Time
@@ -6782,6 +6784,7 @@ func (o *Disk) setDefaults() interface{} {
 		BundleInfo:                o.GetBundleInfo(),
 		Storage:                   o.GetStorage(),
 		ServerID:                  o.GetServerID(),
+		ServerName:                o.GetServerName(),
 		IconID:                    o.GetIconID(),
 		CreatedAt:                 o.GetCreatedAt(),
 		ModifiedAt:                o.GetModifiedAt(),
@@ -7051,6 +7054,16 @@ func (o *Disk) GetServerID() types.ID {
 // SetServerID sets value to ServerID
 func (o *Disk) SetServerID(v types.ID) {
 	o.ServerID = v
+}
+
+// GetServerName returns value of ServerName
+func (o *Disk) GetServerName() string {
+	return o.ServerName
+}
+
+// SetServerName sets value to ServerName
+func (o *Disk) SetServerName(v string) {
+	o.ServerName = v
 }
 
 // GetIconID returns value of IconID


### PR DESCRIPTION
fixes #646 , https://github.com/sacloud/usacloud/issues/609

- Diskに`ServerName`フィールドを追加
- fakeドライバーでDisk.Storageにダミーの値をセットする