### PR TITLE
Fixes database service validations

### DIFF
--- a/v2/helper/service/database/apply_request.go
+++ b/v2/helper/service/database/apply_request.go
@@ -37,7 +37,7 @@ type ApplyRequest struct {
 	DefaultRoute          string   `validate:"omitempty,ipv4"`
 	Port                  int      `validate:"omitempty,min=1,max=65535"`
 	SourceNetwork         []string `validate:"dive,cidrv4"`
-	DatabaseType          string   `validate:"required,oneof=mariadb postgresql"`
+	DatabaseType          string   `validate:"required,oneof=mariadb postgres"`
 	Username              string   `validate:"required"`
 	Password              string   `validate:"required"`
 	EnableReplication     bool

--- a/v2/helper/service/database/builder.go
+++ b/v2/helper/service/database/builder.go
@@ -43,7 +43,7 @@ type Builder struct {
 	DefaultRoute          string   `validate:"omitempty,ipv4"`
 	Port                  int      `validate:"omitempty,min=1,max=65535"`
 	SourceNetwork         []string `validate:"omitempty,dive,cidrv4"`
-	DatabaseType          string   `validate:"required,oneof=mariadb postgresql"`
+	DatabaseType          string   `validate:"required,oneof=mariadb postgres"`
 	Username              string   `validate:"required"`
 	Password              string   `validate:"required"`
 	EnableReplication     bool
@@ -129,9 +129,9 @@ func (b *Builder) actualBuilder() *databaseBuilder.Builder {
 		NetworkMaskLen: b.NetworkMaskLen,
 		DefaultRoute:   b.DefaultRoute,
 		Conf: &sacloud.DatabaseRemarkDBConfCommon{
-			DatabaseName:     types.RDBMSVersions[types.RDBMSType(b.DatabaseType)].Name,
-			DatabaseVersion:  types.RDBMSVersions[types.RDBMSType(b.DatabaseType)].Version,
-			DatabaseRevision: types.RDBMSVersions[types.RDBMSType(b.DatabaseType)].Revision,
+			DatabaseName:     types.RDBMSVersions[types.RDBMSTypeFromString(b.DatabaseType)].Name,
+			DatabaseVersion:  types.RDBMSVersions[types.RDBMSTypeFromString(b.DatabaseType)].Version,
+			DatabaseRevision: types.RDBMSVersions[types.RDBMSTypeFromString(b.DatabaseType)].Revision,
 		},
 		CommonSetting: &sacloud.DatabaseSettingCommon{
 			WebUI:           types.ToWebUI(b.EnableWebUI),

--- a/v2/helper/service/database/create_request.go
+++ b/v2/helper/service/database/create_request.go
@@ -33,7 +33,7 @@ type CreateRequest struct {
 	DefaultRoute          string   `validate:"omitempty,ipv4"`
 	Port                  int      `validate:"omitempty,min=1,max=65535"`
 	SourceNetwork         []string `validate:"omitempty,dive,cidrv4"`
-	DatabaseType          string   `validate:"required,oneof=mariadb postgresql"`
+	DatabaseType          string   `validate:"required,oneof=mariadb postgres"`
 	Username              string   `validate:"required"`
 	Password              string   `validate:"required"`
 	EnableReplication     bool

--- a/v2/helper/service/database/update_request.go
+++ b/v2/helper/service/database/update_request.go
@@ -38,10 +38,10 @@ type UpdateRequest struct {
 
 	SourceNetwork         *[]string                   `request:",omitempty" validate:"omitempty,dive,cidrv4"`
 	EnableReplication     *bool                       `request:",omitempty"`
-	ReplicaUserPassword   *string                     `request:",omitempty" validate:"required_with=EnableReplication"`
+	ReplicaUserPassword   *string                     `request:",omitempty" validate:"omitempty,required_with=EnableReplication"`
 	EnableWebUI           *bool                       `request:",omitempty"`
 	EnableBackup          *bool                       `request:",omitempty"`
-	BackupWeekdays        *[]types.EBackupSpanWeekday `request:",omitempty" validate:"required_with=EnableBackup,max=7"`
+	BackupWeekdays        *[]types.EBackupSpanWeekday `request:",omitempty" validate:"omitempty,required_with=EnableBackup,max=7"`
 	BackupStartTimeHour   *int                        `request:",omitempty" validate:"omitempty,min=0,max=23"`
 	BackupStartTimeMinute *int                        `request:",omitempty" validate:"omitempty,oneof=0 15 30 45"`
 

--- a/v2/sacloud/types/database_version.go
+++ b/v2/sacloud/types/database_version.go
@@ -60,8 +60,12 @@ var RDBMSTypeStrings = []string{
 
 // RDBMSTypeFromString 文字列からRDBMSTypeを取得
 func RDBMSTypeFromString(s string) RDBMSType {
-	if s == strings.ToLower(RDBMSTypesMariaDB.String()) {
+	switch {
+	case s == strings.ToLower(RDBMSTypesMariaDB.String()):
 		return RDBMSTypesMariaDB
+	case strings.ToLower(s) == "postgresql":
+		return RDBMSTypesPostgreSQL
+	default:
+		return RDBMSType(s)
 	}
-	return RDBMSType(s)
 }


### PR DESCRIPTION
データベースサービス関連のバリデーションを修正

- `types.RDBMSType`で`postgresql`と`postgres`両方を許容するように
- ポインタ型フィールドでのタグバリデーションに`omitempty`を付与