### PR TITLE
Improve MobileGateway service - supports partial updates

### DIFF
--- a/v2/helper/service/mobilegateway/apply_service.go
+++ b/v2/helper/service/mobilegateway/apply_service.go
@@ -29,7 +29,11 @@ func (s *Service) ApplyWithContext(ctx context.Context, req *ApplyRequest) (*sac
 		return nil, err
 	}
 
-	builder := req.Builder(s.caller)
+	builder, err := req.Builder(s.caller)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := builder.Validate(ctx, req.Zone); err != nil {
 		return nil, err
 	}

--- a/v2/helper/service/mobilegateway/create_request.go
+++ b/v2/helper/service/mobilegateway/create_request.go
@@ -32,9 +32,9 @@ type CreateRequest struct {
 	SIMRoutes                       []*SIMRouteSetting
 	InternetConnectionEnabled       bool
 	InterDeviceCommunicationEnabled bool
-	DNS                             *sacloud.MobileGatewayDNSSetting
+	DNS                             *DNSSetting
 	SIMs                            []*SIMSetting
-	TrafficConfig                   *sacloud.MobileGatewayTrafficControl
+	TrafficConfig                   *TrafficConfig
 
 	NoWait          bool
 	BootAfterCreate bool

--- a/v2/helper/service/mobilegateway/create_test.go
+++ b/v2/helper/service/mobilegateway/create_test.go
@@ -64,12 +64,12 @@ func TestMobileGatewayService_convertCreateRequest(t *testing.T) {
 				},
 				InternetConnectionEnabled:       true,
 				InterDeviceCommunicationEnabled: true,
-				DNS: &sacloud.MobileGatewayDNSSetting{
+				DNS: &DNSSetting{
 					DNS1: "8.8.8.8",
 					DNS2: "8.8.4.4",
 				},
 				SIMs: nil,
-				TrafficConfig: &sacloud.MobileGatewayTrafficControl{
+				TrafficConfig: &TrafficConfig{
 					TrafficQuotaInMB:     10,
 					BandWidthLimitInKbps: 128,
 					EmailNotifyEnabled:   true,
@@ -96,12 +96,12 @@ func TestMobileGatewayService_convertCreateRequest(t *testing.T) {
 				},
 				InternetConnectionEnabled:       true,
 				InterDeviceCommunicationEnabled: true,
-				DNS: &sacloud.MobileGatewayDNSSetting{
+				DNS: &DNSSetting{
 					DNS1: "8.8.8.8",
 					DNS2: "8.8.4.4",
 				},
 				SIMs: nil,
-				TrafficConfig: &sacloud.MobileGatewayTrafficControl{
+				TrafficConfig: &TrafficConfig{
 					TrafficQuotaInMB:     10,
 					BandWidthLimitInKbps: 128,
 					EmailNotifyEnabled:   true,

--- a/v2/helper/service/mobilegateway/update_request.go
+++ b/v2/helper/service/mobilegateway/update_request.go
@@ -31,17 +31,38 @@ type UpdateRequest struct {
 	Description                     *string                              `request:",omitempty" validate:"omitempty,min=0,max=512"`
 	Tags                            *types.Tags                          `request:",omitempty"`
 	IconID                          *types.ID                            `request:",omitempty"`
-	PrivateInterface                *PrivateInterfaceSetting             `request:",omitempty"`
+	PrivateInterface                *PrivateInterfaceSettingUpdate       `request:",omitempty,recursive"`
 	StaticRoutes                    *[]*sacloud.MobileGatewayStaticRoute `request:",omitempty"`
 	SIMRoutes                       *[]*SIMRouteSetting                  `request:",omitempty"`
 	InternetConnectionEnabled       *bool                                `request:",omitempty"`
 	InterDeviceCommunicationEnabled *bool                                `request:",omitempty"`
-	DNS                             *sacloud.MobileGatewayDNSSetting     `request:",omitempty"`
+	DNS                             *DNSSettingUpdate                    `request:",omitempty,recursive"`
 	SIMs                            *[]*SIMSetting                       `request:",omitempty"`
-	TrafficConfig                   *sacloud.MobileGatewayTrafficControl `request:",omitempty"`
+	TrafficConfig                   *TrafficConfigUpdate                 `request:",omitempty,recursice"`
 
 	SettingsHash string
 	NoWait       bool
+}
+
+// PrivateInterfaceSetting represents API parameter/response structure
+type PrivateInterfaceSettingUpdate struct {
+	SwitchID       *types.ID `request:",omitempty"`
+	IPAddress      *string   `request:",omitempty" validate:"omitempty,ipv4"`
+	NetworkMaskLen *int      `request:",omitempty"`
+}
+
+type DNSSettingUpdate struct {
+	DNS1 *string `request:",omitempty" validate:"required_with=DNS2,omitempty,ipv4"`
+	DNS2 *string `request:",omitempty" validate:"required_with=DNS1,omitempty,ipv4"`
+}
+
+type TrafficConfigUpdate struct {
+	TrafficQuotaInMB       *int    `request:",omitempty"`
+	BandWidthLimitInKbps   *int    `request:",omitempty"`
+	EmailNotifyEnabled     *bool   `request:",omitempty"`
+	SlackNotifyEnabled     *bool   `request:",omitempty"`
+	SlackNotifyWebhooksURL *string `request:",omitempty"`
+	AutoTrafficShaping     *bool   `request:",omitempty"`
 }
 
 func (req *UpdateRequest) Validate() error {
@@ -56,10 +77,10 @@ func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICa
 	}
 
 	var privateInterface *PrivateInterfaceSetting
-	for i, nic := range current.InterfaceSettings {
-		if nic.Index == 1 {
+	for _, nic := range current.InterfaceSettings {
+		if nic.Index == 1 && len(current.Interfaces) > 1 {
 			privateInterface = &PrivateInterfaceSetting{
-				SwitchID:       current.Interfaces[i].SwitchID,
+				SwitchID:       current.Interfaces[nic.Index].SwitchID,
 				IPAddress:      nic.IPAddress[0],
 				NetworkMaskLen: nic.NetworkMaskLen,
 			}
@@ -78,9 +99,16 @@ func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICa
 		})
 	}
 
-	dns, err := mgwOp.GetDNS(ctx, req.Zone, req.ID)
+	currentDNS, err := mgwOp.GetDNS(ctx, req.Zone, req.ID)
 	if err != nil {
 		return nil, err
+	}
+	var dns *DNSSetting
+	if currentDNS != nil {
+		dns = &DNSSetting{
+			DNS1: currentDNS.DNS1,
+			DNS2: currentDNS.DNS2,
+		}
 	}
 
 	sims, err := mgwOp.ListSIM(ctx, req.Zone, req.ID)
@@ -95,9 +123,16 @@ func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICa
 		})
 	}
 
-	trafficConfig, err := mgwOp.GetTrafficConfig(ctx, req.Zone, req.ID)
+	currentTrafficConfig, err := mgwOp.GetTrafficConfig(ctx, req.Zone, req.ID)
 	if err != nil {
 		return nil, err
+	}
+	var trafficConfig *TrafficConfig
+	if currentTrafficConfig != nil {
+		trafficConfig = &TrafficConfig{}
+		if err := service.RequestConvertTo(currentTrafficConfig, trafficConfig); err != nil {
+			return nil, err
+		}
 	}
 
 	applyRequest := &ApplyRequest{


### PR DESCRIPTION
related: #684 

更新時のネストされたパラメータの部分更新をサポートする。

---

例えばモバイルゲートウェイのプライベート側インターフェース設定は以下のパラメータを受け取る。

```go
type PrivateInterfaceSetting struct {
	SwitchID       types.ID `request:",omitempty"`
	IPAddress      string   `request:",omitempty" validate:"required,ipv4"`
	NetworkMaskLen int      `request:",omitempty"`
}
```

このうち、更新時にスイッチは接続したままIPアドレスだけ更新したいケースがある。
このケースに対応するため、#684 で指定されたパラメータのみ既存の値を上書きできるように、更新時のみ各フィールドをポインタ型にしたパラメータの型を追加して対応する。

```go
type PrivateInterfaceSettingUpdate struct {
	SwitchID       *types.ID `request:",omitempty"`
	IPAddress      *string   `request:",omitempty" validate:"omitempty,ipv4"`
	NetworkMaskLen *int      `request:",omitempty"`
}
```