### PR TITLE
Adjust service style

### DIFF
--- a/v2/helper/builder/sim/builder.go
+++ b/v2/helper/builder/sim/builder.go
@@ -44,9 +44,6 @@ func (b *Builder) Validate(ctx context.Context) error {
 	if b.ICCID == "" {
 		return fmt.Errorf("iccid is required")
 	}
-	if b.PassCode == "" {
-		return fmt.Errorf("iccid is required")
-	}
 	if len(b.Carrier) == 0 {
 		return fmt.Errorf("carrier is required")
 	}

--- a/v2/helper/service/containerregistry/apply_test.go
+++ b/v2/helper/service/containerregistry/apply_test.go
@@ -1,0 +1,77 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerregistry
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerRegistryService_convertApplyRequest(t *testing.T) {
+	caller := testutil.SingletonAPICaller()
+	name := testutil.ResourceName("container-registry-service")
+
+	cases := []struct {
+		in     *ApplyRequest
+		expect *Builder
+	}{
+		{
+			in: &ApplyRequest{
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				AccessLevel:    types.ContainerRegistryAccessLevels.ReadWrite,
+				VirtualDomain:  "container-registry.test.libsacloud.com",
+				SubDomainLabel: name,
+				Users: []*User{
+					{
+						UserName:   "user1",
+						Password:   "password1",
+						Permission: types.ContainerRegistryPermissions.ReadWrite,
+					},
+				},
+				SettingsHash: "aaaaaaaa",
+			},
+			expect: &Builder{
+				ID:             0,
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				AccessLevel:    types.ContainerRegistryAccessLevels.ReadWrite,
+				VirtualDomain:  "container-registry.test.libsacloud.com",
+				SubDomainLabel: name,
+				Users: []*User{
+					{
+						UserName:   "user1",
+						Password:   "password1",
+						Permission: types.ContainerRegistryPermissions.ReadWrite,
+					},
+				},
+				SettingsHash: "aaaaaaaa",
+				Client:       sacloud.NewContainerRegistryOp(caller),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		builder, err := tc.in.Builder(caller)
+		require.NoError(t, err)
+		require.EqualValues(t, tc.expect, builder)
+	}
+}

--- a/v2/helper/service/containerregistry/create_request.go
+++ b/v2/helper/service/containerregistry/create_request.go
@@ -16,7 +16,6 @@ package containerregistry
 
 import (
 	"github.com/sacloud/libsacloud/v2/helper/validate"
-	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
@@ -35,8 +34,8 @@ func (req *CreateRequest) Validate() error {
 	return validate.Struct(req)
 }
 
-func (req *CreateRequest) Builder(caller sacloud.APICaller) (*Builder, error) {
-	return &Builder{
+func (req *CreateRequest) ApplyRequest() *ApplyRequest {
+	return &ApplyRequest{
 		Name:           req.Name,
 		Description:    req.Description,
 		Tags:           req.Tags,
@@ -46,6 +45,5 @@ func (req *CreateRequest) Builder(caller sacloud.APICaller) (*Builder, error) {
 		SubDomainLabel: req.SubDomainLabel,
 		Users:          req.Users,
 		SettingsHash:   "",
-		Client:         sacloud.NewContainerRegistryOp(caller),
-	}, nil
+	}
 }

--- a/v2/helper/service/containerregistry/create_service.go
+++ b/v2/helper/service/containerregistry/create_service.go
@@ -29,10 +29,5 @@ func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*s
 		return nil, err
 	}
 
-	builder, err := req.Builder(s.caller)
-	if err != nil {
-		return nil, err
-	}
-
-	return builder.Build(ctx)
+	return s.ApplyWithContext(ctx, req.ApplyRequest())
 }

--- a/v2/helper/service/containerregistry/create_test.go
+++ b/v2/helper/service/containerregistry/create_test.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerregistry
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerRegistryService_convertCreateRequest(t *testing.T) {
+	name := testutil.ResourceName("container-registry-service")
+	cases := []struct {
+		in     *CreateRequest
+		expect *ApplyRequest
+	}{
+		{
+			in: &CreateRequest{
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				IconID:         1,
+				AccessLevel:    types.ContainerRegistryAccessLevels.ReadWrite,
+				VirtualDomain:  "container-registry.test.libsacloud.com",
+				SubDomainLabel: name,
+				Users: []*User{
+					{
+						UserName:   "user1",
+						Password:   "password1",
+						Permission: types.ContainerRegistryPermissions.ReadWrite,
+					},
+				},
+			},
+			expect: &ApplyRequest{
+				ID:             0,
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				IconID:         1,
+				AccessLevel:    types.ContainerRegistryAccessLevels.ReadWrite,
+				VirtualDomain:  "container-registry.test.libsacloud.com",
+				SubDomainLabel: name,
+				Users: []*User{
+					{
+						UserName:   "user1",
+						Password:   "password1",
+						Permission: types.ContainerRegistryPermissions.ReadWrite,
+					},
+				},
+				SettingsHash: "",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		require.EqualValues(t, tc.expect, tc.in.ApplyRequest())
+	}
+}

--- a/v2/helper/service/containerregistry/update_service.go
+++ b/v2/helper/service/containerregistry/update_service.go
@@ -30,10 +30,10 @@ func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*s
 		return nil, err
 	}
 
-	builder, err := req.Builder(ctx, s.caller)
+	applyRequest, err := req.ApplyRequest(ctx, s.caller)
 	if err != nil {
 		return nil, fmt.Errorf("processing request parameter failed: %s", err)
 	}
 
-	return builder.Build(ctx)
+	return s.ApplyWithContext(ctx, applyRequest)
 }

--- a/v2/helper/service/containerregistry/update_test.go
+++ b/v2/helper/service/containerregistry/update_test.go
@@ -1,0 +1,97 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package containerregistry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/pointer"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerRegistryService_convertUpdateRequest(t *testing.T) {
+	caller := testutil.SingletonAPICaller()
+	name := testutil.ResourceName("container-registry-service")
+
+	// setup
+	svc := New(caller)
+	current, err := svc.Create(&CreateRequest{
+		Name:           name,
+		Description:    "desc",
+		Tags:           types.Tags{"tag1", "tag2"},
+		AccessLevel:    types.ContainerRegistryAccessLevels.ReadWrite,
+		VirtualDomain:  "container-registry.test.libsacloud.com",
+		SubDomainLabel: name,
+		Users: []*User{
+			{
+				UserName:   "username",
+				Password:   "password",
+				Permission: types.ContainerRegistryPermissions.ReadWrite,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		sacloud.NewContainerRegistryOp(caller).Delete(context.Background(), current.ID) // nolint
+	}()
+
+	// test
+	cases := []struct {
+		in     *UpdateRequest
+		expect *ApplyRequest
+	}{
+		{
+			in: &UpdateRequest{
+				ID:            current.ID,
+				Name:          pointer.NewString(current.Name + "-upd"),
+				AccessLevel:   &types.ContainerRegistryAccessLevels.ReadOnly,
+				VirtualDomain: pointer.NewString("updated.container-registry.test.libsacloud.com"),
+				Users:         nil,
+				SettingsHash:  "aaaaa",
+			},
+			expect: &ApplyRequest{
+				ID:             current.ID,
+				Name:           current.Name + "-upd",
+				Description:    current.Description,
+				Tags:           current.Tags,
+				IconID:         current.IconID,
+				AccessLevel:    types.ContainerRegistryAccessLevels.ReadOnly,
+				VirtualDomain:  "updated.container-registry.test.libsacloud.com",
+				SubDomainLabel: current.SubDomainLabel,
+				Users: []*User{
+					{
+						UserName:   "username",
+						Password:   "", // Usersを指定しなかった場合のパスワードは常に空となる
+						Permission: types.ContainerRegistryPermissions.ReadWrite,
+					},
+				},
+				SettingsHash: "aaaaa",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		req, err := tc.in.ApplyRequest(context.Background(), caller)
+		require.NoError(t, err)
+		require.EqualValues(t, tc.expect, req)
+	}
+}

--- a/v2/helper/service/database/create_request.go
+++ b/v2/helper/service/database/create_request.go
@@ -15,10 +15,7 @@
 package database
 
 import (
-	"github.com/sacloud/libsacloud/v2/pkg/mapconv"
-
 	"github.com/sacloud/libsacloud/v2/helper/validate"
-	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
@@ -54,10 +51,30 @@ func (req *CreateRequest) Validate() error {
 	return validate.Struct(req)
 }
 
-func (req *CreateRequest) Builder(caller sacloud.APICaller) (*Builder, error) {
-	builder := &Builder{Caller: caller}
-	if err := mapconv.ConvertTo(req, builder); err != nil {
-		return nil, err
+func (req *CreateRequest) ApplyRequest() *ApplyRequest {
+	return &ApplyRequest{
+		Zone:                  req.Zone,
+		Name:                  req.Name,
+		Description:           req.Description,
+		Tags:                  req.Tags,
+		IconID:                req.IconID,
+		PlanID:                req.PlanID,
+		SwitchID:              req.SwitchID,
+		IPAddresses:           req.IPAddresses,
+		NetworkMaskLen:        req.NetworkMaskLen,
+		DefaultRoute:          req.DefaultRoute,
+		Port:                  req.Port,
+		SourceNetwork:         req.SourceNetwork,
+		DatabaseType:          req.DatabaseType,
+		Username:              req.Username,
+		Password:              req.Password,
+		EnableReplication:     req.EnableBackup,
+		ReplicaUserPassword:   req.ReplicaUserPassword,
+		EnableWebUI:           req.EnableWebUI,
+		EnableBackup:          req.EnableBackup,
+		BackupWeekdays:        req.BackupWeekdays,
+		BackupStartTimeHour:   req.BackupStartTimeHour,
+		BackupStartTimeMinute: req.BackupStartTimeMinute,
+		NoWait:                req.NoWait,
 	}
-	return builder, nil
 }

--- a/v2/helper/service/database/create_service.go
+++ b/v2/helper/service/database/create_service.go
@@ -29,10 +29,5 @@ func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*s
 		return nil, err
 	}
 
-	builder, err := req.Builder(s.caller)
-	if err != nil {
-		return nil, err
-	}
-
-	return builder.Build(ctx)
+	return s.ApplyWithContext(ctx, req.ApplyRequest())
 }

--- a/v2/helper/service/database/create_test.go
+++ b/v2/helper/service/database/create_test.go
@@ -17,21 +17,18 @@ package database
 import (
 	"testing"
 
-	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDatabaseService_CreateParameterToBuilder(t *testing.T) {
-	caller := testutil.SingletonAPICaller()
-
+func TestDatabaseService_convertCreateRequest(t *testing.T) {
 	cases := []struct {
 		in     *CreateRequest
-		expect *Builder
+		expect *ApplyRequest
 	}{
 		{
 			in:     &CreateRequest{},
-			expect: &Builder{Caller: caller},
+			expect: &ApplyRequest{},
 		},
 		{
 			in: &CreateRequest{
@@ -59,7 +56,7 @@ func TestDatabaseService_CreateParameterToBuilder(t *testing.T) {
 				BackupStartTimeMinute: 0,
 				NoWait:                true,
 			},
-			expect: &Builder{
+			expect: &ApplyRequest{
 				ID:                    0,
 				Zone:                  "is1a",
 				Name:                  "name",
@@ -84,14 +81,11 @@ func TestDatabaseService_CreateParameterToBuilder(t *testing.T) {
 				BackupStartTimeHour:   10,
 				BackupStartTimeMinute: 0,
 				NoWait:                true,
-				Caller:                caller,
 			},
 		},
 	}
 
 	for _, tc := range cases {
-		got, err := tc.in.Builder(caller)
-		require.NoError(t, err)
-		require.EqualValues(t, tc.expect, got)
+		require.EqualValues(t, tc.expect, tc.in.ApplyRequest())
 	}
 }

--- a/v2/helper/service/database/update_request.go
+++ b/v2/helper/service/database/update_request.go
@@ -16,6 +16,7 @@ package database
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -57,6 +58,10 @@ func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICa
 	current, err := dbOp.Read(ctx, req.Zone, req.ID)
 	if err != nil {
 		return nil, err
+	}
+
+	if current.Availability != types.Availabilities.Available {
+		return nil, fmt.Errorf("target has invalid Availability: Zone=%s ID=%s Availability=%v", req.Zone, req.ID.String(), current.Availability)
 	}
 
 	var bkHour, bkMinute int

--- a/v2/helper/service/database/update_request.go
+++ b/v2/helper/service/database/update_request.go
@@ -16,6 +16,8 @@ package database
 
 import (
 	"context"
+	"strconv"
+	"strings"
 
 	"github.com/sacloud/libsacloud/v2/helper/service"
 
@@ -50,13 +52,64 @@ func (req *UpdateRequest) Validate() error {
 	return validate.Struct(req)
 }
 
-func (req *UpdateRequest) Builder(ctx context.Context, caller sacloud.APICaller) (*Builder, error) {
-	builder, err := BuilderFromResource(ctx, caller, req.Zone, req.ID)
+func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICaller) (*ApplyRequest, error) {
+	dbOp := sacloud.NewDatabaseOp(caller)
+	current, err := dbOp.Read(ctx, req.Zone, req.ID)
 	if err != nil {
 		return nil, err
 	}
-	if err := service.RequestConvertTo(req, builder); err != nil {
+
+	var bkHour, bkMinute int
+	var bkWeekdays []types.EBackupSpanWeekday
+	if current.BackupSetting != nil {
+		bkWeekdays = current.BackupSetting.DayOfWeek
+		if current.BackupSetting.Time != "" {
+			timeStrings := strings.Split(current.BackupSetting.Time, ":")
+			if len(timeStrings) == 2 {
+				hour, err := strconv.ParseInt(timeStrings[0], 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				bkHour = int(hour)
+
+				minute, err := strconv.ParseInt(timeStrings[1], 10, 64)
+				if err != nil {
+					return nil, err
+				}
+				bkMinute = int(minute)
+			}
+		}
+	}
+
+	applyRequest := &ApplyRequest{
+		Zone:                  req.Zone,
+		ID:                    req.ID,
+		Name:                  current.Name,
+		Description:           current.Description,
+		Tags:                  current.Tags,
+		IconID:                current.IconID,
+		PlanID:                current.PlanID,
+		SwitchID:              current.SwitchID,
+		IPAddresses:           current.IPAddresses,
+		NetworkMaskLen:        current.NetworkMaskLen,
+		DefaultRoute:          current.DefaultRoute,
+		Port:                  current.CommonSetting.ServicePort,
+		SourceNetwork:         current.CommonSetting.SourceNetwork,
+		DatabaseType:          current.Conf.DatabaseName,
+		Username:              current.CommonSetting.DefaultUser,
+		Password:              current.CommonSetting.UserPassword,
+		EnableReplication:     current.ReplicationSetting != nil,
+		ReplicaUserPassword:   current.CommonSetting.ReplicaPassword,
+		EnableWebUI:           current.CommonSetting.WebUI.Bool(),
+		EnableBackup:          current.BackupSetting != nil,
+		BackupWeekdays:        bkWeekdays,
+		BackupStartTimeHour:   bkHour,
+		BackupStartTimeMinute: bkMinute,
+		NoWait:                false,
+	}
+
+	if err := service.RequestConvertTo(req, applyRequest); err != nil {
 		return nil, err
 	}
-	return builder, nil
+	return applyRequest, nil
 }

--- a/v2/helper/service/database/update_service.go
+++ b/v2/helper/service/database/update_service.go
@@ -30,10 +30,10 @@ func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*s
 		return nil, err
 	}
 
-	builder, err := req.Builder(ctx, s.caller)
+	applyRequest, err := req.ApplyRequest(ctx, s.caller)
 	if err != nil {
 		return nil, fmt.Errorf("processing request parameter failed: %s", err)
 	}
 
-	return builder.update(ctx)
+	return s.ApplyWithContext(ctx, applyRequest)
 }

--- a/v2/helper/service/database/update_test.go
+++ b/v2/helper/service/database/update_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDatabaseService_convertToBuilder(t *testing.T) {
+func TestDatabaseService_convertUpdateRequest(t *testing.T) {
 	if testutil.IsAccTest() {
 		t.Skip("This test runs only without TESTACC=1")
 	}
@@ -97,7 +97,7 @@ func TestDatabaseService_convertToBuilder(t *testing.T) {
 
 	cases := []struct {
 		in     *UpdateRequest
-		expect *Builder
+		expect *ApplyRequest
 	}{
 		{
 			in: &UpdateRequest{
@@ -106,7 +106,7 @@ func TestDatabaseService_convertToBuilder(t *testing.T) {
 				Name:   pointer.NewString(db.Name + "-upd"),
 				NoWait: true,
 			},
-			expect: &Builder{
+			expect: &ApplyRequest{
 				Zone:                  zone,
 				ID:                    db.ID,
 				Name:                  db.Name + "-upd",
@@ -130,7 +130,6 @@ func TestDatabaseService_convertToBuilder(t *testing.T) {
 				BackupStartTimeHour:   10,
 				BackupStartTimeMinute: 0,
 				NoWait:                true,
-				Caller:                caller,
 			},
 		},
 		{
@@ -141,7 +140,7 @@ func TestDatabaseService_convertToBuilder(t *testing.T) {
 				EnableBackup:      pointer.NewBool(false),
 				NoWait:            true,
 			},
-			expect: &Builder{
+			expect: &ApplyRequest{
 				Zone:                  zone,
 				ID:                    db.ID,
 				Name:                  db.Name,
@@ -165,13 +164,12 @@ func TestDatabaseService_convertToBuilder(t *testing.T) {
 				BackupStartTimeHour:   10,
 				BackupStartTimeMinute: 0,
 				NoWait:                true,
-				Caller:                caller,
 			},
 		},
 	}
 
 	for _, tc := range cases {
-		got, err := tc.in.Builder(ctx, caller)
+		got, err := tc.in.ApplyRequest(ctx, caller)
 		require.NoError(t, err)
 		require.EqualValues(t, tc.expect, got)
 	}

--- a/v2/helper/service/disk/apply_test.go
+++ b/v2/helper/service/disk/apply_test.go
@@ -1,0 +1,131 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package disk
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
+
+	diskBuilder "github.com/sacloud/libsacloud/v2/helper/builder/disk"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiskService_convertApplyRequest(t *testing.T) {
+	caller := testutil.SingletonAPICaller()
+
+	cases := []struct {
+		in     *ApplyRequest
+		expect diskBuilder.Builder
+	}{
+		// blank
+		{
+			in: &ApplyRequest{
+				Zone:          "is1a",
+				Name:          "test",
+				Description:   "description",
+				Tags:          types.Tags{"tag1", "tag2"},
+				IconID:        types.ID(1),
+				ServerID:      types.ID(2),
+				DiskPlanID:    types.DiskPlans.SSD,
+				Connection:    types.DiskConnections.VirtIO,
+				SizeGB:        20,
+				DistantFrom:   nil,
+				OSType:        0,
+				EditParameter: nil,
+				NoWait:        true,
+			},
+			expect: &diskBuilder.BlankBuilder{
+				Name:        "test",
+				Description: "description",
+				Tags:        types.Tags{"tag1", "tag2"},
+				IconID:      types.ID(1),
+				SizeGB:      20,
+				PlanID:      types.DiskPlans.SSD,
+				Connection:  types.DiskConnections.VirtIO,
+				Client:      diskBuilder.NewBuildersAPIClient(caller),
+				NoWait:      true,
+			},
+		},
+		// linux
+		{
+			in: &ApplyRequest{
+				Zone:       "is1a",
+				Name:       "test",
+				DiskPlanID: types.DiskPlans.SSD,
+				Connection: types.DiskConnections.VirtIO,
+				SizeGB:     20,
+				OSType:     ostype.Ubuntu,
+				EditParameter: &EditParameter{
+					HostName: "hostname",
+					Password: "password",
+				},
+				NoWait: true,
+			},
+			expect: &diskBuilder.FromUnixBuilder{
+				OSType:     ostype.Ubuntu,
+				Name:       "test",
+				SizeGB:     20,
+				PlanID:     types.DiskPlans.SSD,
+				Connection: types.DiskConnections.VirtIO,
+				EditParameter: &diskBuilder.UnixEditRequest{
+					HostName: "hostname",
+					Password: "password",
+				},
+				Client: diskBuilder.NewBuildersAPIClient(caller),
+				NoWait: true,
+				ID:     0,
+			},
+		},
+		// source disk
+		{
+			in: &ApplyRequest{
+				Zone:         "is1a",
+				Name:         "test",
+				DiskPlanID:   types.DiskPlans.SSD,
+				Connection:   types.DiskConnections.VirtIO,
+				SourceDiskID: types.ID(1),
+				SizeGB:       20,
+				EditParameter: &EditParameter{
+					HostName: "hostname",
+					Password: "password",
+				},
+				NoWait: true,
+			},
+			expect: &diskBuilder.FromDiskOrArchiveBuilder{
+				Name:         "test",
+				SizeGB:       20,
+				PlanID:       types.DiskPlans.SSD,
+				Connection:   types.DiskConnections.VirtIO,
+				SourceDiskID: types.ID(1),
+				EditParameter: &diskBuilder.UnixEditRequest{
+					HostName: "hostname",
+					Password: "password",
+				},
+				Client: diskBuilder.NewBuildersAPIClient(caller),
+				NoWait: true,
+				ID:     0,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		builder, err := tc.in.Builder(caller)
+		require.NoError(t, err)
+		require.EqualValues(t, tc.expect, builder)
+	}
+}

--- a/v2/helper/service/disk/create_request.go
+++ b/v2/helper/service/disk/create_request.go
@@ -17,11 +17,7 @@ package disk
 import (
 	"fmt"
 
-	diskBuilder "github.com/sacloud/libsacloud/v2/helper/builder/disk"
-
-	"github.com/sacloud/libsacloud/v2/helper/service"
 	"github.com/sacloud/libsacloud/v2/helper/validate"
-	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
@@ -56,29 +52,22 @@ func (req *CreateRequest) Validate() error {
 	return validate.Struct(req)
 }
 
-func (req *CreateRequest) Builder(caller sacloud.APICaller) (diskBuilder.Builder, error) {
-	editParameter := &diskBuilder.EditRequest{}
-	if req.EditParameter != nil {
-		if err := service.RequestConvertTo(req.EditParameter, editParameter); err != nil {
-			return nil, err
-		}
-	}
-
-	director := &diskBuilder.Director{
-		OSType:          req.OSType,
+func (req *CreateRequest) ApplyRequest() *ApplyRequest {
+	return &ApplyRequest{
+		Zone:            req.Zone,
 		Name:            req.Name,
-		SizeGB:          req.SizeGB,
-		DistantFrom:     req.DistantFrom,
-		PlanID:          req.DiskPlanID,
-		Connection:      req.Connection,
 		Description:     req.Description,
 		Tags:            req.Tags,
 		IconID:          req.IconID,
-		SourceDiskID:    req.SourceDiskID,
+		DiskPlanID:      req.DiskPlanID,
+		Connection:      req.Connection,
+		SourceDiskID:    req.SourceArchiveID,
 		SourceArchiveID: req.SourceArchiveID,
-		EditParameter:   editParameter,
+		ServerID:        req.ServerID,
+		SizeGB:          req.SizeGB,
+		DistantFrom:     req.DistantFrom,
+		OSType:          req.OSType,
+		EditParameter:   req.EditParameter,
 		NoWait:          req.NoWait,
-		Client:          diskBuilder.NewBuildersAPIClient(caller),
 	}
-	return director.Builder(), nil
 }

--- a/v2/helper/service/disk/create_service.go
+++ b/v2/helper/service/disk/create_service.go
@@ -29,15 +29,5 @@ func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*s
 		return nil, err
 	}
 
-	builder, err := req.Builder(s.caller)
-	if err != nil {
-		return nil, err
-	}
-
-	result, err := builder.Build(ctx, req.Zone, req.ServerID)
-	if err != nil {
-		return nil, err
-	}
-
-	return sacloud.NewDiskOp(s.caller).Read(ctx, req.Zone, result.DiskID)
+	return s.ApplyWithContext(ctx, req.ApplyRequest())
 }

--- a/v2/helper/service/disk/create_test.go
+++ b/v2/helper/service/disk/create_test.go
@@ -18,50 +18,15 @@ import (
 	"testing"
 
 	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
-
-	diskBuilder "github.com/sacloud/libsacloud/v2/helper/builder/disk"
-	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 	"github.com/stretchr/testify/require"
 )
 
-func TestDiskService_convertCreateParameter(t *testing.T) {
-	caller := testutil.SingletonAPICaller()
-
+func TestDiskService_convertCreateRequest(t *testing.T) {
 	cases := []struct {
 		in     *CreateRequest
-		expect diskBuilder.Builder
+		expect *ApplyRequest
 	}{
-		// blank
-		{
-			in: &CreateRequest{
-				Zone:          "is1a",
-				Name:          "test",
-				Description:   "description",
-				Tags:          types.Tags{"tag1", "tag2"},
-				IconID:        types.ID(1),
-				ServerID:      types.ID(2),
-				DiskPlanID:    types.DiskPlans.SSD,
-				Connection:    types.DiskConnections.VirtIO,
-				SizeGB:        20,
-				DistantFrom:   nil,
-				OSType:        0,
-				EditParameter: nil,
-				NoWait:        true,
-			},
-			expect: &diskBuilder.BlankBuilder{
-				Name:        "test",
-				Description: "description",
-				Tags:        types.Tags{"tag1", "tag2"},
-				IconID:      types.ID(1),
-				SizeGB:      20,
-				PlanID:      types.DiskPlans.SSD,
-				Connection:  types.DiskConnections.VirtIO,
-				Client:      diskBuilder.NewBuildersAPIClient(caller),
-				NoWait:      true,
-			},
-		},
-		// linux
 		{
 			in: &CreateRequest{
 				Zone:       "is1a",
@@ -76,56 +41,23 @@ func TestDiskService_convertCreateParameter(t *testing.T) {
 				},
 				NoWait: true,
 			},
-			expect: &diskBuilder.FromUnixBuilder{
-				OSType:     ostype.Ubuntu,
+			expect: &ApplyRequest{
+				Zone:       "is1a",
 				Name:       "test",
-				SizeGB:     20,
-				PlanID:     types.DiskPlans.SSD,
+				DiskPlanID: types.DiskPlans.SSD,
 				Connection: types.DiskConnections.VirtIO,
-				EditParameter: &diskBuilder.UnixEditRequest{
-					HostName: "hostname",
-					Password: "password",
-				},
-				Client: diskBuilder.NewBuildersAPIClient(caller),
-				NoWait: true,
-				ID:     0,
-			},
-		},
-		// source disk
-		{
-			in: &CreateRequest{
-				Zone:         "is1a",
-				Name:         "test",
-				DiskPlanID:   types.DiskPlans.SSD,
-				Connection:   types.DiskConnections.VirtIO,
-				SourceDiskID: types.ID(1),
-				SizeGB:       20,
+				SizeGB:     20,
+				OSType:     ostype.Ubuntu,
 				EditParameter: &EditParameter{
 					HostName: "hostname",
 					Password: "password",
 				},
 				NoWait: true,
 			},
-			expect: &diskBuilder.FromDiskOrArchiveBuilder{
-				Name:         "test",
-				SizeGB:       20,
-				PlanID:       types.DiskPlans.SSD,
-				Connection:   types.DiskConnections.VirtIO,
-				SourceDiskID: types.ID(1),
-				EditParameter: &diskBuilder.UnixEditRequest{
-					HostName: "hostname",
-					Password: "password",
-				},
-				Client: diskBuilder.NewBuildersAPIClient(caller),
-				NoWait: true,
-				ID:     0,
-			},
 		},
 	}
 
 	for _, tc := range cases {
-		builder, err := tc.in.Builder(caller)
-		require.NoError(t, err)
-		require.EqualValues(t, tc.expect, builder)
+		require.EqualValues(t, tc.expect, tc.in.ApplyRequest())
 	}
 }

--- a/v2/helper/service/disk/update_request.go
+++ b/v2/helper/service/disk/update_request.go
@@ -16,6 +16,7 @@ package disk
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sacloud/libsacloud/v2/helper/service"
 	"github.com/sacloud/libsacloud/v2/helper/validate"
@@ -45,6 +46,9 @@ func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICa
 	current, err := sacloud.NewDiskOp(caller).Read(ctx, req.Zone, req.ID)
 	if err != nil {
 		return nil, err
+	}
+	if current.Availability != types.Availabilities.Available {
+		return nil, fmt.Errorf("target has invalid Availability: Zone=%s ID=%s Availability=%v", req.Zone, req.ID.String(), current.Availability)
 	}
 
 	applyRequest := &ApplyRequest{

--- a/v2/helper/service/disk/update_service.go
+++ b/v2/helper/service/disk/update_service.go
@@ -30,14 +30,9 @@ func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*s
 		return nil, err
 	}
 
-	builder, err := req.Builder(ctx, s.caller)
+	applyRequest, err := req.ApplyRequest(ctx, s.caller)
 	if err != nil {
 		return nil, fmt.Errorf("processing request parameter failed: %s", err)
 	}
-
-	result, err := builder.Update(ctx, req.Zone)
-	if err != nil {
-		return nil, err
-	}
-	return result.Disk, nil
+	return s.ApplyWithContext(ctx, applyRequest)
 }

--- a/v2/helper/service/disk/update_test.go
+++ b/v2/helper/service/disk/update_test.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/helper/wait"
+
 	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
@@ -41,6 +43,7 @@ func TestDiskUpdateRequest_Update(t *testing.T) {
 }
 
 func TestDiskService_convertUpdateRequest(t *testing.T) {
+	ctx := context.Background()
 	caller := testutil.SingletonAPICaller()
 	name := testutil.ResourceName("disk-service-update")
 	zone := testutil.TestZone()
@@ -55,6 +58,12 @@ func TestDiskService_convertUpdateRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	v, err := wait.UntilDiskIsReady(ctx, diskOp, zone, disk.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	disk = v
+
 	defer func() {
 		diskOp.Delete(context.Background(), zone, disk.ID) // nolint
 	}()
@@ -72,7 +81,7 @@ func TestDiskService_convertUpdateRequest(t *testing.T) {
 					HostName: "hostname",
 					Password: "password",
 				},
-				NoWait: true,
+				NoWait: false,
 			},
 			expect: &ApplyRequest{
 				Zone:            zone,
@@ -91,7 +100,7 @@ func TestDiskService_convertUpdateRequest(t *testing.T) {
 					HostName: "hostname",
 					Password: "password",
 				},
-				NoWait: true,
+				NoWait: false,
 			},
 		},
 	}

--- a/v2/helper/service/disk/update_test.go
+++ b/v2/helper/service/disk/update_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	diskBuilder "github.com/sacloud/libsacloud/v2/helper/builder/disk"
 	"github.com/sacloud/libsacloud/v2/pkg/size"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
@@ -60,9 +59,9 @@ func TestDiskService_convertUpdateRequest(t *testing.T) {
 		diskOp.Delete(context.Background(), zone, disk.ID) // nolint
 	}()
 
-	cases := []struct {
+	var cases = []struct {
 		in     *UpdateRequest
-		expect diskBuilder.Builder
+		expect *ApplyRequest
 	}{
 		{
 			in: &UpdateRequest{
@@ -75,25 +74,30 @@ func TestDiskService_convertUpdateRequest(t *testing.T) {
 				},
 				NoWait: true,
 			},
-			expect: &diskBuilder.ConnectedDiskBuilder{
-				Name:        name + "-upd",
-				Connection:  disk.Connection,
-				Description: disk.Description,
-				Tags:        disk.Tags,
-				IconID:      disk.IconID,
-				EditParameter: &diskBuilder.UnixEditRequest{
+			expect: &ApplyRequest{
+				Zone:            zone,
+				ID:              disk.ID,
+				Name:            name + "-upd",
+				Description:     disk.Description,
+				Tags:            disk.Tags,
+				IconID:          disk.IconID,
+				DiskPlanID:      disk.DiskPlanID,
+				Connection:      disk.Connection,
+				SourceDiskID:    disk.SourceDiskID,
+				SourceArchiveID: disk.SourceArchiveID,
+				ServerID:        disk.ServerID,
+				SizeGB:          disk.GetSizeGB(),
+				EditParameter: &EditParameter{
 					HostName: "hostname",
 					Password: "password",
 				},
-				Client: diskBuilder.NewBuildersAPIClient(caller),
 				NoWait: true,
-				ID:     disk.ID,
 			},
 		},
 	}
 	for _, tc := range cases {
-		builder, err := tc.in.Builder(context.Background(), caller)
+		req, err := tc.in.ApplyRequest(context.Background(), caller)
 		require.NoError(t, err)
-		require.EqualValues(t, tc.expect, builder)
+		require.EqualValues(t, tc.expect, req)
 	}
 }

--- a/v2/helper/service/loadbalancer/apply_request.go
+++ b/v2/helper/service/loadbalancer/apply_request.go
@@ -22,8 +22,8 @@ import (
 )
 
 type ApplyRequest struct {
-	ID   types.ID `request:"-"` // for update
-	Zone string   `request:"-" validate:"required"`
+	ID   types.ID // for update
+	Zone string   `validate:"required"`
 
 	Name               string `validate:"required"`
 	Description        string `validate:"min=0,max=512"`
@@ -38,6 +38,7 @@ type ApplyRequest struct {
 	VirtualIPAddresses sacloud.LoadBalancerVirtualIPAddresses
 
 	SettingsHash string // for update
+	NoWait       bool
 }
 
 func (req *ApplyRequest) Validate() error {

--- a/v2/helper/service/loadbalancer/apply_test.go
+++ b/v2/helper/service/loadbalancer/apply_test.go
@@ -1,0 +1,135 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadbalancer
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadBalancerService_convertApplyRequest(t *testing.T) {
+	caller := testutil.SingletonAPICaller()
+	name := testutil.ResourceName("load-balancer-service")
+	zone := testutil.TestZone()
+
+	cases := []struct {
+		in     *ApplyRequest
+		expect *Builder
+	}{
+		{
+			in: &ApplyRequest{
+				ID:             101,
+				Zone:           zone,
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				SwitchID:       102,
+				PlanID:         types.LoadBalancerPlans.Standard,
+				VRID:           10,
+				IPAddresses:    []string{"192.168.0.101", "192.168.0.102"},
+				NetworkMaskLen: 24,
+				DefaultRoute:   "192.168.0.1",
+				VirtualIPAddresses: []*sacloud.LoadBalancerVirtualIPAddress{
+					{
+						VirtualIPAddress: "192.168.0.201",
+						Port:             80,
+						DelayLoop:        10,
+						SorryServer:      "192.168.0.99",
+						Description:      "desc",
+						Servers: []*sacloud.LoadBalancerServer{
+							{
+								IPAddress: "192.168.0.202",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+							{
+								IPAddress: "192.168.0.203",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+						},
+					},
+				},
+				NoWait: true,
+			},
+			expect: &Builder{
+				ID:             101,
+				Zone:           zone,
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				SwitchID:       102,
+				PlanID:         types.LoadBalancerPlans.Standard,
+				VRID:           10,
+				IPAddresses:    []string{"192.168.0.101", "192.168.0.102"},
+				NetworkMaskLen: 24,
+				DefaultRoute:   "192.168.0.1",
+				VirtualIPAddresses: []*sacloud.LoadBalancerVirtualIPAddress{
+					{
+						VirtualIPAddress: "192.168.0.201",
+						Port:             80,
+						DelayLoop:        10,
+						SorryServer:      "192.168.0.99",
+						Description:      "desc",
+						Servers: []*sacloud.LoadBalancerServer{
+							{
+								IPAddress: "192.168.0.202",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+							{
+								IPAddress: "192.168.0.203",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+						},
+					},
+				},
+				NoWait: true,
+				Client: sacloud.NewLoadBalancerOp(caller),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		builder, err := tc.in.Builder(caller)
+		require.NoError(t, err)
+		require.EqualValues(t, tc.expect, builder)
+	}
+}

--- a/v2/helper/service/loadbalancer/create_request.go
+++ b/v2/helper/service/loadbalancer/create_request.go
@@ -15,7 +15,6 @@
 package loadbalancer
 
 import (
-	"github.com/sacloud/libsacloud/v2/helper/service"
 	"github.com/sacloud/libsacloud/v2/helper/validate"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -35,16 +34,29 @@ type CreateRequest struct {
 	NetworkMaskLen     int      `validate:"required"`
 	DefaultRoute       string   `validate:"omitempty,ipv4"`
 	VirtualIPAddresses sacloud.LoadBalancerVirtualIPAddresses
+
+	NoWait bool
 }
 
 func (req *CreateRequest) Validate() error {
 	return validate.Struct(req)
 }
 
-func (req *CreateRequest) ToRequestParameter() (*sacloud.LoadBalancerCreateRequest, error) {
-	params := &sacloud.LoadBalancerCreateRequest{}
-	if err := service.RequestConvertTo(req, params); err != nil {
-		return nil, err
+func (req *CreateRequest) ApplyRequest() *ApplyRequest {
+	return &ApplyRequest{
+		Zone:               req.Zone,
+		Name:               req.Name,
+		Description:        req.Description,
+		Tags:               req.Tags,
+		IconID:             req.IconID,
+		SwitchID:           req.SwitchID,
+		PlanID:             req.PlanID,
+		VRID:               req.VRID,
+		IPAddresses:        req.IPAddresses,
+		NetworkMaskLen:     req.NetworkMaskLen,
+		DefaultRoute:       req.DefaultRoute,
+		VirtualIPAddresses: req.VirtualIPAddresses,
+		SettingsHash:       "",
+		NoWait:             req.NoWait,
 	}
-	return params, nil
 }

--- a/v2/helper/service/loadbalancer/create_service.go
+++ b/v2/helper/service/loadbalancer/create_service.go
@@ -28,12 +28,5 @@ func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*s
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-
-	params, err := req.ToRequestParameter()
-	if err != nil {
-		return nil, err
-	}
-
-	client := sacloud.NewLoadBalancerOp(s.caller)
-	return client.Create(ctx, req.Zone, params)
+	return s.ApplyWithContext(ctx, req.ApplyRequest())
 }

--- a/v2/helper/service/loadbalancer/create_test.go
+++ b/v2/helper/service/loadbalancer/create_test.go
@@ -1,0 +1,129 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadbalancer
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadBalancerService_convertCreateRequest(t *testing.T) {
+	name := testutil.ResourceName("load-balancer-service")
+	zone := testutil.TestZone()
+
+	cases := []struct {
+		in     *CreateRequest
+		expect *ApplyRequest
+	}{
+		{
+			in: &CreateRequest{
+				Zone:           zone,
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				SwitchID:       102,
+				PlanID:         types.LoadBalancerPlans.Standard,
+				VRID:           10,
+				IPAddresses:    []string{"192.168.0.101", "192.168.0.102"},
+				NetworkMaskLen: 24,
+				DefaultRoute:   "192.168.0.1",
+				VirtualIPAddresses: []*sacloud.LoadBalancerVirtualIPAddress{
+					{
+						VirtualIPAddress: "192.168.0.201",
+						Port:             80,
+						DelayLoop:        10,
+						SorryServer:      "192.168.0.99",
+						Description:      "desc",
+						Servers: []*sacloud.LoadBalancerServer{
+							{
+								IPAddress: "192.168.0.202",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+							{
+								IPAddress: "192.168.0.203",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+						},
+					},
+				},
+				NoWait: true,
+			},
+			expect: &ApplyRequest{
+				Zone:           zone,
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				SwitchID:       102,
+				PlanID:         types.LoadBalancerPlans.Standard,
+				VRID:           10,
+				IPAddresses:    []string{"192.168.0.101", "192.168.0.102"},
+				NetworkMaskLen: 24,
+				DefaultRoute:   "192.168.0.1",
+				VirtualIPAddresses: []*sacloud.LoadBalancerVirtualIPAddress{
+					{
+						VirtualIPAddress: "192.168.0.201",
+						Port:             80,
+						DelayLoop:        10,
+						SorryServer:      "192.168.0.99",
+						Description:      "desc",
+						Servers: []*sacloud.LoadBalancerServer{
+							{
+								IPAddress: "192.168.0.202",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+							{
+								IPAddress: "192.168.0.203",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+						},
+					},
+				},
+				NoWait: true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		require.EqualValues(t, tc.expect, tc.in.ApplyRequest())
+	}
+}

--- a/v2/helper/service/loadbalancer/update_request.go
+++ b/v2/helper/service/loadbalancer/update_request.go
@@ -16,6 +16,7 @@ package loadbalancer
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sacloud/libsacloud/v2/helper/service"
 	"github.com/sacloud/libsacloud/v2/helper/validate"
@@ -46,6 +47,9 @@ func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICa
 	current, err := client.Read(ctx, req.Zone, req.ID)
 	if err != nil {
 		return nil, err
+	}
+	if current.Availability != types.Availabilities.Available {
+		return nil, fmt.Errorf("target has invalid Availability: Zone=%s ID=%s Availability=%v", req.Zone, req.ID.String(), current.Availability)
 	}
 
 	applyRequest := &ApplyRequest{

--- a/v2/helper/service/loadbalancer/update_service.go
+++ b/v2/helper/service/loadbalancer/update_service.go
@@ -29,9 +29,9 @@ func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*s
 		return nil, err
 	}
 
-	builder, err := req.Builder(ctx, s.caller)
+	applyRequest, err := req.ApplyRequest(ctx, s.caller)
 	if err != nil {
 		return nil, err
 	}
-	return builder.Build(ctx)
+	return s.ApplyWithContext(ctx, applyRequest)
 }

--- a/v2/helper/service/loadbalancer/update_test.go
+++ b/v2/helper/service/loadbalancer/update_test.go
@@ -1,0 +1,196 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loadbalancer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/helper/wait"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/pointer"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadBalancerService_convertUpdateRequest(t *testing.T) {
+	caller := testutil.SingletonAPICaller()
+	ctx := context.Background()
+	name := testutil.ResourceName("load-balancer-service")
+	zone := testutil.TestZone()
+
+	// setup
+	swOp := sacloud.NewSwitchOp(caller)
+	sw, err := swOp.Create(ctx, zone, &sacloud.SwitchCreateRequest{Name: name})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	current, err := New(caller).CreateWithContext(ctx, &CreateRequest{
+		Zone:           zone,
+		Name:           name,
+		Description:    "desc",
+		Tags:           types.Tags{"tag1", "tag2"},
+		SwitchID:       sw.ID,
+		PlanID:         types.LoadBalancerPlans.Standard,
+		VRID:           10,
+		IPAddresses:    []string{"192.168.0.101", "192.168.0.102"},
+		NetworkMaskLen: 24,
+		DefaultRoute:   "192.168.0.1",
+		VirtualIPAddresses: []*sacloud.LoadBalancerVirtualIPAddress{
+			{
+				VirtualIPAddress: "192.168.0.201",
+				Port:             80,
+				DelayLoop:        10,
+				SorryServer:      "192.168.0.99",
+				Description:      "desc",
+				Servers: []*sacloud.LoadBalancerServer{
+					{
+						IPAddress: "192.168.0.202",
+						Port:      80,
+						Enabled:   true,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+							Path:         "/",
+							ResponseCode: 200,
+						},
+					},
+					{
+						IPAddress: "192.168.0.203",
+						Port:      80,
+						Enabled:   true,
+						HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+							Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+							Path:         "/",
+							ResponseCode: 200,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		lbOp := sacloud.NewLoadBalancerOp(caller)
+		lbOp.Shutdown(ctx, zone, current.ID, &sacloud.ShutdownOption{Force: true}) // nolint
+		wait.UntilLoadBalancerIsDown(ctx, lbOp, zone, current.ID)                  // nolint
+		lbOp.Delete(ctx, zone, current.ID)                                         // nolint
+		swOp.Delete(ctx, zone, sw.ID)                                              // nolint
+	}()
+
+	// test
+	cases := []struct {
+		in     *UpdateRequest
+		expect *ApplyRequest
+	}{
+		{
+			in: &UpdateRequest{
+				Zone: zone,
+				ID:   current.ID,
+				Name: pointer.NewString(name + "-upd"),
+				VirtualIPAddresses: &sacloud.LoadBalancerVirtualIPAddresses{
+					{
+						VirtualIPAddress: "192.168.0.202",
+						Port:             80,
+						DelayLoop:        10,
+						SorryServer:      "192.168.0.99",
+						Description:      "desc",
+						Servers: []*sacloud.LoadBalancerServer{
+							{
+								IPAddress: "192.168.0.202",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+							{
+								IPAddress: "192.168.0.203",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+						},
+					},
+				},
+				SettingsHash: "aaaaa",
+				NoWait:       true,
+			},
+			expect: &ApplyRequest{
+				ID:             current.ID,
+				Zone:           zone,
+				Name:           name + "-upd",
+				Description:    current.Description,
+				Tags:           current.Tags,
+				IconID:         current.IconID,
+				SwitchID:       current.SwitchID,
+				PlanID:         current.PlanID,
+				VRID:           current.VRID,
+				IPAddresses:    current.IPAddresses,
+				NetworkMaskLen: current.NetworkMaskLen,
+				DefaultRoute:   current.DefaultRoute,
+				VirtualIPAddresses: sacloud.LoadBalancerVirtualIPAddresses{
+					{
+						VirtualIPAddress: "192.168.0.202",
+						Port:             80,
+						DelayLoop:        10,
+						SorryServer:      "192.168.0.99",
+						Description:      "desc",
+						Servers: []*sacloud.LoadBalancerServer{
+							{
+								IPAddress: "192.168.0.202",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+							{
+								IPAddress: "192.168.0.203",
+								Port:      80,
+								Enabled:   true,
+								HealthCheck: &sacloud.LoadBalancerServerHealthCheck{
+									Protocol:     types.LoadBalancerHealthCheckProtocols.HTTP,
+									Path:         "/",
+									ResponseCode: 200,
+								},
+							},
+						},
+					},
+				},
+				SettingsHash: "aaaaa",
+				NoWait:       true,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		req, err := tc.in.ApplyRequest(ctx, caller)
+		require.NoError(t, err)
+		require.EqualValues(t, tc.expect, req)
+	}
+}

--- a/v2/helper/service/mobilegateway/apply_request.go
+++ b/v2/helper/service/mobilegateway/apply_request.go
@@ -15,6 +15,8 @@
 package mobilegateway
 
 import (
+	"github.com/sacloud/libsacloud/v2/helper/builder"
+	mobileGatewayBuilder "github.com/sacloud/libsacloud/v2/helper/builder/mobilegateway"
 	"github.com/sacloud/libsacloud/v2/helper/validate"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -30,19 +32,16 @@ type ApplyRequest struct {
 	IconID                          types.ID
 	PrivateInterface                *PrivateInterfaceSetting `validate:"omitempty"`
 	StaticRoutes                    []*sacloud.MobileGatewayStaticRoute
-	SimRoutes                       []*SIMRouteSetting
+	SIMRoutes                       []*SIMRouteSetting
 	InternetConnectionEnabled       bool
 	InterDeviceCommunicationEnabled bool
 	DNS                             *sacloud.MobileGatewayDNSSetting
 	SIMs                            []*SIMSetting
 	TrafficConfig                   *sacloud.MobileGatewayTrafficControl
 
-	SettingsHash string
-	NoWait       bool
-}
-
-func (req *ApplyRequest) Validate() error {
-	return validate.Struct(req)
+	SettingsHash    string
+	BootAfterCreate bool
+	NoWait          bool
 }
 
 // PrivateInterfaceSetting represents API parameter/response structure
@@ -62,4 +61,54 @@ type SIMRouteSetting struct {
 type SIMSetting struct {
 	SIMID     types.ID
 	IPAddress string `validate:"ipv4"`
+}
+
+func (req *ApplyRequest) Validate() error {
+	return validate.Struct(req)
+}
+
+func (req *ApplyRequest) Builder(caller sacloud.APICaller) *mobileGatewayBuilder.Builder {
+	var privateInterface *mobileGatewayBuilder.PrivateInterfaceSetting
+	if req.PrivateInterface != nil {
+		privateInterface = &mobileGatewayBuilder.PrivateInterfaceSetting{
+			SwitchID:       req.PrivateInterface.SwitchID,
+			IPAddress:      req.PrivateInterface.IPAddress,
+			NetworkMaskLen: req.PrivateInterface.NetworkMaskLen,
+		}
+	}
+
+	var simRoutes []*mobileGatewayBuilder.SIMRouteSetting
+	for _, sr := range req.SIMRoutes {
+		simRoutes = append(simRoutes, &mobileGatewayBuilder.SIMRouteSetting{
+			SIMID:  sr.SIMID,
+			Prefix: sr.Prefix,
+		})
+	}
+
+	var sims []*mobileGatewayBuilder.SIMSetting
+	for _, s := range req.SIMs {
+		sims = append(sims, &mobileGatewayBuilder.SIMSetting{
+			SIMID:     s.SIMID,
+			IPAddress: s.IPAddress,
+		})
+	}
+
+	return &mobileGatewayBuilder.Builder{
+		Name:                            req.Name,
+		Description:                     req.Description,
+		Tags:                            req.Tags,
+		IconID:                          req.IconID,
+		PrivateInterface:                privateInterface,
+		StaticRoutes:                    req.StaticRoutes,
+		SIMRoutes:                       simRoutes,
+		InternetConnectionEnabled:       req.InternetConnectionEnabled,
+		InterDeviceCommunicationEnabled: req.InterDeviceCommunicationEnabled,
+		DNS:                             req.DNS,
+		SIMs:                            sims,
+		TrafficConfig:                   req.TrafficConfig,
+		SettingsHash:                    req.SettingsHash,
+		NoWait:                          req.NoWait,
+		SetupOptions:                    &builder.RetryableSetupParameter{BootAfterBuild: req.BootAfterCreate},
+		Client:                          mobileGatewayBuilder.NewAPIClient(caller),
+	}
 }

--- a/v2/helper/service/mobilegateway/apply_service.go
+++ b/v2/helper/service/mobilegateway/apply_service.go
@@ -17,8 +17,6 @@ package mobilegateway
 import (
 	"context"
 
-	mobileGatewayBuilder "github.com/sacloud/libsacloud/v2/helper/builder/mobilegateway"
-	"github.com/sacloud/libsacloud/v2/helper/service"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 )
 
@@ -31,12 +29,7 @@ func (s *Service) ApplyWithContext(ctx context.Context, req *ApplyRequest) (*sac
 		return nil, err
 	}
 
-	builder := &mobileGatewayBuilder.Builder{}
-	if err := service.RequestConvertTo(req, builder); err != nil {
-		return nil, err
-	}
-	builder.Client = mobileGatewayBuilder.NewAPIClient(s.caller)
-
+	builder := req.Builder(s.caller)
 	if err := builder.Validate(ctx, req.Zone); err != nil {
 		return nil, err
 	}

--- a/v2/helper/service/mobilegateway/create_request.go
+++ b/v2/helper/service/mobilegateway/create_request.go
@@ -15,15 +15,13 @@
 package mobilegateway
 
 import (
-	mobileGatewayBuilder "github.com/sacloud/libsacloud/v2/helper/builder/mobilegateway"
-	"github.com/sacloud/libsacloud/v2/helper/service"
 	"github.com/sacloud/libsacloud/v2/helper/validate"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
 type CreateRequest struct {
-	Zone string `request:"-" validate:"required"`
+	Zone string `validate:"required"`
 
 	Name                            string `validate:"required"`
 	Description                     string `validate:"min=0,max=512"`
@@ -31,24 +29,37 @@ type CreateRequest struct {
 	IconID                          types.ID
 	PrivateInterface                *PrivateInterfaceSetting `validate:"omitempty"`
 	StaticRoutes                    []*sacloud.MobileGatewayStaticRoute
-	SimRoutes                       []*SIMRouteSetting
+	SIMRoutes                       []*SIMRouteSetting
 	InternetConnectionEnabled       bool
 	InterDeviceCommunicationEnabled bool
 	DNS                             *sacloud.MobileGatewayDNSSetting
 	SIMs                            []*SIMSetting
 	TrafficConfig                   *sacloud.MobileGatewayTrafficControl
 
-	NoWait bool
+	NoWait          bool
+	BootAfterCreate bool
 }
 
 func (req *CreateRequest) Validate() error {
 	return validate.Struct(req)
 }
 
-func (req *CreateRequest) Builder(caller sacloud.APICaller) (*mobileGatewayBuilder.Builder, error) {
-	builder := &mobileGatewayBuilder.Builder{Client: mobileGatewayBuilder.NewAPIClient(caller)}
-	if err := service.RequestConvertTo(req, builder); err != nil {
-		return nil, err
+func (req *CreateRequest) ApplyRequest() *ApplyRequest {
+	return &ApplyRequest{
+		Zone:                            req.Zone,
+		Name:                            req.Name,
+		Description:                     req.Description,
+		Tags:                            req.Tags,
+		IconID:                          req.IconID,
+		PrivateInterface:                req.PrivateInterface,
+		StaticRoutes:                    req.StaticRoutes,
+		SIMRoutes:                       req.SIMRoutes,
+		InternetConnectionEnabled:       req.InternetConnectionEnabled,
+		InterDeviceCommunicationEnabled: req.InterDeviceCommunicationEnabled,
+		DNS:                             req.DNS,
+		SIMs:                            req.SIMs,
+		TrafficConfig:                   req.TrafficConfig,
+		NoWait:                          req.NoWait,
+		BootAfterCreate:                 req.BootAfterCreate,
 	}
-	return builder, nil
 }

--- a/v2/helper/service/mobilegateway/create_service.go
+++ b/v2/helper/service/mobilegateway/create_service.go
@@ -28,10 +28,5 @@ func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*s
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
-
-	builder, err := req.Builder(s.caller)
-	if err != nil {
-		return nil, err
-	}
-	return builder.Build(ctx, req.Zone)
+	return s.ApplyWithContext(ctx, req.ApplyRequest())
 }

--- a/v2/helper/service/mobilegateway/create_test.go
+++ b/v2/helper/service/mobilegateway/create_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	mobileGatewayBuilder "github.com/sacloud/libsacloud/v2/helper/builder/mobilegateway"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -44,7 +43,7 @@ func TestMobileGatewayService_convertCreateRequest(t *testing.T) {
 	// test
 	cases := []struct {
 		in     *CreateRequest
-		expect *mobileGatewayBuilder.Builder
+		expect *ApplyRequest
 	}{
 		{
 			in: &CreateRequest{
@@ -76,13 +75,15 @@ func TestMobileGatewayService_convertCreateRequest(t *testing.T) {
 					EmailNotifyEnabled:   true,
 					AutoTrafficShaping:   true,
 				},
-				NoWait: true,
+				NoWait:          false,
+				BootAfterCreate: true,
 			},
-			expect: &mobileGatewayBuilder.Builder{
+			expect: &ApplyRequest{
+				Zone:        zone,
 				Name:        name,
 				Description: "description",
 				Tags:        types.Tags{"tag1", "tag2"},
-				PrivateInterface: &mobileGatewayBuilder.PrivateInterfaceSetting{
+				PrivateInterface: &PrivateInterfaceSetting{
 					SwitchID:       sw.ID,
 					IPAddress:      "192.168.0.1",
 					NetworkMaskLen: 24,
@@ -106,16 +107,13 @@ func TestMobileGatewayService_convertCreateRequest(t *testing.T) {
 					EmailNotifyEnabled:   true,
 					AutoTrafficShaping:   true,
 				},
-				NoWait:       true,
-				SetupOptions: nil,
-				Client:       mobileGatewayBuilder.NewAPIClient(caller),
+				NoWait:          false,
+				BootAfterCreate: true,
 			},
 		},
 	}
 
 	for _, tc := range cases {
-		builder, err := tc.in.Builder(caller)
-		require.NoError(t, err)
-		require.EqualValues(t, tc.expect, builder)
+		require.EqualValues(t, tc.expect, tc.in.ApplyRequest())
 	}
 }

--- a/v2/helper/service/mobilegateway/update_request.go
+++ b/v2/helper/service/mobilegateway/update_request.go
@@ -17,7 +17,6 @@ package mobilegateway
 import (
 	"context"
 
-	mobileGatewayBuilder "github.com/sacloud/libsacloud/v2/helper/builder/mobilegateway"
 	"github.com/sacloud/libsacloud/v2/helper/service"
 	"github.com/sacloud/libsacloud/v2/helper/validate"
 	"github.com/sacloud/libsacloud/v2/sacloud"
@@ -34,7 +33,7 @@ type UpdateRequest struct {
 	IconID                          *types.ID                            `request:",omitempty"`
 	PrivateInterface                *PrivateInterfaceSetting             `request:",omitempty"`
 	StaticRoutes                    *[]*sacloud.MobileGatewayStaticRoute `request:",omitempty"`
-	SimRoutes                       *[]*SIMRouteSetting                  `request:",omitempty"`
+	SIMRoutes                       *[]*SIMRouteSetting                  `request:",omitempty"`
 	InternetConnectionEnabled       *bool                                `request:",omitempty"`
 	InterDeviceCommunicationEnabled *bool                                `request:",omitempty"`
 	DNS                             *sacloud.MobileGatewayDNSSetting     `request:",omitempty"`
@@ -49,13 +48,76 @@ func (req *UpdateRequest) Validate() error {
 	return validate.Struct(req)
 }
 
-func (req *UpdateRequest) Builder(ctx context.Context, caller sacloud.APICaller) (*mobileGatewayBuilder.Builder, error) {
-	builder, err := mobileGatewayBuilder.BuilderFromResource(ctx, caller, req.Zone, req.ID)
+func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICaller) (*ApplyRequest, error) {
+	mgwOp := sacloud.NewMobileGatewayOp(caller)
+	current, err := mgwOp.Read(ctx, req.Zone, req.ID)
 	if err != nil {
 		return nil, err
 	}
-	if err := service.RequestConvertTo(req, builder); err != nil {
+
+	var privateInterface *PrivateInterfaceSetting
+	for i, nic := range current.InterfaceSettings {
+		if nic.Index == 1 {
+			privateInterface = &PrivateInterfaceSetting{
+				SwitchID:       current.Interfaces[i].SwitchID,
+				IPAddress:      nic.IPAddress[0],
+				NetworkMaskLen: nic.NetworkMaskLen,
+			}
+		}
+	}
+
+	simRoutes, err := mgwOp.GetSIMRoutes(ctx, req.Zone, req.ID)
+	if err != nil {
 		return nil, err
 	}
-	return builder, nil
+	var simRouteSettings []*SIMRouteSetting
+	for _, r := range simRoutes {
+		simRouteSettings = append(simRouteSettings, &SIMRouteSetting{
+			SIMID:  types.StringID(r.ResourceID),
+			Prefix: r.Prefix,
+		})
+	}
+
+	dns, err := mgwOp.GetDNS(ctx, req.Zone, req.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	sims, err := mgwOp.ListSIM(ctx, req.Zone, req.ID)
+	if err != nil {
+		return nil, err
+	}
+	var simSettings []*SIMSetting
+	for _, s := range sims {
+		simSettings = append(simSettings, &SIMSetting{
+			SIMID:     types.StringID(s.ResourceID),
+			IPAddress: s.IP,
+		})
+	}
+
+	trafficConfig, err := mgwOp.GetTrafficConfig(ctx, req.Zone, req.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	applyRequest := &ApplyRequest{
+		Name:                            current.Name,
+		Description:                     current.Description,
+		Tags:                            current.Tags,
+		IconID:                          current.IconID,
+		PrivateInterface:                privateInterface,
+		StaticRoutes:                    current.StaticRoutes,
+		SIMRoutes:                       simRouteSettings,
+		InternetConnectionEnabled:       current.InternetConnectionEnabled.Bool(),
+		InterDeviceCommunicationEnabled: current.InterDeviceCommunicationEnabled.Bool(),
+		DNS:                             dns,
+		SIMs:                            simSettings,
+		TrafficConfig:                   trafficConfig,
+		SettingsHash:                    current.SettingsHash,
+	}
+
+	if err := service.RequestConvertTo(req, applyRequest); err != nil {
+		return nil, err
+	}
+	return applyRequest, nil
 }

--- a/v2/helper/service/mobilegateway/update_service.go
+++ b/v2/helper/service/mobilegateway/update_service.go
@@ -30,10 +30,9 @@ func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*s
 		return nil, err
 	}
 
-	builder, err := req.Builder(ctx, s.caller)
+	applyRequest, err := req.ApplyRequest(ctx, s.caller)
 	if err != nil {
 		return nil, fmt.Errorf("processing request parameter failed: %s", err)
 	}
-
-	return builder.Update(ctx, req.Zone, req.ID)
+	return s.ApplyWithContext(ctx, applyRequest)
 }

--- a/v2/helper/service/mobilegateway/update_test.go
+++ b/v2/helper/service/mobilegateway/update_test.go
@@ -62,7 +62,7 @@ func TestMobileGatewayService_convertUpdateRequest(t *testing.T) {
 	// test
 	cases := []struct {
 		in     *UpdateRequest
-		expect *mobileGatewayBuilder.Builder
+		expect *ApplyRequest
 	}{
 		{
 			in: &UpdateRequest{
@@ -95,11 +95,13 @@ func TestMobileGatewayService_convertUpdateRequest(t *testing.T) {
 				},
 				NoWait: true,
 			},
-			expect: &mobileGatewayBuilder.Builder{
+			expect: &ApplyRequest{
+				ID:          mgw.ID,
+				Zone:        zone,
 				Name:        name + "-upd",
 				Description: "description",
 				Tags:        types.Tags{"tag1", "tag2"},
-				PrivateInterface: &mobileGatewayBuilder.PrivateInterfaceSetting{
+				PrivateInterface: &PrivateInterfaceSetting{
 					SwitchID:       sw.ID,
 					IPAddress:      "192.168.0.1",
 					NetworkMaskLen: 24,
@@ -124,14 +126,13 @@ func TestMobileGatewayService_convertUpdateRequest(t *testing.T) {
 					AutoTrafficShaping:   true,
 				},
 				NoWait: true,
-				Client: mobileGatewayBuilder.NewAPIClient(caller),
 			},
 		},
 	}
 
 	for _, tc := range cases {
-		builder, err := tc.in.Builder(ctx, caller)
+		req, err := tc.in.ApplyRequest(ctx, caller)
 		require.NoError(t, err)
-		require.EqualValues(t, tc.expect, builder)
+		require.EqualValues(t, tc.expect, req)
 	}
 }

--- a/v2/helper/service/nfs/apply_request.go
+++ b/v2/helper/service/nfs/apply_request.go
@@ -20,8 +20,9 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
-type CreateRequest struct {
-	Zone string `request:"-" validate:"required"`
+type ApplyRequest struct {
+	ID   types.ID // for update
+	Zone string   `request:"-" validate:"required"`
 
 	Name           string `validate:"required"`
 	Description    string `validate:"min=0,max=512"`
@@ -33,15 +34,17 @@ type CreateRequest struct {
 	IPAddresses    []string       `validate:"required,min=1,max=2,dive,ipv4"`
 	NetworkMaskLen int            `validate:"required"`
 	DefaultRoute   string         `validate:"omitempty,ipv4"`
-	NoWait         bool
+
+	NoWait bool
 }
 
-func (req *CreateRequest) Validate() error {
+func (req *ApplyRequest) Validate() error {
 	return validate.Struct(req)
 }
 
-func (req *CreateRequest) Builder(caller sacloud.APICaller) *Builder {
+func (req *ApplyRequest) Builder(caller sacloud.APICaller) *Builder {
 	return &Builder{
+		ID:             req.ID,
 		Zone:           req.Zone,
 		Name:           req.Name,
 		Description:    req.Description,

--- a/v2/helper/service/nfs/apply_service.go
+++ b/v2/helper/service/nfs/apply_service.go
@@ -20,18 +20,15 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud"
 )
 
-func (s *Service) Update(req *UpdateRequest) (*sacloud.NFS, error) {
-	return s.UpdateWithContext(context.Background(), req)
+func (s *Service) Apply(req *ApplyRequest) (*sacloud.NFS, error) {
+	return s.ApplyWithContext(context.Background(), req)
 }
 
-func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*sacloud.NFS, error) {
+func (s *Service) ApplyWithContext(ctx context.Context, req *ApplyRequest) (*sacloud.NFS, error) {
 	if err := req.Validate(); err != nil {
 		return nil, err
 	}
 
-	applyRequest, err := req.ApplyRequest(ctx, s.caller)
-	if err != nil {
-		return nil, err
-	}
-	return s.ApplyWithContext(ctx, applyRequest)
+	builder := req.Builder(s.caller)
+	return builder.Build(ctx)
 }

--- a/v2/helper/service/nfs/apply_test.go
+++ b/v2/helper/service/nfs/apply_test.go
@@ -1,0 +1,70 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nfs
+
+import (
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNFSService_convertApplyRequest(t *testing.T) {
+	caller := testutil.SingletonAPICaller()
+	name := testutil.ResourceName("nfs-service")
+	zone := testutil.TestZone()
+
+	cases := []struct {
+		in     *ApplyRequest
+		expect *Builder
+	}{
+		{
+			in: &ApplyRequest{
+				ID:             101,
+				Zone:           zone,
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				SwitchID:       102,
+				Plan:           types.NFSPlans.SSD,
+				Size:           100,
+				IPAddresses:    []string{"192.168.0.101"},
+				NetworkMaskLen: 24,
+				DefaultRoute:   "192.168.0.1",
+				NoWait:         true,
+			},
+			expect: &Builder{
+				ID:             101,
+				Zone:           zone,
+				Name:           name,
+				Description:    "desc",
+				Tags:           types.Tags{"tag1", "tag2"},
+				SwitchID:       102,
+				Plan:           types.NFSPlans.SSD,
+				Size:           100,
+				IPAddresses:    []string{"192.168.0.101"},
+				NetworkMaskLen: 24,
+				DefaultRoute:   "192.168.0.1",
+				NoWait:         true,
+				Caller:         caller,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		require.EqualValues(t, tc.expect, tc.in.Builder(caller))
+	}
+}

--- a/v2/helper/service/nfs/builder.go
+++ b/v2/helper/service/nfs/builder.go
@@ -47,36 +47,6 @@ type Builder struct {
 	NoWait bool
 }
 
-func BuilderFromResource(ctx context.Context, caller sacloud.APICaller, zone string, id types.ID) (*Builder, error) {
-	client := sacloud.NewNFSOp(caller)
-	current, err := client.Read(ctx, zone, id)
-	if err != nil {
-		return nil, err
-	}
-
-	// find plan
-	plan, err := query.GetNFSPlanInfo(ctx, sacloud.NewNoteOp(caller), current.PlanID)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Builder{
-		ID:             current.ID,
-		Zone:           zone,
-		Name:           current.Name,
-		Description:    current.Description,
-		Tags:           current.Tags,
-		IconID:         current.IconID,
-		SwitchID:       current.SwitchID,
-		Plan:           plan.DiskPlanID,
-		Size:           plan.Size,
-		IPAddresses:    current.IPAddresses,
-		NetworkMaskLen: current.NetworkMaskLen,
-		DefaultRoute:   current.DefaultRoute,
-		Caller:         caller,
-	}, nil
-}
-
 func (b *Builder) Build(ctx context.Context) (*sacloud.NFS, error) {
 	if b.ID.IsEmpty() {
 		return b.create(ctx)

--- a/v2/helper/service/nfs/update_test.go
+++ b/v2/helper/service/nfs/update_test.go
@@ -1,0 +1,99 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nfs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/helper/wait"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/pointer"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNFSService_convertUpdateRequest(t *testing.T) {
+	ctx := context.Background()
+	caller := testutil.SingletonAPICaller()
+	name := testutil.ResourceName("nfs-service")
+	zone := testutil.TestZone()
+
+	// setup
+	swOp := sacloud.NewSwitchOp(caller)
+	sw, err := swOp.Create(ctx, zone, &sacloud.SwitchCreateRequest{Name: name})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	current, err := New(caller).CreateWithContext(ctx, &CreateRequest{
+		Zone:           zone,
+		Name:           name,
+		Description:    "desc",
+		Tags:           types.Tags{"tag1", "tag2"},
+		SwitchID:       sw.ID,
+		Plan:           types.NFSPlans.SSD,
+		Size:           100,
+		IPAddresses:    []string{"192.168.0.101"},
+		NetworkMaskLen: 24,
+		DefaultRoute:   "192.168.0.1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		nfsOp := sacloud.NewNFSOp(caller)
+		nfsOp.Shutdown(ctx, zone, current.ID, &sacloud.ShutdownOption{Force: true}) // nolint
+		wait.UntilNFSIsDown(ctx, nfsOp, zone, current.ID)                           // nolint
+		nfsOp.Delete(ctx, zone, current.ID)                                         // nolint
+		swOp.Delete(ctx, zone, sw.ID)                                               // nolint
+	}()
+
+	// test
+	cases := []struct {
+		in     *UpdateRequest
+		expect *ApplyRequest
+	}{
+		{
+			in: &UpdateRequest{
+				Zone: zone,
+				ID:   current.ID,
+				Name: pointer.NewString(current.Name + "-upd"),
+			},
+			expect: &ApplyRequest{
+				ID:             current.ID,
+				Zone:           zone,
+				Name:           current.Name + "-upd",
+				Description:    current.Description,
+				Tags:           current.Tags,
+				IconID:         current.IconID,
+				SwitchID:       current.SwitchID,
+				Plan:           types.NFSPlans.SSD,
+				Size:           100,
+				IPAddresses:    current.IPAddresses,
+				NetworkMaskLen: current.NetworkMaskLen,
+				DefaultRoute:   current.DefaultRoute,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		req, err := tc.in.ApplyRequest(ctx, caller)
+		require.NoError(t, err)
+		require.EqualValues(t, tc.expect, req)
+	}
+}

--- a/v2/helper/service/server/update_request.go
+++ b/v2/helper/service/server/update_request.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sacloud/libsacloud/v2/helper/service"
 	diskService "github.com/sacloud/libsacloud/v2/helper/service/disk"
@@ -64,6 +65,9 @@ func (req *UpdateRequest) applyRequestFromResource(ctx context.Context, caller s
 	current, err := serverOp.Read(ctx, req.Zone, req.ID)
 	if err != nil {
 		return nil, err
+	}
+	if current.Availability != types.Availabilities.Available {
+		return nil, fmt.Errorf("target has invalid Availability: Zone=%s ID=%s Availability=%v", req.Zone, req.ID.String(), current.Availability)
 	}
 
 	var nics []*NetworkInterface

--- a/v2/helper/service/server/update_test.go
+++ b/v2/helper/service/server/update_test.go
@@ -70,10 +70,10 @@ func TestServerService_convertUpdateRequest(t *testing.T) {
 				DiskPlanID:  types.DiskPlans.SSD,
 				Connection:  types.DiskConnections.VirtIO,
 				SizeGB:      20,
-				NoWait:      true,
+				NoWait:      false,
 			},
 		},
-		NoWait: true,
+		NoWait: false,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/v2/helper/service/sim/apply_request.go
+++ b/v2/helper/service/sim/apply_request.go
@@ -27,7 +27,7 @@ type ApplyRequest struct {
 	Tags        types.Tags
 	IconID      types.ID
 	ICCID       string `validate:"required"`
-	PassCode    string `validate:"required"`
+	PassCode    string // Update時などは空になるためrequiredをはずしておく
 	Activate    bool
 	IMEI        string
 	Carriers    []*sacloud.SIMNetworkOperatorConfig

--- a/v2/helper/service/sim/create_request.go
+++ b/v2/helper/service/sim/create_request.go
@@ -15,7 +15,6 @@
 package sim
 
 import (
-	"github.com/sacloud/libsacloud/v2/helper/service"
 	"github.com/sacloud/libsacloud/v2/helper/validate"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -28,16 +27,26 @@ type CreateRequest struct {
 	IconID      types.ID
 	ICCID       string `validate:"required"`
 	PassCode    string `validate:"required"`
+
+	Activate bool
+	IMEI     string
+	Carriers []*sacloud.SIMNetworkOperatorConfig
 }
 
 func (req *CreateRequest) Validate() error {
 	return validate.Struct(req)
 }
 
-func (req *CreateRequest) ToRequestParameter() (*sacloud.SIMCreateRequest, error) {
-	params := &sacloud.SIMCreateRequest{}
-	if err := service.RequestConvertTo(req, params); err != nil {
-		return nil, err
+func (req *CreateRequest) ApplyRequest() *ApplyRequest {
+	return &ApplyRequest{
+		Name:        req.Name,
+		Description: req.Description,
+		Tags:        req.Tags,
+		IconID:      req.IconID,
+		ICCID:       req.ICCID,
+		PassCode:    req.PassCode,
+		Activate:    req.Activate,
+		IMEI:        req.IMEI,
+		Carriers:    req.Carriers,
 	}
-	return params, nil
 }

--- a/v2/helper/service/sim/create_service.go
+++ b/v2/helper/service/sim/create_service.go
@@ -17,7 +17,6 @@ package sim
 import (
 	"context"
 
-	"github.com/sacloud/libsacloud/v2/helper/query"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 )
 
@@ -30,15 +29,5 @@ func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*s
 		return nil, err
 	}
 
-	params, err := req.ToRequestParameter()
-	if err != nil {
-		return nil, err
-	}
-
-	client := sacloud.NewSIMOp(s.caller)
-	created, err := client.Create(ctx, params)
-	if err != nil {
-		return created, err
-	}
-	return query.FindSIMByID(ctx, client, created.ID)
+	return s.ApplyWithContext(ctx, req.ApplyRequest())
 }

--- a/v2/helper/service/sim/service_test.go
+++ b/v2/helper/service/sim/service_test.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/pointer"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
@@ -42,6 +44,9 @@ func TestSIMService_CRUD(t *testing.T) {
 					Name:     name,
 					ICCID:    iccid,
 					PassCode: passcode,
+					Carriers: []*sacloud.SIMNetworkOperatorConfig{
+						{Allow: true, Name: types.SIMOperators.SoftBank.String()},
+					},
 				})
 			},
 			CheckFunc: func(t testutil.TestT, ctx *testutil.CRUDTestContext, v interface{}) error {

--- a/v2/helper/service/sim/update_service.go
+++ b/v2/helper/service/sim/update_service.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sacloud/libsacloud/v2/helper/query"
 	"github.com/sacloud/libsacloud/v2/sacloud"
 )
 
@@ -31,20 +30,9 @@ func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*s
 		return nil, err
 	}
 
-	client := sacloud.NewSIMOp(s.caller)
-	current, err := client.Read(ctx, req.ID)
-	if err != nil {
-		return nil, fmt.Errorf("reading SIM[%s] failed: %s", req.ID, err)
-	}
-
-	params, err := req.ToRequestParameter(current)
+	applyRequest, err := req.ApplyRequest(ctx, s.caller)
 	if err != nil {
 		return nil, fmt.Errorf("processing request parameter failed: %s", err)
 	}
-
-	updated, err := client.Update(ctx, req.ID, params)
-	if err != nil {
-		return updated, err
-	}
-	return query.FindSIMByID(ctx, client, updated.ID)
+	return s.ApplyWithContext(ctx, applyRequest)
 }

--- a/v2/helper/service/sim/update_test.go
+++ b/v2/helper/service/sim/update_test.go
@@ -1,0 +1,99 @@
+// Copyright 2016-2020 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sacloud/libsacloud/v2/helper/cleanup"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/pointer"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSIMService_convertUpdateRequest(t *testing.T) {
+	ctx := context.Background()
+	caller := testutil.SingletonAPICaller()
+	name := testutil.ResourceName("sim-service")
+
+	// setup
+	simOp := sacloud.NewSIMOp(caller)
+	sim, err := New(caller).CreateWithContext(ctx, &CreateRequest{
+		Name:        name,
+		Description: "desc",
+		Tags:        types.Tags{"tag1", "tag2"},
+		ICCID:       "aaaaaaaa",
+		PassCode:    "bbbbbbbb",
+		Activate:    true,
+		IMEI:        "cccccccc",
+		Carriers: []*sacloud.SIMNetworkOperatorConfig{
+			{
+				Allow: true,
+				Name:  types.SIMOperators.Docomo.String(),
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		cleanup.DeleteSIM(ctx, simOp, sim.ID) // nolint
+	}()
+
+	// test
+	cases := []struct {
+		in     *UpdateRequest
+		expect *ApplyRequest
+	}{
+		{
+			in: &UpdateRequest{
+				ID:       sim.ID,
+				Name:     pointer.NewString(name + "-upd"),
+				Activate: pointer.NewBool(false),
+				IMEI:     pointer.NewString(""),
+				Carriers: &[]*sacloud.SIMNetworkOperatorConfig{
+					{Allow: true, Name: types.SIMOperators.SoftBank.String()},
+				},
+			},
+			expect: &ApplyRequest{
+				ID:          sim.ID,
+				Name:        name + "-upd",
+				Description: sim.Description,
+				Tags:        sim.Tags,
+				IconID:      sim.IconID,
+				ICCID:       sim.ICCID,
+				PassCode:    "",
+				Activate:    false,
+				IMEI:        "",
+				Carriers: []*sacloud.SIMNetworkOperatorConfig{
+					{
+						Allow: true,
+						Name:  types.SIMOperators.SoftBank.String(),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		req, err := tc.in.ApplyRequest(ctx, caller)
+		require.NoError(t, err)
+		require.EqualValues(t, tc.expect, req)
+	}
+}

--- a/v2/helper/service/vpcrouter/update_request.go
+++ b/v2/helper/service/vpcrouter/update_request.go
@@ -52,10 +52,10 @@ func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICa
 	}
 
 	if current.PlanID == types.VPCRouterPlans.Standard {
-		return nil, fmt.Errorf("target VPCRouter(Zone=%s ID=%q) is not a premium or higher plan", req.Zone, req.ID)
+		return nil, fmt.Errorf("target is not a premium or higher plan: Zone=%s ID=%s", req.Zone, req.ID)
 	}
 	if current.Availability != types.Availabilities.Available {
-		return nil, fmt.Errorf("target VPCRouter has invalid Availability: %v", current.Availability)
+		return nil, fmt.Errorf("target has invalid Availability: Zone=%s ID=%s Availability=%v", req.Zone, req.ID.String(), current.Availability)
 	}
 
 	var additionalNICs []AdditionalNICSettingHolder

--- a/v2/helper/service/vpcrouter/update_standard_request.go
+++ b/v2/helper/service/vpcrouter/update_standard_request.go
@@ -51,10 +51,10 @@ func (req *UpdateStandardRequest) ApplyRequest(ctx context.Context, caller saclo
 	}
 
 	if current.PlanID != types.VPCRouterPlans.Standard {
-		return nil, fmt.Errorf("target VPCRouter(Zone=%s ID=%q) is not a standard plan", req.Zone, req.ID)
+		return nil, fmt.Errorf("target is not a standard plan: Zone=%s ID=%s", req.Zone, req.ID)
 	}
 	if current.Availability != types.Availabilities.Available {
-		return nil, fmt.Errorf("target VPCRouter has invalid Availability: %v", current.Availability)
+		return nil, fmt.Errorf("target has invalid Availability: Zone=%s ID=%s Availability=%v", req.Zone, req.ID.String(), current.Availability)
 	}
 
 	var additionalNICs []AdditionalNICSettingHolder

--- a/v2/sacloud/fake/ops_disk.go
+++ b/v2/sacloud/fake/ops_disk.go
@@ -45,6 +45,7 @@ func (o *DiskOp) Create(ctx context.Context, zone string, param *sacloud.DiskCre
 	result := &sacloud.Disk{}
 	copySameNameField(param, result)
 	fill(result, fillID, fillCreatedAt, fillDiskPlan)
+	result.Availability = types.Availabilities.Migrating
 
 	result.Storage = &sacloud.Storage{
 		ID:   types.ID(123456789012),

--- a/v2/sacloud/fake/ops_server.go
+++ b/v2/sacloud/fake/ops_server.go
@@ -143,6 +143,7 @@ func (o *ServerOp) Create(ctx context.Context, zone string, param *sacloud.Serve
 		}
 	}
 
+	result.Availability = types.Availabilities.Available
 	putServer(zone, result)
 	return result, nil
 }


### PR DESCRIPTION
#673 の後続PR

- データベースとディスクのサービスのCreate/Updateを他のサービスと同じくApplyを直接呼び出す形に修正
- コンテナレジストリのサービスのCreate/Updateを他のサービスと同じくApplyを直接呼び出す形に修正
- ロードバランサのサービスのCreate/Updateを他のサービスと同じくApplyを直接呼び出す形に修正
- ロードバランササービスに`NoWait`を追加
- NFSサービスに`NoWait`を追加、Applyを追加しCreate/Updateを他のサービスと同じくApplyを直接呼び出す形に修正
- 各リソースのUpdate時に`Availability`をチェックする
- モバイルゲートウェイサービスのCreate/Updateを他のサービスと同じくApplyを直接呼び出す形に修正