### PR TITLE
Use url.PathEscape instead of url.URL#.String()

### DIFF
--- a/v2/sacloud/search/filter.go
+++ b/v2/sacloud/search/filter.go
@@ -81,6 +81,9 @@ func escapeFilterString(s string) string {
 	//HACK さくらのクラウド側でqueryStringでの+エスケープに対応していないため、
 	// %20にエスケープされるurl.Pathを利用する。
 	// http://qiita.com/shibukawa/items/c0730092371c0e243f62
-	u := &url.URL{Path: s}
-	return u.String()
+	//
+	// UPDATE: https://github.com/sacloud/libsacloud/issues/657#issuecomment-733467472
+	// (&url.URL{Path:s}).String()だと、MADAddressが"./00:00:5E:00:53:00"のようになってしまう。
+	// このためurl.PathEscapeを利用する。
+	return url.PathEscape(s)
 }

--- a/v2/sacloud/search/filter_test.go
+++ b/v2/sacloud/search/filter_test.go
@@ -64,6 +64,16 @@ func TestFilter(t *testing.T) {
 			},
 			expect: `{"field":"value1%20value2"}`,
 		},
+		// escape query string
+		{
+			conditions: []*inputKeyValue{
+				{
+					key:       Key("field"),
+					condition: AndEqual("00:00:5E:00:53:00", "00:00:5E:00:53:01"),
+				},
+			},
+			expect: `{"field":"00:00:5E:00:53:00%2000:00:5E:00:53:01"}`,
+		},
 		// multiple keys(AND)
 		{
 			conditions: []*inputKeyValue{


### PR DESCRIPTION
fixes #657 

MACAddressをエスケープする際に`00:00:5E:00:53:00`が`./00:00:5E:00:53:00`になってしまう問題を解決するために
`url.URL`の`String()`を利用していたのを`url.PathEscape()`を利用するように修正