### PR TITLE
Remove validate tags from models

### DIFF
--- a/v2/internal/define/dns.go
+++ b/v2/internal/define/dns.go
@@ -99,8 +99,7 @@ var (
 				Name: "Name",
 				Type: meta.TypeString,
 				Tags: &dsl.FieldTags{
-					Validate: "required",
-					MapConv:  "Name/Status.Zone", // NameとStatus.Zone2箇所に同じ値を設定
+					MapConv: "Name/Status.Zone", // NameとStatus.Zone2箇所に同じ値を設定
 				},
 			},
 

--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -81,9 +81,6 @@ func (f *fieldsDef) Name() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "Name",
 		Type: meta.TypeString,
-		Tags: &dsl.FieldTags{
-			Validate: "required",
-		},
 	}
 }
 
@@ -605,8 +602,7 @@ func (f *fieldsDef) ApplianceIPAddresses() *dsl.FieldDesc {
 		Name: "IPAddresses",
 		Type: meta.TypeStringSlice,
 		Tags: &dsl.FieldTags{
-			MapConv:  "Remark.[]Servers.IPAddress",
-			Validate: "min=1,max=2,dive,ipv4",
+			MapConv: "Remark.[]Servers.IPAddress",
 		},
 	}
 }
@@ -615,9 +611,6 @@ func (f *fieldsDef) LoadBalancerVIPPort() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "Port",
 		Type: meta.TypeStringNumber,
-		Tags: &dsl.FieldTags{
-			Validate: "min=1,max=65535",
-		},
 	}
 }
 
@@ -626,8 +619,7 @@ func (f *fieldsDef) LoadBalancerVIPDelayLoop() *dsl.FieldDesc {
 		Name: "DelayLoop",
 		Type: meta.TypeStringNumber,
 		Tags: &dsl.FieldTags{
-			Validate: "min=0,max=10000",
-			MapConv:  ",default=10",
+			MapConv: ",default=10",
 		},
 		DefaultValue: "10",
 	}
@@ -637,9 +629,6 @@ func (f *fieldsDef) LoadBalancerVIPSorryServer() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "SorryServer",
 		Type: meta.TypeString,
-		Tags: &dsl.FieldTags{
-			Validate: "omitempty,ipv4",
-		},
 	}
 }
 
@@ -647,18 +636,12 @@ func (f *fieldsDef) LoadBalancerServerIPAddress() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "IPAddress",
 		Type: meta.TypeString,
-		Tags: &dsl.FieldTags{
-			Validate: "ipv4",
-		},
 	}
 }
 func (f *fieldsDef) LoadBalancerServerPort() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "Port",
 		Type: meta.TypeStringNumber,
-		Tags: &dsl.FieldTags{
-			Validate: "min=1,max=65535",
-		},
 	}
 }
 func (f *fieldsDef) LoadBalancerServerEnabled() *dsl.FieldDesc {
@@ -676,9 +659,6 @@ func (f *fieldsDef) LoadBalancerServerHealthCheck() *dsl.FieldDesc {
 				{
 					Name: "Protocol",
 					Type: meta.Static(types.ELoadBalancerHealthCheckProtocol("")),
-					Tags: &dsl.FieldTags{
-						Validate: "oneof=http https ping tcp",
-					},
 				},
 				{
 					Name: "Path",
@@ -713,8 +693,7 @@ func (f *fieldsDef) LoadBalancerVIPServers() *dsl.FieldDesc {
 			},
 		},
 		Tags: &dsl.FieldTags{
-			MapConv:  "[]Servers,recursive",
-			Validate: "min=0,max=40",
+			MapConv: "[]Servers,recursive",
 		},
 	}
 }
@@ -723,9 +702,6 @@ func (f *fieldsDef) LoadBalancerVIPVirtualIPAddress() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "VirtualIPAddress",
 		Type: meta.TypeString,
-		Tags: &dsl.FieldTags{
-			Validate: "ipv4",
-		},
 	}
 }
 
@@ -745,8 +721,7 @@ func (f *fieldsDef) LoadBalancerVIP() *dsl.FieldDesc {
 			},
 		},
 		Tags: &dsl.FieldTags{
-			MapConv:  "Settings.[]LoadBalancer,recursive",
-			Validate: "min=0,max=10",
+			MapConv: "Settings.[]LoadBalancer,recursive",
 		},
 	}
 }
@@ -807,8 +782,7 @@ func (f *fieldsDef) SIMICCID() *dsl.FieldDesc {
 		Name: "ICCID",
 		Type: meta.TypeString,
 		Tags: &dsl.FieldTags{
-			MapConv:  "Status.ICCID",
-			Validate: "numeric",
+			MapConv: "Status.ICCID",
 		},
 	}
 }
@@ -843,9 +817,6 @@ func (f *fieldsDef) GSLBHealthCheck() *dsl.FieldDesc {
 				{
 					Name: "Protocol",
 					Type: meta.Static(types.EGSLBHealthCheckProtocol("")),
-					Tags: &dsl.FieldTags{
-						Validate: "oneof=http https ping tcp",
-					},
 				},
 				{
 					Name: "HostHeader",
@@ -888,8 +859,7 @@ func (f *fieldsDef) GSLBDelayLoop() *dsl.FieldDesc {
 		Name: "DelayLoop",
 		Type: meta.TypeInt,
 		Tags: &dsl.FieldTags{
-			Validate: "min=10,max=60",
-			MapConv:  "Settings.GSLB.DelayLoop",
+			MapConv: "Settings.GSLB.DelayLoop",
 		},
 		DefaultValue: "10",
 	}
@@ -915,9 +885,6 @@ func (f *fieldsDef) GSLBDestinationServers() *dsl.FieldDesc {
 				{
 					Name: "IPAddress",
 					Type: meta.TypeString,
-					Tags: &dsl.FieldTags{
-						Validate: "ipv4",
-					},
 				},
 				{
 					Name: "Enabled",
@@ -930,8 +897,7 @@ func (f *fieldsDef) GSLBDestinationServers() *dsl.FieldDesc {
 			},
 		},
 		Tags: &dsl.FieldTags{
-			MapConv:  "Settings.GSLB.[]Servers,recursive",
-			Validate: "min=0,max=12",
+			MapConv: "Settings.GSLB.[]Servers,recursive",
 		},
 	}
 }
@@ -1032,8 +998,7 @@ func (f *fieldsDef) DNSRecords() *dsl.FieldDesc {
 			},
 		},
 		Tags: &dsl.FieldTags{
-			MapConv:  "Settings.DNS.[]ResourceRecordSets,recursive",
-			Validate: "min=0,max=1000",
+			MapConv: "Settings.DNS.[]ResourceRecordSets,recursive",
 		},
 	}
 }
@@ -1073,8 +1038,7 @@ func (f *fieldsDef) SimpleMonitorDelayLoop() *dsl.FieldDesc {
 		Name: "DelayLoop",
 		Type: meta.TypeInt,
 		Tags: &dsl.FieldTags{
-			Validate: "min=60,max=3600",
-			MapConv:  "Settings.SimpleMonitor.DelayLoop",
+			MapConv: "Settings.SimpleMonitor.DelayLoop",
 		},
 		DefaultValue: "60",
 	}
@@ -1085,8 +1049,7 @@ func (f *fieldsDef) SimpleMonitorNotifyInterval() *dsl.FieldDesc {
 		Name: "NotifyInterval",
 		Type: meta.TypeInt,
 		Tags: &dsl.FieldTags{
-			Validate: "min=3600,max=259200", // 1-72時間
-			MapConv:  "Settings.SimpleMonitor.NotifyInterval",
+			MapConv: "Settings.SimpleMonitor.NotifyInterval",
 		},
 		DefaultValue: "7200",
 	}
@@ -1308,16 +1271,12 @@ func (f *fieldsDef) ProxyLBSorryServer() *dsl.FieldDesc {
 				{
 					Name: "IPAddress",
 					Type: meta.TypeString,
-					Tags: &dsl.FieldTags{
-						Validate: "ipv4",
-					},
 				},
 				{
 					Name: "Port",
 					Type: meta.TypeInt,
 					Tags: &dsl.FieldTags{
-						Validate: "min=0,max=65535",
-						MapConv:  ",omitempty",
+						MapConv: ",omitempty",
 					},
 				},
 			},
@@ -1342,9 +1301,6 @@ func (f *fieldsDef) ProxyLBBindPorts() *dsl.FieldDesc {
 				{
 					Name: "Port",
 					Type: meta.TypeInt,
-					Tags: &dsl.FieldTags{
-						Validate: "min=0,max=65535",
-					},
 				},
 				{
 					Name: "RedirectToHTTPS",
@@ -1386,16 +1342,10 @@ func (f *fieldsDef) ProxyLBServers() *dsl.FieldDesc {
 				{
 					Name: "IPAddress",
 					Type: meta.TypeString,
-					Tags: &dsl.FieldTags{
-						Validate: "ipv4",
-					},
 				},
 				{
 					Name: "Port",
 					Type: meta.TypeInt,
-					Tags: &dsl.FieldTags{
-						Validate: "min=0,max=65535",
-					},
 				},
 				{
 					Name: "ServerGroup",
@@ -1491,11 +1441,8 @@ func (f *fieldsDef) ProxyLBTimeout() *dsl.FieldDesc {
 			Name: "ProxyLBTimeout",
 			Fields: []*dsl.FieldDesc{
 				{
-					Name: "InactiveSec",
-					Type: meta.TypeInt,
-					Tags: &dsl.FieldTags{
-						Validate: "min=10,max=600",
-					},
+					Name:         "InactiveSec",
+					Type:         meta.TypeInt,
 					DefaultValue: `10`,
 				},
 			},
@@ -1819,9 +1766,6 @@ func (f *fieldsDef) Description() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "Description",
 		Type: meta.TypeString,
-		Tags: &dsl.FieldTags{
-			Validate: "min=0,max=512",
-		},
 	}
 }
 
@@ -1910,9 +1854,6 @@ func (f *fieldsDef) DefaultRoute() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "DefaultRoute",
 		Type: meta.TypeString,
-		Tags: &dsl.FieldTags{
-			Validate: "ipv4",
-		},
 	}
 }
 
@@ -1924,9 +1865,6 @@ func (f *fieldsDef) NextHop() *dsl.FieldDesc {
 			スイッチ+ルータでの追加IPアドレスブロックを示すSubnetの中でのみ設定される項目。
 			この場合DefaultRouteの値は設定されないためNextHopを代用する。
 			StaticRouteと同じ値が設定される。`,
-		Tags: &dsl.FieldTags{
-			Validate: "ipv4",
-		},
 	}
 }
 
@@ -1938,9 +1876,6 @@ func (f *fieldsDef) StaticRoute() *dsl.FieldDesc {
 			スイッチ+ルータでの追加IPアドレスブロックを示すSubnetの中でのみ設定される項目。
 			この場合DefaultRouteの値は設定されないためNextHopを代用する。
 			NextHopと同じ値が設定される。`,
-		Tags: &dsl.FieldTags{
-			Validate: "ipv4",
-		},
 	}
 }
 
@@ -1948,9 +1883,6 @@ func (f *fieldsDef) NetworkMaskLen() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "NetworkMaskLen",
 		Type: meta.TypeInt,
-		Tags: &dsl.FieldTags{
-			Validate: "min=24,max=28",
-		},
 	}
 }
 
@@ -1958,9 +1890,6 @@ func (f *fieldsDef) NetworkAddress() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "NetworkAddress",
 		Type: meta.TypeString,
-		Tags: &dsl.FieldTags{
-			Validate: "ipv4",
-		},
 	}
 }
 
@@ -1969,8 +1898,7 @@ func (f *fieldsDef) UserSubnetNetworkMaskLen() *dsl.FieldDesc {
 		Name: "NetworkMaskLen",
 		Type: meta.TypeInt,
 		Tags: &dsl.FieldTags{
-			Validate: "min=1,max=32",
-			MapConv:  "UserSubnet.NetworkMaskLen",
+			MapConv: "UserSubnet.NetworkMaskLen",
 		},
 	}
 }
@@ -1980,8 +1908,7 @@ func (f *fieldsDef) UserSubnetDefaultRoute() *dsl.FieldDesc {
 		Name: "DefaultRoute",
 		Type: meta.TypeString,
 		Tags: &dsl.FieldTags{
-			Validate: "ipv4",
-			MapConv:  "UserSubnet.DefaultRoute",
+			MapConv: "UserSubnet.DefaultRoute",
 		},
 	}
 }
@@ -1991,8 +1918,7 @@ func (f *fieldsDef) RemarkNetworkMaskLen() *dsl.FieldDesc {
 		Name: "NetworkMaskLen",
 		Type: meta.TypeInt,
 		Tags: &dsl.FieldTags{
-			Validate: "min=1,max=32",
-			MapConv:  "Remark.Network.NetworkMaskLen",
+			MapConv: "Remark.Network.NetworkMaskLen",
 		},
 	}
 }
@@ -2012,8 +1938,7 @@ func (f *fieldsDef) RemarkDefaultRoute() *dsl.FieldDesc {
 		Name: "DefaultRoute",
 		Type: meta.TypeString,
 		Tags: &dsl.FieldTags{
-			Validate: "ipv4",
-			MapConv:  "Remark.Network.DefaultRoute",
+			MapConv: "Remark.Network.DefaultRoute",
 		},
 	}
 }

--- a/v2/internal/define/models.go
+++ b/v2/internal/define/models.go
@@ -118,9 +118,8 @@ func (m *modelsDef) diskEdit() *dsl.Model {
 			Name: "NetworkMaskLen",
 			Type: meta.TypeInt,
 			Tags: &dsl.FieldTags{
-				MapConv:  ",omitempty",
-				Validate: "min=0,max=32",
-				JSON:     ",omitempty",
+				MapConv: ",omitempty",
+				JSON:    ",omitempty",
 			},
 		},
 	}
@@ -931,16 +930,14 @@ func (m *modelsDef) vpcRouterStaticNAT() *dsl.Model {
 				Name: "GlobalAddress",
 				Type: meta.TypeString,
 				Tags: &dsl.FieldTags{
-					MapConv:  "GlobalAddress",
-					Validate: "ipv4",
+					MapConv: "GlobalAddress",
 				},
 			},
 			{
 				Name: "PrivateAddress",
 				Type: meta.TypeString,
 				Tags: &dsl.FieldTags{
-					MapConv:  "PrivateAddress",
-					Validate: "ipv4",
+					MapConv: "PrivateAddress",
 				},
 			},
 			{
@@ -969,8 +966,7 @@ func (m *modelsDef) vpcRouterPortForwarding() *dsl.Model {
 				Name: "PrivateAddress",
 				Type: meta.TypeString,
 				Tags: &dsl.FieldTags{
-					MapConv:  "PrivateAddress",
-					Validate: "ipv4",
+					MapConv: "PrivateAddress",
 				},
 			},
 			{
@@ -1061,23 +1057,14 @@ func (m *modelsDef) vpcRouterDHCPServer() *dsl.Model {
 			{
 				Name: "RangeStart",
 				Type: meta.TypeString,
-				Tags: &dsl.FieldTags{
-					Validate: "ipv4",
-				},
 			},
 			{
 				Name: "RangeStop",
 				Type: meta.TypeString,
-				Tags: &dsl.FieldTags{
-					Validate: "ipv4",
-				},
 			},
 			{
 				Name: "DNSServers",
 				Type: meta.TypeStringSlice,
-				Tags: &dsl.FieldTags{
-					Validate: "dive,ipv4",
-				},
 			},
 		},
 	}
@@ -1096,9 +1083,6 @@ func (m *modelsDef) vpcRouterDHCPStaticMapping() *dsl.Model {
 			{
 				Name: "IPAddress",
 				Type: meta.TypeString,
-				Tags: &dsl.FieldTags{
-					Validate: "ipv4",
-				},
 			},
 		},
 	}
@@ -1112,16 +1096,10 @@ func (m *modelsDef) vpcRouterPPTPServer() *dsl.Model {
 			{
 				Name: "RangeStart",
 				Type: meta.TypeString,
-				Tags: &dsl.FieldTags{
-					Validate: "ipv4",
-				},
 			},
 			{
 				Name: "RangeStop",
 				Type: meta.TypeString,
-				Tags: &dsl.FieldTags{
-					Validate: "ipv4",
-				},
 			},
 		},
 	}
@@ -1135,16 +1113,10 @@ func (m *modelsDef) vpcRouterL2TPIPsecServer() *dsl.Model {
 			{
 				Name: "RangeStart",
 				Type: meta.TypeString,
-				Tags: &dsl.FieldTags{
-					Validate: "ipv4",
-				},
 			},
 			{
 				Name: "RangeStop",
 				Type: meta.TypeString,
-				Tags: &dsl.FieldTags{
-					Validate: "ipv4",
-				},
 			},
 			{
 				Name: "PreSharedSecret",

--- a/v2/internal/define/simple_monitor.go
+++ b/v2/internal/define/simple_monitor.go
@@ -119,8 +119,7 @@ var (
 				Name: "Target",
 				Type: meta.TypeString,
 				Tags: &dsl.FieldTags{
-					Validate: "required",
-					MapConv:  "Name/Status.Target", // NameとStatus.Targetに同じ値を設定
+					MapConv: "Name/Status.Target", // NameとStatus.Targetに同じ値を設定
 				},
 			},
 

--- a/v2/sacloud/zz_envelopes.go
+++ b/v2/sacloud/zz_envelopes.go
@@ -1184,8 +1184,8 @@ type internetUpdateBandWidthResponseEnvelope struct {
 
 // internetAddSubnetRequestEnvelope is envelop of API request
 type internetAddSubnetRequestEnvelope struct {
-	NetworkMaskLen int    `validate:"min=24,max=28"`
-	NextHop        string `validate:"ipv4"`
+	NetworkMaskLen int    `json:",omitempty"`
+	NextHop        string `json:",omitempty"`
 }
 
 // internetAddSubnetResponseEnvelope is envelop of API response
@@ -1198,7 +1198,7 @@ type internetAddSubnetResponseEnvelope struct {
 
 // internetUpdateSubnetRequestEnvelope is envelop of API request
 type internetUpdateSubnetRequestEnvelope struct {
-	NextHop string `validate:"ipv4"`
+	NextHop string `json:",omitempty"`
 }
 
 // internetUpdateSubnetResponseEnvelope is envelop of API response

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -32,8 +32,8 @@ import (
 // Archive represents API parameter/response structure
 type Archive struct {
 	ID                        types.ID
-	Name                      string `validate:"required"`
-	Description               string `validate:"min=0,max=512"`
+	Name                      string
+	Description               string
 	Tags                      types.Tags
 	DisplayOrder              int64
 	Availability              types.EAvailability
@@ -65,8 +65,8 @@ func (o *Archive) Validate() error {
 func (o *Archive) setDefaults() interface{} {
 	return &struct {
 		ID                        types.ID
-		Name                      string `validate:"required"`
-		Description               string `validate:"min=0,max=512"`
+		Name                      string
+		Description               string
 		Tags                      types.Tags
 		DisplayOrder              int64
 		Availability              types.EAvailability
@@ -485,7 +485,7 @@ func (o *BundleInfo) SetServiceClass(v string) {
 // Storage represents API parameter/response structure
 type Storage struct {
 	ID         types.ID
-	Name       string `validate:"required"`
+	Name       string
 	Class      string `json:",omitempty" mapconv:",omitempty"`
 	Generation int    `json:",omitempty" mapconv:",omitempty"`
 }
@@ -499,7 +499,7 @@ func (o *Storage) Validate() error {
 func (o *Storage) setDefaults() interface{} {
 	return &struct {
 		ID         types.ID
-		Name       string `validate:"required"`
+		Name       string
 		Class      string `json:",omitempty" mapconv:",omitempty"`
 		Generation int    `json:",omitempty" mapconv:",omitempty"`
 	}{
@@ -753,8 +753,8 @@ func (o *FindCondition) SetExclude(v []string) {
 type ArchiveCreateRequest struct {
 	SourceDiskID    types.ID `mapconv:"SourceDisk.ID,omitempty"`
 	SourceArchiveID types.ID `mapconv:"SourceArchive.ID,omitempty"`
-	Name            string   `validate:"required"`
-	Description     string   `validate:"min=0,max=512"`
+	Name            string
+	Description     string
 	Tags            types.Tags
 	IconID          types.ID `mapconv:"Icon.ID"`
 }
@@ -769,8 +769,8 @@ func (o *ArchiveCreateRequest) setDefaults() interface{} {
 	return &struct {
 		SourceDiskID    types.ID `mapconv:"SourceDisk.ID,omitempty"`
 		SourceArchiveID types.ID `mapconv:"SourceArchive.ID,omitempty"`
-		Name            string   `validate:"required"`
-		Description     string   `validate:"min=0,max=512"`
+		Name            string
+		Description     string
 		Tags            types.Tags
 		IconID          types.ID `mapconv:"Icon.ID"`
 	}{
@@ -942,8 +942,8 @@ func (o *FTPServer) SetPassword(v string) {
 // ArchiveCreateBlankRequest represents API parameter/response structure
 type ArchiveCreateBlankRequest struct {
 	SizeMB      int
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -957,8 +957,8 @@ func (o *ArchiveCreateBlankRequest) Validate() error {
 func (o *ArchiveCreateBlankRequest) setDefaults() interface{} {
 	return &struct {
 		SizeMB      int
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -1056,8 +1056,8 @@ func (o *ArchiveCreateBlankRequest) SetIconID(v types.ID) {
 
 // ArchiveUpdateRequest represents API parameter/response structure
 type ArchiveUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -1070,8 +1070,8 @@ func (o *ArchiveUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ArchiveUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -1214,8 +1214,8 @@ func (o *ArchiveShareInfo) SetSharedKey(v types.ArchiveShareKey) {
 
 // ArchiveCreateRequestFromShared represents API parameter/response structure
 type ArchiveCreateRequestFromShared struct {
-	Name            string `validate:"required"`
-	Description     string `validate:"min=0,max=512"`
+	Name            string
+	Description     string
 	Tags            types.Tags
 	IconID          types.ID `mapconv:"Icon.ID"`
 	SourceSharedKey types.ArchiveShareKey
@@ -1229,8 +1229,8 @@ func (o *ArchiveCreateRequestFromShared) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ArchiveCreateRequestFromShared) setDefaults() interface{} {
 	return &struct {
-		Name            string `validate:"required"`
-		Description     string `validate:"min=0,max=512"`
+		Name            string
+		Description     string
 		Tags            types.Tags
 		IconID          types.ID `mapconv:"Icon.ID"`
 		SourceSharedKey types.ArchiveShareKey
@@ -1320,8 +1320,8 @@ func (o *ArchiveCreateRequestFromShared) SetSourceSharedKey(v types.ArchiveShare
 // ArchiveTransferRequest represents API parameter/response structure
 type ArchiveTransferRequest struct {
 	SizeMB      int
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -1335,8 +1335,8 @@ func (o *ArchiveTransferRequest) Validate() error {
 func (o *ArchiveTransferRequest) setDefaults() interface{} {
 	return &struct {
 		SizeMB      int
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -1611,8 +1611,8 @@ func (o *AuthStatus) SetPermission(v types.EPermission) {
 // AutoBackup represents API parameter/response structure
 type AutoBackup struct {
 	ID                      types.ID
-	Name                    string `validate:"required"`
-	Description             string `validate:"min=0,max=512"`
+	Name                    string
+	Description             string
 	Tags                    types.Tags
 	Availability            types.EAvailability
 	IconID                  types.ID `mapconv:"Icon.ID"`
@@ -1636,8 +1636,8 @@ func (o *AutoBackup) Validate() error {
 func (o *AutoBackup) setDefaults() interface{} {
 	return &struct {
 		ID                      types.ID
-		Name                    string `validate:"required"`
-		Description             string `validate:"min=0,max=512"`
+		Name                    string
+		Description             string
 		Tags                    types.Tags
 		Availability            types.EAvailability
 		IconID                  types.ID `mapconv:"Icon.ID"`
@@ -1868,8 +1868,8 @@ type AutoBackupCreateRequest struct {
 	DiskID                  types.ID                   `mapconv:"Status.DiskID"`
 	BackupSpanWeekdays      []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 	MaximumNumberOfArchives int                        `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
-	Name                    string                     `validate:"required"`
-	Description             string                     `validate:"min=0,max=512"`
+	Name                    string
+	Description             string
 	Tags                    types.Tags
 	IconID                  types.ID `mapconv:"Icon.ID"`
 }
@@ -1885,8 +1885,8 @@ func (o *AutoBackupCreateRequest) setDefaults() interface{} {
 		DiskID                  types.ID                   `mapconv:"Status.DiskID"`
 		BackupSpanWeekdays      []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
 		MaximumNumberOfArchives int                        `mapconv:"Settings.Autobackup.MaximumNumberOfArchives"`
-		Name                    string                     `validate:"required"`
-		Description             string                     `validate:"min=0,max=512"`
+		Name                    string
+		Description             string
 		Tags                    types.Tags
 		IconID                  types.ID              `mapconv:"Icon.ID"`
 		Class                   string                `mapconv:"Provider.Class"`
@@ -2000,8 +2000,8 @@ func (o *AutoBackupCreateRequest) SetIconID(v types.ID) {
 
 // AutoBackupUpdateRequest represents API parameter/response structure
 type AutoBackupUpdateRequest struct {
-	Name                    string `validate:"required"`
-	Description             string `validate:"min=0,max=512"`
+	Name                    string
+	Description             string
 	Tags                    types.Tags
 	IconID                  types.ID                   `mapconv:"Icon.ID"`
 	BackupSpanWeekdays      []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
@@ -2017,8 +2017,8 @@ func (o *AutoBackupUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *AutoBackupUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name                    string `validate:"required"`
-		Description             string `validate:"min=0,max=512"`
+		Name                    string
+		Description             string
 		Tags                    types.Tags
 		IconID                  types.ID                   `mapconv:"Icon.ID"`
 		BackupSpanWeekdays      []types.EBackupSpanWeekday `mapconv:"Settings.Autobackup.BackupSpanWeekdays"`
@@ -2327,7 +2327,7 @@ func (o *Bill) SetPaymentClassID(v types.ID) {
 type BillDetail struct {
 	ID               types.ID
 	Amount           int64
-	Description      string `validate:"min=0,max=512"`
+	Description      string
 	ServiceClassID   types.ID
 	ServiceClassPath string
 	Usage            int64
@@ -2347,7 +2347,7 @@ func (o *BillDetail) setDefaults() interface{} {
 	return &struct {
 		ID               types.ID
 		Amount           int64
-		Description      string `validate:"min=0,max=512"`
+		Description      string
 		ServiceClassID   types.ID
 		ServiceClassPath string
 		Usage            int64
@@ -2594,8 +2594,8 @@ func (o *BillDetailCSV) SetBodyRows(v [][]string) {
 // Bridge represents API parameter/response structure
 type Bridge struct {
 	ID           types.ID
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
+	Name         string
+	Description  string
 	CreatedAt    time.Time
 	Region       *Region       `json:",omitempty"`
 	BridgeInfo   []*BridgeInfo `mapconv:"Info.[]Switches,recursive"`
@@ -2611,8 +2611,8 @@ func (o *Bridge) Validate() error {
 func (o *Bridge) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
+		Name         string
+		Description  string
 		CreatedAt    time.Time
 		Region       *Region       `json:",omitempty"`
 		BridgeInfo   []*BridgeInfo `mapconv:"Info.[]Switches,recursive"`
@@ -2725,8 +2725,8 @@ func (o *Bridge) SetSwitchInZone(v *BridgeSwitchInfo) {
 // Region represents API parameter/response structure
 type Region struct {
 	ID          types.ID
-	Name        string   `validate:"required"`
-	Description string   `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	NameServers []string `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -2739,8 +2739,8 @@ func (o *Region) Validate() error {
 func (o *Region) setDefaults() interface{} {
 	return &struct {
 		ID          types.ID
-		Name        string   `validate:"required"`
-		Description string   `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		NameServers []string `json:",omitempty" mapconv:",omitempty"`
 	}{
 		ID:          o.GetID(),
@@ -2817,7 +2817,7 @@ func (o *Region) SetNameServers(v []string) {
 // BridgeInfo represents API parameter/response structure
 type BridgeInfo struct {
 	ID       types.ID
-	Name     string   `validate:"required"`
+	Name     string
 	ZoneID   types.ID `mapconv:"Zone.ID"`
 	ZoneName string   `mapconv:"Zone.Name"`
 }
@@ -2831,7 +2831,7 @@ func (o *BridgeInfo) Validate() error {
 func (o *BridgeInfo) setDefaults() interface{} {
 	return &struct {
 		ID       types.ID
-		Name     string   `validate:"required"`
+		Name     string
 		ZoneID   types.ID `mapconv:"Zone.ID"`
 		ZoneName string   `mapconv:"Zone.Name"`
 	}{
@@ -2909,7 +2909,7 @@ func (o *BridgeInfo) SetZoneName(v string) {
 // BridgeSwitchInfo represents API parameter/response structure
 type BridgeSwitchInfo struct {
 	ID             types.ID
-	Name           string `validate:"required"`
+	Name           string
 	Scope          types.EScope
 	ServerCount    int
 	ApplianceCount int
@@ -2924,7 +2924,7 @@ func (o *BridgeSwitchInfo) Validate() error {
 func (o *BridgeSwitchInfo) setDefaults() interface{} {
 	return &struct {
 		ID             types.ID
-		Name           string `validate:"required"`
+		Name           string
 		Scope          types.EScope
 		ServerCount    int
 		ApplianceCount int
@@ -3013,8 +3013,8 @@ func (o *BridgeSwitchInfo) SetApplianceCount(v int) {
 
 // BridgeCreateRequest represents API parameter/response structure
 type BridgeCreateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 }
 
 // Validate validates by field tags
@@ -3025,8 +3025,8 @@ func (o *BridgeCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *BridgeCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 	}{
 		Name:        o.GetName(),
 		Description: o.GetDescription(),
@@ -3059,8 +3059,8 @@ func (o *BridgeCreateRequest) SetDescription(v string) {
 
 // BridgeUpdateRequest represents API parameter/response structure
 type BridgeUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 }
 
 // Validate validates by field tags
@@ -3071,8 +3071,8 @@ func (o *BridgeUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *BridgeUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 	}{
 		Name:        o.GetName(),
 		Description: o.GetDescription(),
@@ -3106,8 +3106,8 @@ func (o *BridgeUpdateRequest) SetDescription(v string) {
 // CDROM represents API parameter/response structure
 type CDROM struct {
 	ID           types.ID
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
+	Name         string
+	Description  string
 	DisplayOrder int64
 	Tags         types.Tags
 	Availability types.EAvailability
@@ -3128,8 +3128,8 @@ func (o *CDROM) Validate() error {
 func (o *CDROM) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
+		Name         string
+		Description  string
 		DisplayOrder int64
 		Tags         types.Tags
 		Availability types.EAvailability
@@ -3332,8 +3332,8 @@ func (o *CDROM) SetModifiedAt(v time.Time) {
 // CDROMCreateRequest represents API parameter/response structure
 type CDROMCreateRequest struct {
 	SizeMB      int
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -3347,8 +3347,8 @@ func (o *CDROMCreateRequest) Validate() error {
 func (o *CDROMCreateRequest) setDefaults() interface{} {
 	return &struct {
 		SizeMB      int
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -3446,8 +3446,8 @@ func (o *CDROMCreateRequest) SetIconID(v types.ID) {
 
 // CDROMUpdateRequest represents API parameter/response structure
 type CDROMUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -3460,8 +3460,8 @@ func (o *CDROMUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *CDROMUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -3539,8 +3539,8 @@ func (o *CDROMUpdateRequest) SetIconID(v types.ID) {
 // ContainerRegistry represents API parameter/response structure
 type ContainerRegistry struct {
 	ID             types.ID
-	Name           string `validate:"required"`
-	Description    string `validate:"min=0,max=512"`
+	Name           string
+	Description    string
 	Tags           types.Tags
 	Availability   types.EAvailability
 	IconID         types.ID `mapconv:"Icon.ID"`
@@ -3562,8 +3562,8 @@ func (o *ContainerRegistry) Validate() error {
 func (o *ContainerRegistry) setDefaults() interface{} {
 	return &struct {
 		ID             types.ID
-		Name           string `validate:"required"`
-		Description    string `validate:"min=0,max=512"`
+		Name           string
+		Description    string
 		Tags           types.Tags
 		Availability   types.EAvailability
 		IconID         types.ID `mapconv:"Icon.ID"`
@@ -3767,8 +3767,8 @@ func (o *ContainerRegistry) SetFQDN(v string) {
 
 // ContainerRegistryCreateRequest represents API parameter/response structure
 type ContainerRegistryCreateRequest struct {
-	Name           string `validate:"required"`
-	Description    string `validate:"min=0,max=512"`
+	Name           string
+	Description    string
 	Tags           types.Tags
 	IconID         types.ID                            `mapconv:"Icon.ID"`
 	AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
@@ -3784,8 +3784,8 @@ func (o *ContainerRegistryCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistryCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name           string `validate:"required"`
-		Description    string `validate:"min=0,max=512"`
+		Name           string
+		Description    string
 		Tags           types.Tags
 		IconID         types.ID                            `mapconv:"Icon.ID"`
 		AccessLevel    types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
@@ -3900,8 +3900,8 @@ func (o *ContainerRegistryCreateRequest) SetSubDomainLabel(v string) {
 
 // ContainerRegistryUpdateRequest represents API parameter/response structure
 type ContainerRegistryUpdateRequest struct {
-	Name          string `validate:"required"`
-	Description   string `validate:"min=0,max=512"`
+	Name          string
+	Description   string
 	Tags          types.Tags
 	IconID        types.ID                            `mapconv:"Icon.ID"`
 	AccessLevel   types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
@@ -3917,8 +3917,8 @@ func (o *ContainerRegistryUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ContainerRegistryUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name          string `validate:"required"`
-		Description   string `validate:"min=0,max=512"`
+		Name          string
+		Description   string
 		Tags          types.Tags
 		IconID        types.ID                            `mapconv:"Icon.ID"`
 		AccessLevel   types.EContainerRegistryAccessLevel `mapconv:"Settings.ContainerRegistry.Public"`
@@ -4407,8 +4407,8 @@ func (o *Coupon) SetUntilAt(v time.Time) {
 type Database struct {
 	ID                      types.ID
 	Class                   string
-	Name                    string `validate:"required"`
-	Description             string `validate:"min=0,max=512"`
+	Name                    string
+	Description             string
 	Tags                    types.Tags
 	Availability            types.EAvailability
 	IconID                  types.ID `mapconv:"Icon.ID"`
@@ -4425,8 +4425,8 @@ type Database struct {
 	PlanID                  types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
 	SwitchID                types.ID                    `mapconv:"Remark.Switch.ID"`
 	Conf                    *DatabaseRemarkDBConfCommon `mapconv:"Remark.DBConf.Common,recursive"`
-	DefaultRoute            string                      `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-	NetworkMaskLen          int                         `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
+	DefaultRoute            string                      `mapconv:"Remark.Network.DefaultRoute"`
+	NetworkMaskLen          int                         `mapconv:"Remark.Network.NetworkMaskLen"`
 	IPAddresses             []string                    `mapconv:"Remark.[]Servers.IPAddress"`
 	ZoneID                  types.ID                    `mapconv:"Remark.Zone.ID"`
 	Interfaces              []*InterfaceView            `json:",omitempty" mapconv:"[]Interfaces,recursive,omitempty"`
@@ -4442,8 +4442,8 @@ func (o *Database) setDefaults() interface{} {
 	return &struct {
 		ID                      types.ID
 		Class                   string
-		Name                    string `validate:"required"`
-		Description             string `validate:"min=0,max=512"`
+		Name                    string
+		Description             string
 		Tags                    types.Tags
 		Availability            types.EAvailability
 		IconID                  types.ID `mapconv:"Icon.ID"`
@@ -4460,8 +4460,8 @@ func (o *Database) setDefaults() interface{} {
 		PlanID                  types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
 		SwitchID                types.ID                    `mapconv:"Remark.Switch.ID"`
 		Conf                    *DatabaseRemarkDBConfCommon `mapconv:"Remark.DBConf.Common,recursive"`
-		DefaultRoute            string                      `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-		NetworkMaskLen          int                         `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
+		DefaultRoute            string                      `mapconv:"Remark.Network.DefaultRoute"`
+		NetworkMaskLen          int                         `mapconv:"Remark.Network.NetworkMaskLen"`
 		IPAddresses             []string                    `mapconv:"Remark.[]Servers.IPAddress"`
 		ZoneID                  types.ID                    `mapconv:"Remark.Zone.ID"`
 		Interfaces              []*InterfaceView            `json:",omitempty" mapconv:"[]Interfaces,recursive,omitempty"`
@@ -5419,16 +5419,16 @@ func (o *InterfaceView) SetUpstreamType(v types.EUpstreamNetworkType) {
 type DatabaseCreateRequest struct {
 	PlanID             types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
 	SwitchID           types.ID                    `mapconv:"Remark.Switch.ID"`
-	IPAddresses        []string                    `mapconv:"Remark.[]Servers.IPAddress" validate:"min=1,max=2,dive,ipv4"`
-	NetworkMaskLen     int                         `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
-	DefaultRoute       string                      `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
+	IPAddresses        []string                    `mapconv:"Remark.[]Servers.IPAddress"`
+	NetworkMaskLen     int                         `mapconv:"Remark.Network.NetworkMaskLen"`
+	DefaultRoute       string                      `mapconv:"Remark.Network.DefaultRoute"`
 	Conf               *DatabaseRemarkDBConfCommon `mapconv:"Remark.DBConf.Common,recursive"`
 	SourceID           types.ID                    `mapconv:"Remark.SourceAppliance.ID"`
 	CommonSetting      *DatabaseSettingCommon      `mapconv:"Settings.DBConf.Common,recursive"`
 	BackupSetting      *DatabaseSettingBackup      `mapconv:"Settings.DBConf.Backup,recursive"`
 	ReplicationSetting *DatabaseReplicationSetting `mapconv:"Settings.DBConf.Replication,recursive"`
-	Name               string                      `validate:"required"`
-	Description        string                      `validate:"min=0,max=512"`
+	Name               string
+	Description        string
 	Tags               types.Tags
 	IconID             types.ID `mapconv:"Icon.ID"`
 }
@@ -5443,16 +5443,16 @@ func (o *DatabaseCreateRequest) setDefaults() interface{} {
 	return &struct {
 		PlanID             types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
 		SwitchID           types.ID                    `mapconv:"Remark.Switch.ID"`
-		IPAddresses        []string                    `mapconv:"Remark.[]Servers.IPAddress" validate:"min=1,max=2,dive,ipv4"`
-		NetworkMaskLen     int                         `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
-		DefaultRoute       string                      `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
+		IPAddresses        []string                    `mapconv:"Remark.[]Servers.IPAddress"`
+		NetworkMaskLen     int                         `mapconv:"Remark.Network.NetworkMaskLen"`
+		DefaultRoute       string                      `mapconv:"Remark.Network.DefaultRoute"`
 		Conf               *DatabaseRemarkDBConfCommon `mapconv:"Remark.DBConf.Common,recursive"`
 		SourceID           types.ID                    `mapconv:"Remark.SourceAppliance.ID"`
 		CommonSetting      *DatabaseSettingCommon      `mapconv:"Settings.DBConf.Common,recursive"`
 		BackupSetting      *DatabaseSettingBackup      `mapconv:"Settings.DBConf.Backup,recursive"`
 		ReplicationSetting *DatabaseReplicationSetting `mapconv:"Settings.DBConf.Replication,recursive"`
-		Name               string                      `validate:"required"`
-		Description        string                      `validate:"min=0,max=512"`
+		Name               string
+		Description        string
 		Tags               types.Tags
 		IconID             types.ID `mapconv:"Icon.ID"`
 		Class              string
@@ -5641,8 +5641,8 @@ func (o *DatabaseCreateRequest) SetIconID(v types.ID) {
 
 // DatabaseUpdateRequest represents API parameter/response structure
 type DatabaseUpdateRequest struct {
-	Name               string `validate:"required"`
-	Description        string `validate:"min=0,max=512"`
+	Name               string
+	Description        string
 	Tags               types.Tags
 	IconID             types.ID                    `mapconv:"Icon.ID"`
 	CommonSetting      *DatabaseSettingCommon      `mapconv:"Settings.DBConf.Common,recursive"`
@@ -5659,8 +5659,8 @@ func (o *DatabaseUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *DatabaseUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name               string `validate:"required"`
-		Description        string `validate:"min=0,max=512"`
+		Name               string
+		Description        string
 		Tags               types.Tags
 		IconID             types.ID                    `mapconv:"Icon.ID"`
 		CommonSetting      *DatabaseSettingCommon      `mapconv:"Settings.DBConf.Common,recursive"`
@@ -6703,8 +6703,8 @@ func (o *DatabaseBackupHistory) SetSize(v int64) {
 // Disk represents API parameter/response structure
 type Disk struct {
 	ID                        types.ID
-	Name                      string `validate:"required"`
-	Description               string `validate:"min=0,max=512"`
+	Name                      string
+	Description               string
 	Tags                      types.Tags
 	Availability              types.EAvailability
 	Connection                types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
@@ -6738,8 +6738,8 @@ func (o *Disk) Validate() error {
 func (o *Disk) setDefaults() interface{} {
 	return &struct {
 		ID                        types.ID
-		Name                      string `validate:"required"`
-		Description               string `validate:"min=0,max=512"`
+		Name                      string
+		Description               string
 		Tags                      types.Tags
 		Availability              types.EAvailability
 		Connection                types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
@@ -7213,8 +7213,8 @@ type DiskCreateRequest struct {
 	SourceArchiveID types.ID              `mapconv:"SourceArchive.ID,omitempty"`
 	ServerID        types.ID              `mapconv:"Server.ID,omitempty"`
 	SizeMB          int
-	Name            string `validate:"required"`
-	Description     string `validate:"min=0,max=512"`
+	Name            string
+	Description     string
 	Tags            types.Tags
 	IconID          types.ID `mapconv:"Icon.ID"`
 }
@@ -7233,8 +7233,8 @@ func (o *DiskCreateRequest) setDefaults() interface{} {
 		SourceArchiveID types.ID              `mapconv:"SourceArchive.ID,omitempty"`
 		ServerID        types.ID              `mapconv:"Server.ID,omitempty"`
 		SizeMB          int
-		Name            string `validate:"required"`
-		Description     string `validate:"min=0,max=512"`
+		Name            string
+		Description     string
 		Tags            types.Tags
 		IconID          types.ID `mapconv:"Icon.ID"`
 	}{
@@ -7656,7 +7656,7 @@ func (o *DiskEditNote) SetVariables(v map[string]interface{}) {
 // DiskEditUserSubnet represents API parameter/response structure
 type DiskEditUserSubnet struct {
 	DefaultRoute   string `json:",omitempty" mapconv:",omitempty"`
-	NetworkMaskLen int    `json:",omitempty" mapconv:",omitempty" validate:"min=0,max=32"`
+	NetworkMaskLen int    `json:",omitempty" mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -7668,7 +7668,7 @@ func (o *DiskEditUserSubnet) Validate() error {
 func (o *DiskEditUserSubnet) setDefaults() interface{} {
 	return &struct {
 		DefaultRoute   string `json:",omitempty" mapconv:",omitempty"`
-		NetworkMaskLen int    `json:",omitempty" mapconv:",omitempty" validate:"min=0,max=32"`
+		NetworkMaskLen int    `json:",omitempty" mapconv:",omitempty"`
 	}{
 		DefaultRoute:   o.GetDefaultRoute(),
 		NetworkMaskLen: o.GetNetworkMaskLen(),
@@ -7803,8 +7803,8 @@ func (o *DiskInstallRequest) SetSizeGB(size int) {
 
 // DiskUpdateRequest represents API parameter/response structure
 type DiskUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID              `mapconv:"Icon.ID"`
 	Connection  types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
@@ -7818,8 +7818,8 @@ func (o *DiskUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *DiskUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID              `mapconv:"Icon.ID"`
 		Connection  types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
@@ -7909,7 +7909,7 @@ func (o *DiskUpdateRequest) SetConnection(v types.EDiskConnection) {
 // DiskPlan represents API parameter/response structure
 type DiskPlan struct {
 	ID           types.ID
-	Name         string `validate:"required"`
+	Name         string
 	StorageClass string
 	Availability types.EAvailability
 	Size         []*DiskPlanSizeInfo `mapconv:"[]Size,recursive"`
@@ -7924,7 +7924,7 @@ func (o *DiskPlan) Validate() error {
 func (o *DiskPlan) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
+		Name         string
 		StorageClass string
 		Availability types.EAvailability
 		Size         []*DiskPlanSizeInfo `mapconv:"[]Size,recursive"`
@@ -8096,14 +8096,14 @@ func (o *DiskPlanSizeInfo) SetSizeGB(size int) {
 // DNS represents API parameter/response structure
 type DNS struct {
 	ID             types.ID
-	Name           string `validate:"required"`
-	Description    string `validate:"min=0,max=512"`
+	Name           string
+	Description    string
 	Tags           types.Tags
 	Availability   types.EAvailability
 	IconID         types.ID `mapconv:"Icon.ID"`
 	CreatedAt      time.Time
 	ModifiedAt     time.Time
-	Records        DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+	Records        DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive"`
 	SettingsHash   string     `json:",omitempty" mapconv:",omitempty"`
 	DNSZone        string     `mapconv:"Status.Zone"`
 	DNSNameServers []string   `mapconv:"Status.NS"`
@@ -8118,14 +8118,14 @@ func (o *DNS) Validate() error {
 func (o *DNS) setDefaults() interface{} {
 	return &struct {
 		ID             types.ID
-		Name           string `validate:"required"`
-		Description    string `validate:"min=0,max=512"`
+		Name           string
+		Description    string
 		Tags           types.Tags
 		Availability   types.EAvailability
 		IconID         types.ID `mapconv:"Icon.ID"`
 		CreatedAt      time.Time
 		ModifiedAt     time.Time
-		Records        DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+		Records        DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive"`
 		SettingsHash   string     `json:",omitempty" mapconv:",omitempty"`
 		DNSZone        string     `mapconv:"Status.Zone"`
 		DNSNameServers []string   `mapconv:"Status.NS"`
@@ -8383,9 +8383,9 @@ func (o *DNSRecord) SetTTL(v int) {
 
 // DNSCreateRequest represents API parameter/response structure
 type DNSCreateRequest struct {
-	Name        string     `mapconv:"Name/Status.Zone" validate:"required"`
-	Records     DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
-	Description string     `validate:"min=0,max=512"`
+	Name        string     `mapconv:"Name/Status.Zone"`
+	Records     DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive"`
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -8398,9 +8398,9 @@ func (o *DNSCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *DNSCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string     `mapconv:"Name/Status.Zone" validate:"required"`
-		Records     DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
-		Description string     `validate:"min=0,max=512"`
+		Name        string     `mapconv:"Name/Status.Zone"`
+		Records     DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive"`
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 		Class       string   `mapconv:"Provider.Class"`
@@ -8490,10 +8490,10 @@ func (o *DNSCreateRequest) SetIconID(v types.ID) {
 
 // DNSUpdateRequest represents API parameter/response structure
 type DNSUpdateRequest struct {
-	Description  string `validate:"min=0,max=512"`
+	Description  string
 	Tags         types.Tags
 	IconID       types.ID   `mapconv:"Icon.ID"`
-	Records      DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+	Records      DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive"`
 	SettingsHash string     `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -8505,10 +8505,10 @@ func (o *DNSUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *DNSUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Description  string `validate:"min=0,max=512"`
+		Description  string
 		Tags         types.Tags
 		IconID       types.ID   `mapconv:"Icon.ID"`
-		Records      DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+		Records      DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive"`
 		SettingsHash string     `json:",omitempty" mapconv:",omitempty"`
 	}{
 		Description:  o.GetDescription(),
@@ -8595,7 +8595,7 @@ func (o *DNSUpdateRequest) SetSettingsHash(v string) {
 
 // DNSUpdateSettingsRequest represents API parameter/response structure
 type DNSUpdateSettingsRequest struct {
-	Records      DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+	Records      DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive"`
 	SettingsHash string     `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -8607,7 +8607,7 @@ func (o *DNSUpdateSettingsRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *DNSUpdateSettingsRequest) setDefaults() interface{} {
 	return &struct {
-		Records      DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive" validate:"min=0,max=1000"`
+		Records      DNSRecords `mapconv:"Settings.DNS.[]ResourceRecordSets,recursive"`
 		SettingsHash string     `json:",omitempty" mapconv:",omitempty"`
 	}{
 		Records:      o.GetRecords(),
@@ -8642,8 +8642,8 @@ func (o *DNSUpdateSettingsRequest) SetSettingsHash(v string) {
 // ESME represents API parameter/response structure
 type ESME struct {
 	ID           types.ID
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
+	Name         string
+	Description  string
 	Tags         types.Tags
 	Availability types.EAvailability
 	IconID       types.ID `mapconv:"Icon.ID"`
@@ -8660,8 +8660,8 @@ func (o *ESME) Validate() error {
 func (o *ESME) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
+		Name         string
+		Description  string
 		Tags         types.Tags
 		Availability types.EAvailability
 		IconID       types.ID `mapconv:"Icon.ID"`
@@ -8805,8 +8805,8 @@ func (o *ESME) SetModifiedAt(v time.Time) {
 
 // ESMECreateRequest represents API parameter/response structure
 type ESMECreateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -8819,8 +8819,8 @@ func (o *ESMECreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ESMECreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 		Class       string   `mapconv:"Provider.Class"`
@@ -8899,8 +8899,8 @@ func (o *ESMECreateRequest) SetIconID(v types.ID) {
 
 // ESMEUpdateRequest represents API parameter/response structure
 type ESMEUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -8913,8 +8913,8 @@ func (o *ESMEUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ESMEUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -9271,8 +9271,8 @@ func (o *ESMELogs) SetRetryCount(v int) {
 // GSLB represents API parameter/response structure
 type GSLB struct {
 	ID                 types.ID
-	Name               string `validate:"required"`
-	Description        string `validate:"min=0,max=512"`
+	Name               string
+	Description        string
 	Tags               types.Tags
 	Availability       types.EAvailability
 	IconID             types.ID `mapconv:"Icon.ID"`
@@ -9280,11 +9280,11 @@ type GSLB struct {
 	ModifiedAt         time.Time
 	SettingsHash       string           `json:",omitempty" mapconv:",omitempty"`
 	FQDN               string           `mapconv:"Status.FQDN"`
-	DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+	DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop"`
 	Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
 	HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
 	SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+	DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive"`
 }
 
 // Validate validates by field tags
@@ -9296,8 +9296,8 @@ func (o *GSLB) Validate() error {
 func (o *GSLB) setDefaults() interface{} {
 	return &struct {
 		ID                 types.ID
-		Name               string `validate:"required"`
-		Description        string `validate:"min=0,max=512"`
+		Name               string
+		Description        string
 		Tags               types.Tags
 		Availability       types.EAvailability
 		IconID             types.ID `mapconv:"Icon.ID"`
@@ -9305,11 +9305,11 @@ func (o *GSLB) setDefaults() interface{} {
 		ModifiedAt         time.Time
 		SettingsHash       string           `json:",omitempty" mapconv:",omitempty"`
 		FQDN               string           `mapconv:"Status.FQDN"`
-		DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+		DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop"`
 		Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
 		HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
 		SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
-		DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+		DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive"`
 	}{
 		ID:                 o.GetID(),
 		Name:               o.GetName(),
@@ -9528,11 +9528,11 @@ func (o *GSLB) SetDestinationServers(v GSLBServers) {
 
 // GSLBHealthCheck represents API parameter/response structure
 type GSLBHealthCheck struct {
-	Protocol     types.EGSLBHealthCheckProtocol `validate:"oneof=http https ping tcp"`
-	HostHeader   string                         `mapconv:"Host"`
-	Path         string                         `mapconv:"Path"`
-	ResponseCode types.StringNumber             `mapconv:"Status"`
-	Port         types.StringNumber             `mapconv:"Port"`
+	Protocol     types.EGSLBHealthCheckProtocol
+	HostHeader   string             `mapconv:"Host"`
+	Path         string             `mapconv:"Path"`
+	ResponseCode types.StringNumber `mapconv:"Status"`
+	Port         types.StringNumber `mapconv:"Port"`
 }
 
 // Validate validates by field tags
@@ -9543,11 +9543,11 @@ func (o *GSLBHealthCheck) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *GSLBHealthCheck) setDefaults() interface{} {
 	return &struct {
-		Protocol     types.EGSLBHealthCheckProtocol `validate:"oneof=http https ping tcp"`
-		HostHeader   string                         `mapconv:"Host"`
-		Path         string                         `mapconv:"Path"`
-		ResponseCode types.StringNumber             `mapconv:"Status"`
-		Port         types.StringNumber             `mapconv:"Port"`
+		Protocol     types.EGSLBHealthCheckProtocol
+		HostHeader   string             `mapconv:"Host"`
+		Path         string             `mapconv:"Path"`
+		ResponseCode types.StringNumber `mapconv:"Status"`
+		Port         types.StringNumber `mapconv:"Port"`
 	}{
 		Protocol:     o.GetProtocol(),
 		HostHeader:   o.GetHostHeader(),
@@ -9613,7 +9613,7 @@ func (o *GSLBHealthCheck) SetPort(v types.StringNumber) {
 
 // GSLBServer represents API parameter/response structure
 type GSLBServer struct {
-	IPAddress string `validate:"ipv4"`
+	IPAddress string
 	Enabled   types.StringFlag
 	Weight    types.StringNumber
 }
@@ -9626,7 +9626,7 @@ func (o *GSLBServer) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *GSLBServer) setDefaults() interface{} {
 	return &struct {
-		IPAddress string `validate:"ipv4"`
+		IPAddress string
 		Enabled   types.StringFlag
 		Weight    types.StringNumber
 	}{
@@ -9673,12 +9673,12 @@ func (o *GSLBServer) SetWeight(v types.StringNumber) {
 // GSLBCreateRequest represents API parameter/response structure
 type GSLBCreateRequest struct {
 	HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
-	DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+	DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop"`
 	Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
 	SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
-	Name               string           `validate:"required"`
-	Description        string           `validate:"min=0,max=512"`
+	DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive"`
+	Name               string
+	Description        string
 	Tags               types.Tags
 	IconID             types.ID `mapconv:"Icon.ID"`
 }
@@ -9692,12 +9692,12 @@ func (o *GSLBCreateRequest) Validate() error {
 func (o *GSLBCreateRequest) setDefaults() interface{} {
 	return &struct {
 		HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
-		DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+		DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop"`
 		Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
 		SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
-		DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
-		Name               string           `validate:"required"`
-		Description        string           `validate:"min=0,max=512"`
+		DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive"`
+		Name               string
+		Description        string
 		Tags               types.Tags
 		IconID             types.ID `mapconv:"Icon.ID"`
 		Class              string   `mapconv:"Provider.Class"`
@@ -9834,15 +9834,15 @@ func (o *GSLBCreateRequest) SetIconID(v types.ID) {
 
 // GSLBUpdateRequest represents API parameter/response structure
 type GSLBUpdateRequest struct {
-	Name               string `validate:"required"`
-	Description        string `validate:"min=0,max=512"`
+	Name               string
+	Description        string
 	Tags               types.Tags
 	IconID             types.ID         `mapconv:"Icon.ID"`
 	HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
-	DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+	DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop"`
 	Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
 	SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+	DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive"`
 	SettingsHash       string           `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -9854,15 +9854,15 @@ func (o *GSLBUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *GSLBUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name               string `validate:"required"`
-		Description        string `validate:"min=0,max=512"`
+		Name               string
+		Description        string
 		Tags               types.Tags
 		IconID             types.ID         `mapconv:"Icon.ID"`
 		HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
-		DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+		DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop"`
 		Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
 		SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
-		DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+		DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive"`
 		SettingsHash       string           `json:",omitempty" mapconv:",omitempty"`
 	}{
 		Name:               o.GetName(),
@@ -10008,10 +10008,10 @@ func (o *GSLBUpdateRequest) SetSettingsHash(v string) {
 // GSLBUpdateSettingsRequest represents API parameter/response structure
 type GSLBUpdateSettingsRequest struct {
 	HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
-	DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+	DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop"`
 	Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
 	SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
-	DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+	DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive"`
 	SettingsHash       string           `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -10024,10 +10024,10 @@ func (o *GSLBUpdateSettingsRequest) Validate() error {
 func (o *GSLBUpdateSettingsRequest) setDefaults() interface{} {
 	return &struct {
 		HealthCheck        *GSLBHealthCheck `mapconv:"Settings.GSLB.HealthCheck,recursive"`
-		DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop" validate:"min=10,max=60"`
+		DelayLoop          int              `mapconv:"Settings.GSLB.DelayLoop"`
 		Weighted           types.StringFlag `mapconv:"Settings.GSLB.Weighted"`
 		SorryServer        string           `mapconv:"Settings.GSLB.SorryServer"`
-		DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive" validate:"min=0,max=12"`
+		DestinationServers GSLBServers      `mapconv:"Settings.GSLB.[]Servers,recursive"`
 		SettingsHash       string           `json:",omitempty" mapconv:",omitempty"`
 	}{
 		HealthCheck:        o.GetHealthCheck(),
@@ -10109,7 +10109,7 @@ func (o *GSLBUpdateSettingsRequest) SetSettingsHash(v string) {
 // Icon represents API parameter/response structure
 type Icon struct {
 	ID           types.ID
-	Name         string `validate:"required"`
+	Name         string
 	Tags         types.Tags
 	Availability types.EAvailability
 	Scope        types.EScope
@@ -10127,7 +10127,7 @@ func (o *Icon) Validate() error {
 func (o *Icon) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
+		Name         string
 		Tags         types.Tags
 		Availability types.EAvailability
 		Scope        types.EScope
@@ -10272,7 +10272,7 @@ func (o *Icon) SetModifiedAt(v time.Time) {
 
 // IconCreateRequest represents API parameter/response structure
 type IconCreateRequest struct {
-	Name  string `validate:"required"`
+	Name  string
 	Tags  types.Tags
 	Image string
 }
@@ -10285,7 +10285,7 @@ func (o *IconCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *IconCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name  string `validate:"required"`
+		Name  string
 		Tags  types.Tags
 		Image string
 	}{
@@ -10351,7 +10351,7 @@ func (o *IconCreateRequest) SetImage(v string) {
 
 // IconUpdateRequest represents API parameter/response structure
 type IconUpdateRequest struct {
-	Name string `validate:"required"`
+	Name string
 	Tags types.Tags
 }
 
@@ -10363,7 +10363,7 @@ func (o *IconUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *IconUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name string `validate:"required"`
+		Name string
 		Tags types.Tags
 	}{
 		Name: o.GetName(),
@@ -10654,13 +10654,13 @@ func (o *InterfaceUpdateRequest) SetUserIPAddress(v string) {
 // Internet represents API parameter/response structure
 type Internet struct {
 	ID             types.ID
-	Name           string `validate:"required"`
-	Description    string `validate:"min=0,max=512"`
+	Name           string
+	Description    string
 	Tags           types.Tags
 	IconID         types.ID `mapconv:"Icon.ID"`
 	CreatedAt      time.Time
 	BandWidthMbps  int
-	NetworkMaskLen int         `validate:"min=24,max=28"`
+	NetworkMaskLen int
 	Switch         *SwitchInfo `mapconv:",recursive"`
 }
 
@@ -10673,13 +10673,13 @@ func (o *Internet) Validate() error {
 func (o *Internet) setDefaults() interface{} {
 	return &struct {
 		ID             types.ID
-		Name           string `validate:"required"`
-		Description    string `validate:"min=0,max=512"`
+		Name           string
+		Description    string
 		Tags           types.Tags
 		IconID         types.ID `mapconv:"Icon.ID"`
 		CreatedAt      time.Time
 		BandWidthMbps  int
-		NetworkMaskLen int         `validate:"min=24,max=28"`
+		NetworkMaskLen int
 		Switch         *SwitchInfo `mapconv:",recursive"`
 	}{
 		ID:             o.GetID(),
@@ -10831,8 +10831,8 @@ func (o *Internet) SetSwitch(v *SwitchInfo) {
 // SwitchInfo represents API parameter/response structure
 type SwitchInfo struct {
 	ID          types.ID
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	Scope       types.EScope
 	Subnets     []*InternetSubnet `mapconv:"[]Subnets,recursive"`
@@ -10848,8 +10848,8 @@ func (o *SwitchInfo) Validate() error {
 func (o *SwitchInfo) setDefaults() interface{} {
 	return &struct {
 		ID          types.ID
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		Scope       types.EScope
 		Subnets     []*InternetSubnet `mapconv:"[]Subnets,recursive"`
@@ -10982,11 +10982,11 @@ func (o *SwitchInfo) SetIPv6Nets(v []*IPv6NetInfo) {
 // InternetSubnet represents API parameter/response structure
 type InternetSubnet struct {
 	ID             types.ID
-	DefaultRoute   string `validate:"ipv4"`
-	NextHop        string `validate:"ipv4"`
-	StaticRoute    string `validate:"ipv4"`
-	NetworkAddress string `validate:"ipv4"`
-	NetworkMaskLen int    `validate:"min=24,max=28"`
+	DefaultRoute   string
+	NextHop        string
+	StaticRoute    string
+	NetworkAddress string
+	NetworkMaskLen int
 }
 
 // Validate validates by field tags
@@ -10998,11 +10998,11 @@ func (o *InternetSubnet) Validate() error {
 func (o *InternetSubnet) setDefaults() interface{} {
 	return &struct {
 		ID             types.ID
-		DefaultRoute   string `validate:"ipv4"`
-		NextHop        string `validate:"ipv4"`
-		StaticRoute    string `validate:"ipv4"`
-		NetworkAddress string `validate:"ipv4"`
-		NetworkMaskLen int    `validate:"min=24,max=28"`
+		DefaultRoute   string
+		NextHop        string
+		StaticRoute    string
+		NetworkAddress string
+		NetworkMaskLen int
 	}{
 		ID:             o.GetID(),
 		DefaultRoute:   o.GetDefaultRoute(),
@@ -11178,11 +11178,11 @@ func (o *IPv6NetInfo) SetIPv6PrefixLen(v int) {
 
 // InternetCreateRequest represents API parameter/response structure
 type InternetCreateRequest struct {
-	Name           string `validate:"required"`
-	Description    string `validate:"min=0,max=512"`
+	Name           string
+	Description    string
 	Tags           types.Tags
 	IconID         types.ID `mapconv:"Icon.ID"`
-	NetworkMaskLen int      `validate:"min=24,max=28"`
+	NetworkMaskLen int
 	BandWidthMbps  int
 }
 
@@ -11194,11 +11194,11 @@ func (o *InternetCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *InternetCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name           string `validate:"required"`
-		Description    string `validate:"min=0,max=512"`
+		Name           string
+		Description    string
 		Tags           types.Tags
 		IconID         types.ID `mapconv:"Icon.ID"`
-		NetworkMaskLen int      `validate:"min=24,max=28"`
+		NetworkMaskLen int
 		BandWidthMbps  int
 	}{
 		Name:           o.GetName(),
@@ -11296,8 +11296,8 @@ func (o *InternetCreateRequest) SetBandWidthMbps(v int) {
 
 // InternetUpdateRequest represents API parameter/response structure
 type InternetUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -11310,8 +11310,8 @@ func (o *InternetUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *InternetUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -11422,11 +11422,11 @@ func (o *InternetUpdateBandWidthRequest) SetBandWidthMbps(v int) {
 // InternetSubnetOperationResult represents API parameter/response structure
 type InternetSubnetOperationResult struct {
 	ID             types.ID
-	DefaultRoute   string   `validate:"ipv4"`
-	NextHop        string   `validate:"ipv4"`
-	StaticRoute    string   `validate:"ipv4"`
-	NetworkAddress string   `validate:"ipv4"`
-	NetworkMaskLen int      `validate:"min=24,max=28"`
+	DefaultRoute   string
+	NextHop        string
+	StaticRoute    string
+	NetworkAddress string
+	NetworkMaskLen int
 	IPAddresses    []string `mapconv:"[]IPAddresses.IPAddress"`
 }
 
@@ -11439,11 +11439,11 @@ func (o *InternetSubnetOperationResult) Validate() error {
 func (o *InternetSubnetOperationResult) setDefaults() interface{} {
 	return &struct {
 		ID             types.ID
-		DefaultRoute   string   `validate:"ipv4"`
-		NextHop        string   `validate:"ipv4"`
-		StaticRoute    string   `validate:"ipv4"`
-		NetworkAddress string   `validate:"ipv4"`
-		NetworkMaskLen int      `validate:"min=24,max=28"`
+		DefaultRoute   string
+		NextHop        string
+		StaticRoute    string
+		NetworkAddress string
+		NetworkMaskLen int
 		IPAddresses    []string `mapconv:"[]IPAddresses.IPAddress"`
 	}{
 		ID:             o.GetID(),
@@ -11552,8 +11552,8 @@ func (o *InternetSubnetOperationResult) SetIPAddresses(v []string) {
 
 // InternetAddSubnetRequest represents API parameter/response structure
 type InternetAddSubnetRequest struct {
-	NetworkMaskLen int    `validate:"min=24,max=28"`
-	NextHop        string `validate:"ipv4"`
+	NetworkMaskLen int
+	NextHop        string
 }
 
 // Validate validates by field tags
@@ -11564,8 +11564,8 @@ func (o *InternetAddSubnetRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *InternetAddSubnetRequest) setDefaults() interface{} {
 	return &struct {
-		NetworkMaskLen int    `validate:"min=24,max=28"`
-		NextHop        string `validate:"ipv4"`
+		NetworkMaskLen int
+		NextHop        string
 	}{
 		NetworkMaskLen: o.GetNetworkMaskLen(),
 		NextHop:        o.GetNextHop(),
@@ -11598,7 +11598,7 @@ func (o *InternetAddSubnetRequest) SetNextHop(v string) {
 
 // InternetUpdateSubnetRequest represents API parameter/response structure
 type InternetUpdateSubnetRequest struct {
-	NextHop string `validate:"ipv4"`
+	NextHop string
 }
 
 // Validate validates by field tags
@@ -11609,7 +11609,7 @@ func (o *InternetUpdateSubnetRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *InternetUpdateSubnetRequest) setDefaults() interface{} {
 	return &struct {
-		NextHop string `validate:"ipv4"`
+		NextHop string
 	}{
 		NextHop: o.GetNextHop(),
 	}
@@ -11724,7 +11724,7 @@ func (o *MonitorRouterValue) SetOut(v float64) {
 // InternetPlan represents API parameter/response structure
 type InternetPlan struct {
 	ID            types.ID
-	Name          string `validate:"required"`
+	Name          string
 	BandWidthMbps int
 	Availability  types.EAvailability
 }
@@ -11738,7 +11738,7 @@ func (o *InternetPlan) Validate() error {
 func (o *InternetPlan) setDefaults() interface{} {
 	return &struct {
 		ID            types.ID
-		Name          string `validate:"required"`
+		Name          string
 		BandWidthMbps int
 		Availability  types.EAvailability
 	}{
@@ -12222,7 +12222,7 @@ func (o *IPv6AddrUpdateRequest) SetHostName(v string) {
 // License represents API parameter/response structure
 type License struct {
 	ID              types.ID
-	Name            string   `validate:"required"`
+	Name            string
 	LicenseInfoID   types.ID `mapconv:"LicenseInfo.ID"`
 	LicenseInfoName string   `mapconv:"LicenseInfo.Name"`
 	CreatedAt       time.Time
@@ -12238,7 +12238,7 @@ func (o *License) Validate() error {
 func (o *License) setDefaults() interface{} {
 	return &struct {
 		ID              types.ID
-		Name            string   `validate:"required"`
+		Name            string
 		LicenseInfoID   types.ID `mapconv:"LicenseInfo.ID"`
 		LicenseInfoName string   `mapconv:"LicenseInfo.Name"`
 		CreatedAt       time.Time
@@ -12339,7 +12339,7 @@ func (o *License) SetModifiedAt(v time.Time) {
 
 // LicenseCreateRequest represents API parameter/response structure
 type LicenseCreateRequest struct {
-	Name          string   `validate:"required"`
+	Name          string
 	LicenseInfoID types.ID `mapconv:"LicenseInfo.ID"`
 }
 
@@ -12351,7 +12351,7 @@ func (o *LicenseCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LicenseCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name          string   `validate:"required"`
+		Name          string
 		LicenseInfoID types.ID `mapconv:"LicenseInfo.ID"`
 	}{
 		Name:          o.GetName(),
@@ -12385,7 +12385,7 @@ func (o *LicenseCreateRequest) SetLicenseInfoID(v types.ID) {
 
 // LicenseUpdateRequest represents API parameter/response structure
 type LicenseUpdateRequest struct {
-	Name string `validate:"required"`
+	Name string
 }
 
 // Validate validates by field tags
@@ -12396,7 +12396,7 @@ func (o *LicenseUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LicenseUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name string `validate:"required"`
+		Name string
 	}{
 		Name: o.GetName(),
 	}
@@ -12419,7 +12419,7 @@ func (o *LicenseUpdateRequest) SetName(v string) {
 // LicenseInfo represents API parameter/response structure
 type LicenseInfo struct {
 	ID         types.ID
-	Name       string `validate:"required"`
+	Name       string
 	CreatedAt  time.Time
 	ModifiedAt time.Time
 	TermsOfUse string
@@ -12434,7 +12434,7 @@ func (o *LicenseInfo) Validate() error {
 func (o *LicenseInfo) setDefaults() interface{} {
 	return &struct {
 		ID         types.ID
-		Name       string `validate:"required"`
+		Name       string
 		CreatedAt  time.Time
 		ModifiedAt time.Time
 		TermsOfUse string
@@ -12524,8 +12524,8 @@ func (o *LicenseInfo) SetTermsOfUse(v string) {
 // LoadBalancer represents API parameter/response structure
 type LoadBalancer struct {
 	ID                      types.ID
-	Name                    string `validate:"required"`
-	Description             string `validate:"min=0,max=512"`
+	Name                    string
+	Description             string
 	Tags                    types.Tags
 	Availability            types.EAvailability
 	Class                   string
@@ -12538,12 +12538,12 @@ type LoadBalancer struct {
 	InstanceStatusChangedAt time.Time                      `mapconv:"Instance.StatusChangedAt"`
 	PlanID                  types.ID                       `mapconv:"Remark.Plan.ID/Plan.ID"`
 	SwitchID                types.ID                       `mapconv:"Remark.Switch.ID"`
-	DefaultRoute            string                         `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-	NetworkMaskLen          int                            `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
+	DefaultRoute            string                         `mapconv:"Remark.Network.DefaultRoute"`
+	NetworkMaskLen          int                            `mapconv:"Remark.Network.NetworkMaskLen"`
 	IPAddresses             []string                       `mapconv:"Remark.[]Servers.IPAddress"`
 	ZoneID                  types.ID                       `mapconv:"Remark.Zone.ID"`
 	VRID                    int                            `mapconv:"Remark.VRRP.VRID"`
-	VirtualIPAddresses      LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+	VirtualIPAddresses      LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive"`
 	SettingsHash            string                         `json:",omitempty" mapconv:",omitempty"`
 	Interfaces              []*InterfaceView               `json:",omitempty" mapconv:"[]Interfaces,recursive,omitempty"`
 }
@@ -12557,8 +12557,8 @@ func (o *LoadBalancer) Validate() error {
 func (o *LoadBalancer) setDefaults() interface{} {
 	return &struct {
 		ID                      types.ID
-		Name                    string `validate:"required"`
-		Description             string `validate:"min=0,max=512"`
+		Name                    string
+		Description             string
 		Tags                    types.Tags
 		Availability            types.EAvailability
 		Class                   string
@@ -12571,12 +12571,12 @@ func (o *LoadBalancer) setDefaults() interface{} {
 		InstanceStatusChangedAt time.Time                      `mapconv:"Instance.StatusChangedAt"`
 		PlanID                  types.ID                       `mapconv:"Remark.Plan.ID/Plan.ID"`
 		SwitchID                types.ID                       `mapconv:"Remark.Switch.ID"`
-		DefaultRoute            string                         `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-		NetworkMaskLen          int                            `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
+		DefaultRoute            string                         `mapconv:"Remark.Network.DefaultRoute"`
+		NetworkMaskLen          int                            `mapconv:"Remark.Network.NetworkMaskLen"`
 		IPAddresses             []string                       `mapconv:"Remark.[]Servers.IPAddress"`
 		ZoneID                  types.ID                       `mapconv:"Remark.Zone.ID"`
 		VRID                    int                            `mapconv:"Remark.VRRP.VRID"`
-		VirtualIPAddresses      LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+		VirtualIPAddresses      LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive"`
 		SettingsHash            string                         `json:",omitempty" mapconv:",omitempty"`
 		Interfaces              []*InterfaceView               `json:",omitempty" mapconv:"[]Interfaces,recursive,omitempty"`
 	}{
@@ -12882,12 +12882,12 @@ func (o *LoadBalancer) SetInterfaces(v []*InterfaceView) {
 
 // LoadBalancerVirtualIPAddress represents API parameter/response structure
 type LoadBalancerVirtualIPAddress struct {
-	VirtualIPAddress string              `validate:"ipv4"`
-	Port             types.StringNumber  `validate:"min=1,max=65535"`
-	DelayLoop        types.StringNumber  `mapconv:",default=10" validate:"min=0,max=10000"`
-	SorryServer      string              `validate:"omitempty,ipv4"`
-	Description      string              `validate:"min=0,max=512"`
-	Servers          LoadBalancerServers `mapconv:"[]Servers,recursive" validate:"min=0,max=40"`
+	VirtualIPAddress string
+	Port             types.StringNumber
+	DelayLoop        types.StringNumber `mapconv:",default=10"`
+	SorryServer      string
+	Description      string
+	Servers          LoadBalancerServers `mapconv:"[]Servers,recursive"`
 }
 
 // Validate validates by field tags
@@ -12898,12 +12898,12 @@ func (o *LoadBalancerVirtualIPAddress) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LoadBalancerVirtualIPAddress) setDefaults() interface{} {
 	return &struct {
-		VirtualIPAddress string              `validate:"ipv4"`
-		Port             types.StringNumber  `validate:"min=1,max=65535"`
-		DelayLoop        types.StringNumber  `mapconv:",default=10" validate:"min=0,max=10000"`
-		SorryServer      string              `validate:"omitempty,ipv4"`
-		Description      string              `validate:"min=0,max=512"`
-		Servers          LoadBalancerServers `mapconv:"[]Servers,recursive" validate:"min=0,max=40"`
+		VirtualIPAddress string
+		Port             types.StringNumber
+		DelayLoop        types.StringNumber `mapconv:",default=10"`
+		SorryServer      string
+		Description      string
+		Servers          LoadBalancerServers `mapconv:"[]Servers,recursive"`
 	}{
 		VirtualIPAddress: o.GetVirtualIPAddress(),
 		Port:             o.GetPort(),
@@ -12983,8 +12983,8 @@ func (o *LoadBalancerVirtualIPAddress) SetServers(v LoadBalancerServers) {
 
 // LoadBalancerServer represents API parameter/response structure
 type LoadBalancerServer struct {
-	IPAddress   string             `validate:"ipv4"`
-	Port        types.StringNumber `validate:"min=1,max=65535"`
+	IPAddress   string
+	Port        types.StringNumber
 	Enabled     types.StringFlag
 	HealthCheck *LoadBalancerServerHealthCheck `mapconv:"HealthCheck,recursive"`
 }
@@ -12997,8 +12997,8 @@ func (o *LoadBalancerServer) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LoadBalancerServer) setDefaults() interface{} {
 	return &struct {
-		IPAddress   string             `validate:"ipv4"`
-		Port        types.StringNumber `validate:"min=1,max=65535"`
+		IPAddress   string
+		Port        types.StringNumber
 		Enabled     types.StringFlag
 		HealthCheck *LoadBalancerServerHealthCheck `mapconv:"HealthCheck,recursive"`
 	}{
@@ -13055,7 +13055,7 @@ func (o *LoadBalancerServer) SetHealthCheck(v *LoadBalancerServerHealthCheck) {
 
 // LoadBalancerServerHealthCheck represents API parameter/response structure
 type LoadBalancerServerHealthCheck struct {
-	Protocol     types.ELoadBalancerHealthCheckProtocol `validate:"oneof=http https ping tcp"`
+	Protocol     types.ELoadBalancerHealthCheckProtocol
 	Path         string
 	ResponseCode types.StringNumber `mapconv:"Status"`
 }
@@ -13068,7 +13068,7 @@ func (o *LoadBalancerServerHealthCheck) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LoadBalancerServerHealthCheck) setDefaults() interface{} {
 	return &struct {
-		Protocol     types.ELoadBalancerHealthCheckProtocol `validate:"oneof=http https ping tcp"`
+		Protocol     types.ELoadBalancerHealthCheckProtocol
 		Path         string
 		ResponseCode types.StringNumber `mapconv:"Status"`
 	}{
@@ -13117,14 +13117,14 @@ type LoadBalancerCreateRequest struct {
 	SwitchID           types.ID `mapconv:"Remark.Switch.ID"`
 	PlanID             types.ID `mapconv:"Remark.Plan.ID/Plan.ID"`
 	VRID               int      `mapconv:"Remark.VRRP.VRID"`
-	IPAddresses        []string `mapconv:"Remark.[]Servers.IPAddress" validate:"min=1,max=2,dive,ipv4"`
-	NetworkMaskLen     int      `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
-	DefaultRoute       string   `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-	Name               string   `validate:"required"`
-	Description        string   `validate:"min=0,max=512"`
+	IPAddresses        []string `mapconv:"Remark.[]Servers.IPAddress"`
+	NetworkMaskLen     int      `mapconv:"Remark.Network.NetworkMaskLen"`
+	DefaultRoute       string   `mapconv:"Remark.Network.DefaultRoute"`
+	Name               string
+	Description        string
 	Tags               types.Tags
 	IconID             types.ID                       `mapconv:"Icon.ID"`
-	VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+	VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive"`
 }
 
 // Validate validates by field tags
@@ -13138,14 +13138,14 @@ func (o *LoadBalancerCreateRequest) setDefaults() interface{} {
 		SwitchID           types.ID `mapconv:"Remark.Switch.ID"`
 		PlanID             types.ID `mapconv:"Remark.Plan.ID/Plan.ID"`
 		VRID               int      `mapconv:"Remark.VRRP.VRID"`
-		IPAddresses        []string `mapconv:"Remark.[]Servers.IPAddress" validate:"min=1,max=2,dive,ipv4"`
-		NetworkMaskLen     int      `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
-		DefaultRoute       string   `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-		Name               string   `validate:"required"`
-		Description        string   `validate:"min=0,max=512"`
+		IPAddresses        []string `mapconv:"Remark.[]Servers.IPAddress"`
+		NetworkMaskLen     int      `mapconv:"Remark.Network.NetworkMaskLen"`
+		DefaultRoute       string   `mapconv:"Remark.Network.DefaultRoute"`
+		Name               string
+		Description        string
 		Tags               types.Tags
 		IconID             types.ID                       `mapconv:"Icon.ID"`
-		VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+		VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive"`
 		Class              string
 	}{
 		SwitchID:           o.GetSwitchID(),
@@ -13299,11 +13299,11 @@ func (o *LoadBalancerCreateRequest) SetVirtualIPAddresses(v LoadBalancerVirtualI
 
 // LoadBalancerUpdateRequest represents API parameter/response structure
 type LoadBalancerUpdateRequest struct {
-	Name               string `validate:"required"`
-	Description        string `validate:"min=0,max=512"`
+	Name               string
+	Description        string
 	Tags               types.Tags
 	IconID             types.ID                       `mapconv:"Icon.ID"`
-	VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+	VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive"`
 	SettingsHash       string                         `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -13315,11 +13315,11 @@ func (o *LoadBalancerUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LoadBalancerUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name               string `validate:"required"`
-		Description        string `validate:"min=0,max=512"`
+		Name               string
+		Description        string
 		Tags               types.Tags
 		IconID             types.ID                       `mapconv:"Icon.ID"`
-		VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+		VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive"`
 		SettingsHash       string                         `json:",omitempty" mapconv:",omitempty"`
 	}{
 		Name:               o.GetName(),
@@ -13417,7 +13417,7 @@ func (o *LoadBalancerUpdateRequest) SetSettingsHash(v string) {
 
 // LoadBalancerUpdateSettingsRequest represents API parameter/response structure
 type LoadBalancerUpdateSettingsRequest struct {
-	VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+	VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive"`
 	SettingsHash       string                         `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -13429,7 +13429,7 @@ func (o *LoadBalancerUpdateSettingsRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LoadBalancerUpdateSettingsRequest) setDefaults() interface{} {
 	return &struct {
-		VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive" validate:"min=0,max=10"`
+		VirtualIPAddresses LoadBalancerVirtualIPAddresses `mapconv:"Settings.[]LoadBalancer,recursive"`
 		SettingsHash       string                         `json:",omitempty" mapconv:",omitempty"`
 	}{
 		VirtualIPAddresses: o.GetVirtualIPAddresses(),
@@ -13621,8 +13621,8 @@ func (o *LoadBalancerServerStatus) SetCPS(v types.StringNumber) {
 // LocalRouter represents API parameter/response structure
 type LocalRouter struct {
 	ID           types.ID
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
+	Name         string
+	Description  string
 	Tags         types.Tags
 	Availability types.EAvailability
 	IconID       types.ID `mapconv:"Icon.ID"`
@@ -13645,8 +13645,8 @@ func (o *LocalRouter) Validate() error {
 func (o *LocalRouter) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
+		Name         string
+		Description  string
 		Tags         types.Tags
 		Availability types.EAvailability
 		IconID       types.ID `mapconv:"Icon.ID"`
@@ -14111,8 +14111,8 @@ func (o *LocalRouterStaticRoute) SetNextHop(v string) {
 
 // LocalRouterCreateRequest represents API parameter/response structure
 type LocalRouterCreateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -14125,8 +14125,8 @@ func (o *LocalRouterCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *LocalRouterCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 		Class       string   `mapconv:"Provider.Class"`
@@ -14210,8 +14210,8 @@ type LocalRouterUpdateRequest struct {
 	Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
 	StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
 	SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
-	Name         string                    `validate:"required"`
-	Description  string                    `validate:"min=0,max=512"`
+	Name         string
+	Description  string
 	Tags         types.Tags
 	IconID       types.ID `mapconv:"Icon.ID"`
 }
@@ -14229,8 +14229,8 @@ func (o *LocalRouterUpdateRequest) setDefaults() interface{} {
 		Peers        []*LocalRouterPeer        `mapconv:"Settings.LocalRouter.[]Peers,recursive"`
 		StaticRoutes []*LocalRouterStaticRoute `mapconv:"Settings.LocalRouter.[]StaticRoutes,recursive"`
 		SettingsHash string                    `json:",omitempty" mapconv:",omitempty"`
-		Name         string                    `validate:"required"`
-		Description  string                    `validate:"min=0,max=512"`
+		Name         string
+		Description  string
 		Tags         types.Tags
 		IconID       types.ID `mapconv:"Icon.ID"`
 	}{
@@ -14632,8 +14632,8 @@ func (o *MonitorLocalRouterValue) SetSendBytesPerSec(v float64) {
 // MobileGateway represents API parameter/response structure
 type MobileGateway struct {
 	ID                              types.ID
-	Name                            string `validate:"required"`
-	Description                     string `validate:"min=0,max=512"`
+	Name                            string
+	Description                     string
 	Tags                            types.Tags
 	Availability                    types.EAvailability
 	Class                           string
@@ -14661,8 +14661,8 @@ func (o *MobileGateway) Validate() error {
 func (o *MobileGateway) setDefaults() interface{} {
 	return &struct {
 		ID                              types.ID
-		Name                            string `validate:"required"`
-		Description                     string `validate:"min=0,max=512"`
+		Name                            string
+		Description                     string
 		Tags                            types.Tags
 		Availability                    types.EAvailability
 		Class                           string
@@ -15330,8 +15330,8 @@ func (o *MobileGatewayStaticRoute) SetNextHop(v string) {
 
 // MobileGatewayCreateRequest represents API parameter/response structure
 type MobileGatewayCreateRequest struct {
-	Name                            string `validate:"required"`
-	Description                     string `validate:"min=0,max=512"`
+	Name                            string
+	Description                     string
 	Tags                            types.Tags
 	IconID                          types.ID                    `mapconv:"Icon.ID"`
 	StaticRoutes                    []*MobileGatewayStaticRoute `json:",omitempty" mapconv:"Settings.MobileGateway.[]StaticRoutes,omitempty,recursive"`
@@ -15347,8 +15347,8 @@ func (o *MobileGatewayCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MobileGatewayCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name                            string `validate:"required"`
-		Description                     string `validate:"min=0,max=512"`
+		Name                            string
+		Description                     string
 		Tags                            types.Tags
 		IconID                          types.ID                    `mapconv:"Icon.ID"`
 		StaticRoutes                    []*MobileGatewayStaticRoute `json:",omitempty" mapconv:"Settings.MobileGateway.[]StaticRoutes,omitempty,recursive"`
@@ -15467,8 +15467,8 @@ func (o *MobileGatewayCreateRequest) SetInterDeviceCommunicationEnabled(v types.
 
 // MobileGatewayUpdateRequest represents API parameter/response structure
 type MobileGatewayUpdateRequest struct {
-	Name                            string `validate:"required"`
-	Description                     string `validate:"min=0,max=512"`
+	Name                            string
+	Description                     string
 	Tags                            types.Tags
 	IconID                          types.ID                         `mapconv:"Icon.ID"`
 	InterfaceSettings               []*MobileGatewayInterfaceSetting `mapconv:"Settings.MobileGateway.[]Interfaces,recursive"`
@@ -15486,8 +15486,8 @@ func (o *MobileGatewayUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *MobileGatewayUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name                            string `validate:"required"`
-		Description                     string `validate:"min=0,max=512"`
+		Name                            string
+		Description                     string
 		Tags                            types.Tags
 		IconID                          types.ID                         `mapconv:"Icon.ID"`
 		InterfaceSettings               []*MobileGatewayInterfaceSetting `mapconv:"Settings.MobileGateway.[]Interfaces,recursive"`
@@ -16397,8 +16397,8 @@ func (o *MobileGatewayTrafficStatus) SetTrafficShaping(v bool) {
 // NFS represents API parameter/response structure
 type NFS struct {
 	ID                      types.ID
-	Name                    string `validate:"required"`
-	Description             string `validate:"min=0,max=512"`
+	Name                    string
+	Description             string
 	Tags                    types.Tags
 	Availability            types.EAvailability
 	Class                   string
@@ -16409,8 +16409,8 @@ type NFS struct {
 	Interfaces              []*InterfaceView            `json:",omitempty" mapconv:"[]Interfaces,recursive,omitempty"`
 	PlanID                  types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
 	SwitchID                types.ID                    `mapconv:"Remark.Switch.ID"`
-	DefaultRoute            string                      `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-	NetworkMaskLen          int                         `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
+	DefaultRoute            string                      `mapconv:"Remark.Network.DefaultRoute"`
+	NetworkMaskLen          int                         `mapconv:"Remark.Network.NetworkMaskLen"`
 	IPAddresses             []string                    `mapconv:"Remark.[]Servers.IPAddress"`
 	ZoneID                  types.ID                    `mapconv:"Remark.Zone.ID"`
 	IconID                  types.ID                    `mapconv:"Icon.ID"`
@@ -16428,8 +16428,8 @@ func (o *NFS) Validate() error {
 func (o *NFS) setDefaults() interface{} {
 	return &struct {
 		ID                      types.ID
-		Name                    string `validate:"required"`
-		Description             string `validate:"min=0,max=512"`
+		Name                    string
+		Description             string
 		Tags                    types.Tags
 		Availability            types.EAvailability
 		Class                   string
@@ -16440,8 +16440,8 @@ func (o *NFS) setDefaults() interface{} {
 		Interfaces              []*InterfaceView            `json:",omitempty" mapconv:"[]Interfaces,recursive,omitempty"`
 		PlanID                  types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
 		SwitchID                types.ID                    `mapconv:"Remark.Switch.ID"`
-		DefaultRoute            string                      `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-		NetworkMaskLen          int                         `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
+		DefaultRoute            string                      `mapconv:"Remark.Network.DefaultRoute"`
+		NetworkMaskLen          int                         `mapconv:"Remark.Network.NetworkMaskLen"`
 		IPAddresses             []string                    `mapconv:"Remark.[]Servers.IPAddress"`
 		ZoneID                  types.ID                    `mapconv:"Remark.Zone.ID"`
 		IconID                  types.ID                    `mapconv:"Icon.ID"`
@@ -16731,11 +16731,11 @@ func (o *NFS) SetSwitchName(v string) {
 type NFSCreateRequest struct {
 	SwitchID       types.ID `mapconv:"Remark.Switch.ID"`
 	PlanID         types.ID `mapconv:"Remark.Plan.ID/Plan.ID"`
-	IPAddresses    []string `mapconv:"Remark.[]Servers.IPAddress" validate:"min=1,max=2,dive,ipv4"`
-	NetworkMaskLen int      `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
-	DefaultRoute   string   `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-	Name           string   `validate:"required"`
-	Description    string   `validate:"min=0,max=512"`
+	IPAddresses    []string `mapconv:"Remark.[]Servers.IPAddress"`
+	NetworkMaskLen int      `mapconv:"Remark.Network.NetworkMaskLen"`
+	DefaultRoute   string   `mapconv:"Remark.Network.DefaultRoute"`
+	Name           string
+	Description    string
 	Tags           types.Tags
 	IconID         types.ID `mapconv:"Icon.ID"`
 }
@@ -16750,11 +16750,11 @@ func (o *NFSCreateRequest) setDefaults() interface{} {
 	return &struct {
 		SwitchID       types.ID `mapconv:"Remark.Switch.ID"`
 		PlanID         types.ID `mapconv:"Remark.Plan.ID/Plan.ID"`
-		IPAddresses    []string `mapconv:"Remark.[]Servers.IPAddress" validate:"min=1,max=2,dive,ipv4"`
-		NetworkMaskLen int      `mapconv:"Remark.Network.NetworkMaskLen" validate:"min=1,max=32"`
-		DefaultRoute   string   `mapconv:"Remark.Network.DefaultRoute" validate:"ipv4"`
-		Name           string   `validate:"required"`
-		Description    string   `validate:"min=0,max=512"`
+		IPAddresses    []string `mapconv:"Remark.[]Servers.IPAddress"`
+		NetworkMaskLen int      `mapconv:"Remark.Network.NetworkMaskLen"`
+		DefaultRoute   string   `mapconv:"Remark.Network.DefaultRoute"`
+		Name           string
+		Description    string
 		Tags           types.Tags
 		IconID         types.ID `mapconv:"Icon.ID"`
 		Class          string
@@ -16888,8 +16888,8 @@ func (o *NFSCreateRequest) SetIconID(v types.ID) {
 
 // NFSUpdateRequest represents API parameter/response structure
 type NFSUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -16902,8 +16902,8 @@ func (o *NFSUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *NFSUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -17060,8 +17060,8 @@ func (o *MonitorFreeDiskSizeValue) SetFreeDiskSize(v float64) {
 // Note represents API parameter/response structure
 type Note struct {
 	ID           types.ID
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
+	Name         string
+	Description  string
 	Tags         types.Tags
 	Availability types.EAvailability
 	Scope        types.EScope
@@ -17081,8 +17081,8 @@ func (o *Note) Validate() error {
 func (o *Note) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
+		Name         string
+		Description  string
 		Tags         types.Tags
 		Availability types.EAvailability
 		Scope        types.EScope
@@ -17262,7 +17262,7 @@ func (o *Note) SetModifiedAt(v time.Time) {
 
 // NoteCreateRequest represents API parameter/response structure
 type NoteCreateRequest struct {
-	Name    string `validate:"required"`
+	Name    string
 	Tags    types.Tags
 	IconID  types.ID `mapconv:"Icon.ID"`
 	Class   string
@@ -17277,7 +17277,7 @@ func (o *NoteCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *NoteCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name    string `validate:"required"`
+		Name    string
 		Tags    types.Tags
 		IconID  types.ID `mapconv:"Icon.ID"`
 		Class   string
@@ -17367,7 +17367,7 @@ func (o *NoteCreateRequest) SetContent(v string) {
 
 // NoteUpdateRequest represents API parameter/response structure
 type NoteUpdateRequest struct {
-	Name    string `validate:"required"`
+	Name    string
 	Tags    types.Tags
 	IconID  types.ID `mapconv:"Icon.ID"`
 	Class   string
@@ -17382,7 +17382,7 @@ func (o *NoteUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *NoteUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name    string `validate:"required"`
+		Name    string
 		Tags    types.Tags
 		IconID  types.ID `mapconv:"Icon.ID"`
 		Class   string
@@ -17473,8 +17473,8 @@ func (o *NoteUpdateRequest) SetContent(v string) {
 // PacketFilter represents API parameter/response structure
 type PacketFilter struct {
 	ID                  types.ID
-	Name                string `validate:"required"`
-	Description         string `validate:"min=0,max=512"`
+	Name                string
+	Description         string
 	RequiredHostVersion types.StringNumber
 	Expression          []*PacketFilterExpression `mapconv:"[]Expression,recursive"`
 	ExpressionHash      string
@@ -17490,8 +17490,8 @@ func (o *PacketFilter) Validate() error {
 func (o *PacketFilter) setDefaults() interface{} {
 	return &struct {
 		ID                  types.ID
-		Name                string `validate:"required"`
-		Description         string `validate:"min=0,max=512"`
+		Name                string
+		Description         string
 		RequiredHostVersion types.StringNumber
 		Expression          []*PacketFilterExpression `mapconv:"[]Expression,recursive"`
 		ExpressionHash      string
@@ -17701,8 +17701,8 @@ func (o *PacketFilterExpression) SetDescription(v string) {
 
 // PacketFilterCreateRequest represents API parameter/response structure
 type PacketFilterCreateRequest struct {
-	Name        string                    `validate:"required"`
-	Description string                    `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Expression  []*PacketFilterExpression `mapconv:"[]Expression,recursive"`
 }
 
@@ -17714,8 +17714,8 @@ func (o *PacketFilterCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *PacketFilterCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string                    `validate:"required"`
-		Description string                    `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Expression  []*PacketFilterExpression `mapconv:"[]Expression,recursive"`
 	}{
 		Name:        o.GetName(),
@@ -17760,8 +17760,8 @@ func (o *PacketFilterCreateRequest) SetExpression(v []*PacketFilterExpression) {
 
 // PacketFilterUpdateRequest represents API parameter/response structure
 type PacketFilterUpdateRequest struct {
-	Name        string                    `validate:"required"`
-	Description string                    `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Expression  []*PacketFilterExpression `mapconv:"[]Expression,recursive"`
 }
 
@@ -17773,8 +17773,8 @@ func (o *PacketFilterUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *PacketFilterUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string                    `validate:"required"`
-		Description string                    `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Expression  []*PacketFilterExpression `mapconv:"[]Expression,recursive"`
 	}{
 		Name:        o.GetName(),
@@ -17820,8 +17820,8 @@ func (o *PacketFilterUpdateRequest) SetExpression(v []*PacketFilterExpression) {
 // PrivateHost represents API parameter/response structure
 type PrivateHost struct {
 	ID               types.ID
-	Name             string `validate:"required"`
-	Description      string `validate:"min=0,max=512"`
+	Name             string
+	Description      string
 	Tags             types.Tags
 	IconID           types.ID `mapconv:"Icon.ID"`
 	CreatedAt        time.Time
@@ -17844,8 +17844,8 @@ func (o *PrivateHost) Validate() error {
 func (o *PrivateHost) setDefaults() interface{} {
 	return &struct {
 		ID               types.ID
-		Name             string `validate:"required"`
-		Description      string `validate:"min=0,max=512"`
+		Name             string
+		Description      string
 		Tags             types.Tags
 		IconID           types.ID `mapconv:"Icon.ID"`
 		CreatedAt        time.Time
@@ -18081,8 +18081,8 @@ func (o *PrivateHost) SetHostName(v string) {
 
 // PrivateHostCreateRequest represents API parameter/response structure
 type PrivateHostCreateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 	PlanID      types.ID `mapconv:"Plan.ID,omitempty"`
@@ -18096,8 +18096,8 @@ func (o *PrivateHostCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *PrivateHostCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 		PlanID      types.ID `mapconv:"Plan.ID,omitempty"`
@@ -18186,8 +18186,8 @@ func (o *PrivateHostCreateRequest) SetPlanID(v types.ID) {
 
 // PrivateHostUpdateRequest represents API parameter/response structure
 type PrivateHostUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -18200,8 +18200,8 @@ func (o *PrivateHostUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *PrivateHostUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -18279,7 +18279,7 @@ func (o *PrivateHostUpdateRequest) SetIconID(v types.ID) {
 // PrivateHostPlan represents API parameter/response structure
 type PrivateHostPlan struct {
 	ID           types.ID
-	Name         string `validate:"required"`
+	Name         string
 	Class        string
 	CPU          int
 	MemoryMB     int
@@ -18295,7 +18295,7 @@ func (o *PrivateHostPlan) Validate() error {
 func (o *PrivateHostPlan) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
+		Name         string
 		Class        string
 		CPU          int
 		MemoryMB     int
@@ -18407,8 +18407,8 @@ func (o *PrivateHostPlan) SetAvailability(v types.EAvailability) {
 // ProxyLB represents API parameter/response structure
 type ProxyLB struct {
 	ID               types.ID
-	Name             string `validate:"required"`
-	Description      string `validate:"min=0,max=512"`
+	Name             string
+	Description      string
 	Tags             types.Tags
 	Availability     types.EAvailability
 	IconID           types.ID `mapconv:"Icon.ID"`
@@ -18440,8 +18440,8 @@ func (o *ProxyLB) Validate() error {
 func (o *ProxyLB) setDefaults() interface{} {
 	return &struct {
 		ID               types.ID
-		Name             string `validate:"required"`
-		Description      string `validate:"min=0,max=512"`
+		Name             string
+		Description      string
 		Tags             types.Tags
 		Availability     types.EAvailability
 		IconID           types.ID `mapconv:"Icon.ID"`
@@ -18837,8 +18837,8 @@ func (o *ProxyLBHealthCheck) SetDelayLoop(v int) {
 
 // ProxyLBSorryServer represents API parameter/response structure
 type ProxyLBSorryServer struct {
-	IPAddress string `validate:"ipv4"`
-	Port      int    `mapconv:",omitempty" validate:"min=0,max=65535"`
+	IPAddress string
+	Port      int `mapconv:",omitempty"`
 }
 
 // Validate validates by field tags
@@ -18849,8 +18849,8 @@ func (o *ProxyLBSorryServer) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ProxyLBSorryServer) setDefaults() interface{} {
 	return &struct {
-		IPAddress string `validate:"ipv4"`
-		Port      int    `mapconv:",omitempty" validate:"min=0,max=65535"`
+		IPAddress string
+		Port      int `mapconv:",omitempty"`
 	}{
 		IPAddress: o.GetIPAddress(),
 		Port:      o.GetPort(),
@@ -18884,7 +18884,7 @@ func (o *ProxyLBSorryServer) SetPort(v int) {
 // ProxyLBBindPort represents API parameter/response structure
 type ProxyLBBindPort struct {
 	ProxyMode         types.EProxyLBProxyMode
-	Port              int `validate:"min=0,max=65535"`
+	Port              int
 	RedirectToHTTPS   bool
 	SupportHTTP2      bool
 	AddResponseHeader []*ProxyLBResponseHeader `mapconv:"[]AddResponseHeader,recursive"`
@@ -18899,7 +18899,7 @@ func (o *ProxyLBBindPort) Validate() error {
 func (o *ProxyLBBindPort) setDefaults() interface{} {
 	return &struct {
 		ProxyMode         types.EProxyLBProxyMode
-		Port              int `validate:"min=0,max=65535"`
+		Port              int
 		RedirectToHTTPS   bool
 		SupportHTTP2      bool
 		AddResponseHeader []*ProxyLBResponseHeader `mapconv:"[]AddResponseHeader,recursive"`
@@ -19014,8 +19014,8 @@ func (o *ProxyLBResponseHeader) SetValue(v string) {
 
 // ProxyLBServer represents API parameter/response structure
 type ProxyLBServer struct {
-	IPAddress   string `validate:"ipv4"`
-	Port        int    `validate:"min=0,max=65535"`
+	IPAddress   string
+	Port        int
 	ServerGroup string
 	Enabled     bool
 }
@@ -19028,8 +19028,8 @@ func (o *ProxyLBServer) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ProxyLBServer) setDefaults() interface{} {
 	return &struct {
-		IPAddress   string `validate:"ipv4"`
-		Port        int    `validate:"min=0,max=65535"`
+		IPAddress   string
+		Port        int
 		ServerGroup string
 		Enabled     bool
 	}{
@@ -19237,7 +19237,7 @@ func (o *ProxyLBStickySession) SetEnabled(v bool) {
 
 // ProxyLBTimeout represents API parameter/response structure
 type ProxyLBTimeout struct {
-	InactiveSec int `validate:"min=10,max=600"`
+	InactiveSec int
 }
 
 // Validate validates by field tags
@@ -19248,7 +19248,7 @@ func (o *ProxyLBTimeout) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ProxyLBTimeout) setDefaults() interface{} {
 	return &struct {
-		InactiveSec int `validate:"min=10,max=600"`
+		InactiveSec int
 	}{
 		InactiveSec: o.GetInactiveSec(),
 	}
@@ -19284,8 +19284,8 @@ type ProxyLBCreateRequest struct {
 	Timeout        *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
 	UseVIPFailover bool                  `mapconv:"Status.UseVIPFailover"`
 	Region         types.EProxyLBRegion  `mapconv:"Status.Region"`
-	Name           string                `validate:"required"`
-	Description    string                `validate:"min=0,max=512"`
+	Name           string
+	Description    string
 	Tags           types.Tags
 	IconID         types.ID `mapconv:"Icon.ID"`
 }
@@ -19309,8 +19309,8 @@ func (o *ProxyLBCreateRequest) setDefaults() interface{} {
 		Timeout        *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
 		UseVIPFailover bool                  `mapconv:"Status.UseVIPFailover"`
 		Region         types.EProxyLBRegion  `mapconv:"Status.Region"`
-		Name           string                `validate:"required"`
-		Description    string                `validate:"min=0,max=512"`
+		Name           string
+		Description    string
 		Tags           types.Tags
 		IconID         types.ID `mapconv:"Icon.ID"`
 		Class          string   `mapconv:"Provider.Class"`
@@ -19519,8 +19519,8 @@ type ProxyLBUpdateRequest struct {
 	StickySession *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
 	Timeout       *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
 	SettingsHash  string                `json:",omitempty" mapconv:",omitempty"`
-	Name          string                `validate:"required"`
-	Description   string                `validate:"min=0,max=512"`
+	Name          string
+	Description   string
 	Tags          types.Tags
 	IconID        types.ID `mapconv:"Icon.ID"`
 }
@@ -19542,8 +19542,8 @@ func (o *ProxyLBUpdateRequest) setDefaults() interface{} {
 		StickySession *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
 		Timeout       *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
 		SettingsHash  string                `json:",omitempty" mapconv:",omitempty"`
-		Name          string                `validate:"required"`
-		Description   string                `validate:"min=0,max=512"`
+		Name          string
+		Description   string
 		Tags          types.Tags
 		IconID        types.ID `mapconv:"Icon.ID"`
 	}{
@@ -20316,8 +20316,8 @@ func (o *MonitorConnectionValue) SetConnectionsPerSec(v float64) {
 // Server represents API parameter/response structure
 type Server struct {
 	ID                      types.ID
-	Name                    string `validate:"required"`
-	Description             string `validate:"min=0,max=512"`
+	Name                    string
+	Description             string
 	Tags                    types.Tags
 	Availability            types.EAvailability
 	HostName                string
@@ -20356,8 +20356,8 @@ func (o *Server) Validate() error {
 func (o *Server) setDefaults() interface{} {
 	return &struct {
 		ID                      types.ID
-		Name                    string `validate:"required"`
-		Description             string `validate:"min=0,max=512"`
+		Name                    string
+		Description             string
 		Tags                    types.Tags
 		Availability            types.EAvailability
 		HostName                string
@@ -20777,7 +20777,7 @@ func (o *Server) SetModifiedAt(v time.Time) {
 // ZoneInfo represents API parameter/response structure
 type ZoneInfo struct {
 	ID          types.ID
-	Name        string         `validate:"required"`
+	Name        string
 	DisplayName string         `json:",omitempty" mapconv:"Description,omitempty"`
 	IsDummy     bool           `json:",omitempty" mapconv:",omitempty"`
 	VNCProxy    *VNCProxy      `json:",omitempty" mapconv:",omitempty,recursive"`
@@ -20794,7 +20794,7 @@ func (o *ZoneInfo) Validate() error {
 func (o *ZoneInfo) setDefaults() interface{} {
 	return &struct {
 		ID          types.ID
-		Name        string         `validate:"required"`
+		Name        string
 		DisplayName string         `json:",omitempty" mapconv:"Description,omitempty"`
 		IsDummy     bool           `json:",omitempty" mapconv:",omitempty"`
 		VNCProxy    *VNCProxy      `json:",omitempty" mapconv:",omitempty,recursive"`
@@ -21000,7 +21000,7 @@ func (o *FTPServerInfo) SetIPAddress(v string) {
 // ServerConnectedDisk represents API parameter/response structure
 type ServerConnectedDisk struct {
 	ID              types.ID
-	Name            string `validate:"required"`
+	Name            string
 	Availability    types.EAvailability
 	Connection      types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
 	ConnectionOrder int
@@ -21019,7 +21019,7 @@ func (o *ServerConnectedDisk) Validate() error {
 func (o *ServerConnectedDisk) setDefaults() interface{} {
 	return &struct {
 		ID              types.ID
-		Name            string `validate:"required"`
+		Name            string
 		Availability    types.EAvailability
 		Connection      types.EDiskConnection `json:",omitempty" mapconv:",omitempty"`
 		ConnectionOrder int
@@ -21172,8 +21172,8 @@ type ServerCreateRequest struct {
 	ServerPlanGeneration types.EPlanGeneration `mapconv:"ServerPlan.Generation"`
 	ConnectedSwitches    []*ConnectedSwitch    `json:",omitempty" mapconv:"[]ConnectedSwitches,recursive"`
 	InterfaceDriver      types.EInterfaceDriver
-	Name                 string `validate:"required"`
-	Description          string `validate:"min=0,max=512"`
+	Name                 string
+	Description          string
 	Tags                 types.Tags
 	IconID               types.ID `mapconv:"Icon.ID"`
 	WaitDiskMigration    bool     `json:",omitempty" mapconv:",omitempty"`
@@ -21194,8 +21194,8 @@ func (o *ServerCreateRequest) setDefaults() interface{} {
 		ServerPlanGeneration types.EPlanGeneration `mapconv:"ServerPlan.Generation"`
 		ConnectedSwitches    []*ConnectedSwitch    `json:",omitempty" mapconv:"[]ConnectedSwitches,recursive"`
 		InterfaceDriver      types.EInterfaceDriver
-		Name                 string `validate:"required"`
-		Description          string `validate:"min=0,max=512"`
+		Name                 string
+		Description          string
 		Tags                 types.Tags
 		IconID               types.ID `mapconv:"Icon.ID"`
 		WaitDiskMigration    bool     `json:",omitempty" mapconv:",omitempty"`
@@ -21439,8 +21439,8 @@ func (o *ConnectedSwitch) SetScope(v types.EScope) {
 
 // ServerUpdateRequest represents API parameter/response structure
 type ServerUpdateRequest struct {
-	Name            string `validate:"required"`
-	Description     string `validate:"min=0,max=512"`
+	Name            string
+	Description     string
 	Tags            types.Tags
 	IconID          types.ID `mapconv:"Icon.ID"`
 	PrivateHostID   types.ID `mapconv:"PrivateHost.ID"`
@@ -21455,8 +21455,8 @@ func (o *ServerUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ServerUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name            string `validate:"required"`
-		Description     string `validate:"min=0,max=512"`
+		Name            string
+		Description     string
 		Tags            types.Tags
 		IconID          types.ID `mapconv:"Icon.ID"`
 		PrivateHostID   types.ID `mapconv:"PrivateHost.ID"`
@@ -21929,7 +21929,7 @@ func (o *VNCProxyInfo) SetVNCFile(v string) {
 // ServerPlan represents API parameter/response structure
 type ServerPlan struct {
 	ID           types.ID
-	Name         string `validate:"required"`
+	Name         string
 	CPU          int
 	MemoryMB     int
 	Commitment   types.ECommitment
@@ -21946,7 +21946,7 @@ func (o *ServerPlan) Validate() error {
 func (o *ServerPlan) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
+		Name         string
 		CPU          int
 		MemoryMB     int
 		Commitment   types.ECommitment
@@ -22364,12 +22364,12 @@ func (o *Price) SetZone(v string) {
 // SIM represents API parameter/response structure
 type SIM struct {
 	ID           types.ID
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
+	Name         string
+	Description  string
 	Tags         types.Tags
 	Availability types.EAvailability
 	Class        string
-	ICCID        string   `mapconv:"Status.ICCID" validate:"numeric"`
+	ICCID        string   `mapconv:"Status.ICCID"`
 	Info         *SIMInfo `mapconv:"Status.SIMInfo"`
 	IconID       types.ID `mapconv:"Icon.ID"`
 	CreatedAt    time.Time
@@ -22385,12 +22385,12 @@ func (o *SIM) Validate() error {
 func (o *SIM) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
+		Name         string
+		Description  string
 		Tags         types.Tags
 		Availability types.EAvailability
 		Class        string
-		ICCID        string   `mapconv:"Status.ICCID" validate:"numeric"`
+		ICCID        string   `mapconv:"Status.ICCID"`
 		Info         *SIMInfo `mapconv:"Status.SIMInfo"`
 		IconID       types.ID `mapconv:"Icon.ID"`
 		CreatedAt    time.Time
@@ -22781,11 +22781,11 @@ func (o *SIMInfo) SetConnectedIMEI(v string) {
 
 // SIMCreateRequest represents API parameter/response structure
 type SIMCreateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
-	ICCID       string   `mapconv:"Status.ICCID" validate:"numeric"`
+	ICCID       string   `mapconv:"Status.ICCID"`
 	PassCode    string   `mapconv:"Remark.PassCode"`
 }
 
@@ -22797,11 +22797,11 @@ func (o *SIMCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SIMCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
-		ICCID       string   `mapconv:"Status.ICCID" validate:"numeric"`
+		ICCID       string   `mapconv:"Status.ICCID"`
 		PassCode    string   `mapconv:"Remark.PassCode"`
 		Class       string   `mapconv:"Provider.Class"`
 	}{
@@ -22901,8 +22901,8 @@ func (o *SIMCreateRequest) SetPassCode(v string) {
 
 // SIMUpdateRequest represents API parameter/response structure
 type SIMUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID `mapconv:"Icon.ID"`
 }
@@ -22915,8 +22915,8 @@ func (o *SIMUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SIMUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID `mapconv:"Icon.ID"`
 	}{
@@ -23296,8 +23296,8 @@ func (o *MonitorLinkValue) SetDownlinkBPS(v float64) {
 // SimpleMonitor represents API parameter/response structure
 type SimpleMonitor struct {
 	ID                 types.ID
-	Name               string `validate:"required"`
-	Description        string `validate:"min=0,max=512"`
+	Name               string
+	Description        string
 	Tags               types.Tags
 	Availability       types.EAvailability
 	IconID             types.ID `mapconv:"Icon.ID"`
@@ -23305,14 +23305,14 @@ type SimpleMonitor struct {
 	ModifiedAt         time.Time
 	Class              string
 	Target             string                    `mapconv:"Status.Target"`
-	DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+	DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop"`
 	Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
 	HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
 	NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
 	NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
 	NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
 	SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
-	NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+	NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval"`
 	SettingsHash       string                    `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -23325,8 +23325,8 @@ func (o *SimpleMonitor) Validate() error {
 func (o *SimpleMonitor) setDefaults() interface{} {
 	return &struct {
 		ID                 types.ID
-		Name               string `validate:"required"`
-		Description        string `validate:"min=0,max=512"`
+		Name               string
+		Description        string
 		Tags               types.Tags
 		Availability       types.EAvailability
 		IconID             types.ID `mapconv:"Icon.ID"`
@@ -23334,14 +23334,14 @@ func (o *SimpleMonitor) setDefaults() interface{} {
 		ModifiedAt         time.Time
 		Class              string
 		Target             string                    `mapconv:"Status.Target"`
-		DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+		DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop"`
 		Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
 		HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
 		NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
 		NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
 		NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
 		SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
-		NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+		NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval"`
 		SettingsHash       string                    `json:",omitempty" mapconv:",omitempty"`
 	}{
 		ID:                 o.GetID(),
@@ -23810,16 +23810,16 @@ func (o *SimpleMonitorHealthCheck) SetRemainingDays(v int) {
 
 // SimpleMonitorCreateRequest represents API parameter/response structure
 type SimpleMonitorCreateRequest struct {
-	Target             string                    `mapconv:"Name/Status.Target" validate:"required"`
-	DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+	Target             string                    `mapconv:"Name/Status.Target"`
+	DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop"`
 	Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
 	HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
 	NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
 	NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
 	NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
 	SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
-	NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
-	Description        string                    `validate:"min=0,max=512"`
+	NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval"`
+	Description        string
 	Tags               types.Tags
 	IconID             types.ID `mapconv:"Icon.ID"`
 }
@@ -23832,16 +23832,16 @@ func (o *SimpleMonitorCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SimpleMonitorCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Target             string                    `mapconv:"Name/Status.Target" validate:"required"`
-		DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+		Target             string                    `mapconv:"Name/Status.Target"`
+		DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop"`
 		Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
 		HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
 		NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
 		NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
 		NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
 		SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
-		NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
-		Description        string                    `validate:"min=0,max=512"`
+		NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval"`
+		Description        string
 		Tags               types.Tags
 		IconID             types.ID `mapconv:"Icon.ID"`
 		Class              string   `mapconv:"Provider.Class"`
@@ -24014,17 +24014,17 @@ func (o *SimpleMonitorCreateRequest) SetIconID(v types.ID) {
 
 // SimpleMonitorUpdateRequest represents API parameter/response structure
 type SimpleMonitorUpdateRequest struct {
-	Description        string `validate:"min=0,max=512"`
+	Description        string
 	Tags               types.Tags
 	IconID             types.ID                  `mapconv:"Icon.ID"`
-	DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+	DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop"`
 	Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
 	HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
 	NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
 	NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
 	NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
 	SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
-	NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+	NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval"`
 	SettingsHash       string                    `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -24036,17 +24036,17 @@ func (o *SimpleMonitorUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SimpleMonitorUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Description        string `validate:"min=0,max=512"`
+		Description        string
 		Tags               types.Tags
 		IconID             types.ID                  `mapconv:"Icon.ID"`
-		DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+		DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop"`
 		Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
 		HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
 		NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
 		NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
 		NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
 		SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
-		NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+		NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval"`
 		SettingsHash       string                    `json:",omitempty" mapconv:",omitempty"`
 	}{
 		Description:        o.GetDescription(),
@@ -24216,14 +24216,14 @@ func (o *SimpleMonitorUpdateRequest) SetSettingsHash(v string) {
 
 // SimpleMonitorUpdateSettingsRequest represents API parameter/response structure
 type SimpleMonitorUpdateSettingsRequest struct {
-	DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+	DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop"`
 	Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
 	HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
 	NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
 	NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
 	NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
 	SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
-	NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+	NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval"`
 	SettingsHash       string                    `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -24235,14 +24235,14 @@ func (o *SimpleMonitorUpdateSettingsRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SimpleMonitorUpdateSettingsRequest) setDefaults() interface{} {
 	return &struct {
-		DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop" validate:"min=60,max=3600"`
+		DelayLoop          int                       `mapconv:"Settings.SimpleMonitor.DelayLoop"`
 		Enabled            types.StringFlag          `mapconv:"Settings.SimpleMonitor.Enabled"`
 		HealthCheck        *SimpleMonitorHealthCheck `mapconv:"Settings.SimpleMonitor.HealthCheck,recursive"`
 		NotifyEmailEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.Enabled"`
 		NotifyEmailHTML    types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifyEmail.HTML"`
 		NotifySlackEnabled types.StringFlag          `mapconv:"Settings.SimpleMonitor.NotifySlack.Enabled"`
 		SlackWebhooksURL   string                    `mapconv:"Settings.SimpleMonitor.NotifySlack.IncomingWebhooksURL"`
-		NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval" validate:"min=3600,max=259200"`
+		NotifyInterval     int                       `mapconv:"Settings.SimpleMonitor.NotifyInterval"`
 		SettingsHash       string                    `json:",omitempty" mapconv:",omitempty"`
 	}{
 		DelayLoop:          o.GetDelayLoop(),
@@ -24498,8 +24498,8 @@ func (o *SimpleMonitorHealthStatus) SetHealth(v types.ESimpleMonitorHealth) {
 // SSHKey represents API parameter/response structure
 type SSHKey struct {
 	ID          types.ID
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	CreatedAt   time.Time
 	PublicKey   string
 	Fingerprint string
@@ -24514,8 +24514,8 @@ func (o *SSHKey) Validate() error {
 func (o *SSHKey) setDefaults() interface{} {
 	return &struct {
 		ID          types.ID
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		CreatedAt   time.Time
 		PublicKey   string
 		Fingerprint string
@@ -24615,8 +24615,8 @@ func (o *SSHKey) SetFingerprint(v string) {
 
 // SSHKeyCreateRequest represents API parameter/response structure
 type SSHKeyCreateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	PublicKey   string
 }
 
@@ -24628,8 +24628,8 @@ func (o *SSHKeyCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SSHKeyCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		PublicKey   string
 	}{
 		Name:        o.GetName(),
@@ -24675,8 +24675,8 @@ func (o *SSHKeyCreateRequest) SetPublicKey(v string) {
 // SSHKeyGenerated represents API parameter/response structure
 type SSHKeyGenerated struct {
 	ID          types.ID
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	CreatedAt   time.Time
 	PublicKey   string
 	Fingerprint string
@@ -24692,8 +24692,8 @@ func (o *SSHKeyGenerated) Validate() error {
 func (o *SSHKeyGenerated) setDefaults() interface{} {
 	return &struct {
 		ID          types.ID
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		CreatedAt   time.Time
 		PublicKey   string
 		Fingerprint string
@@ -24805,8 +24805,8 @@ func (o *SSHKeyGenerated) SetPrivateKey(v string) {
 
 // SSHKeyGenerateRequest represents API parameter/response structure
 type SSHKeyGenerateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	PassPhrase  string
 }
 
@@ -24818,8 +24818,8 @@ func (o *SSHKeyGenerateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SSHKeyGenerateRequest) setDefaults() interface{} {
 	return &struct {
-		Name           string `validate:"required"`
-		Description    string `validate:"min=0,max=512"`
+		Name           string
+		Description    string
 		PassPhrase     string
 		GenerateFormat string
 	}{
@@ -24866,8 +24866,8 @@ func (o *SSHKeyGenerateRequest) SetPassPhrase(v string) {
 
 // SSHKeyUpdateRequest represents API parameter/response structure
 type SSHKeyUpdateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 }
 
 // Validate validates by field tags
@@ -24878,8 +24878,8 @@ func (o *SSHKeyUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SSHKeyUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 	}{
 		Name:        o.GetName(),
 		Description: o.GetDescription(),
@@ -24913,13 +24913,13 @@ func (o *SSHKeyUpdateRequest) SetDescription(v string) {
 // Subnet represents API parameter/response structure
 type Subnet struct {
 	ID             types.ID
-	SwitchID       types.ID           `mapconv:"Switch.ID,omitempty"`
-	InternetID     types.ID           `mapconv:"Switch.Internet.ID,omitempty"`
-	DefaultRoute   string             `validate:"ipv4"`
-	NextHop        string             `validate:"ipv4"`
-	StaticRoute    string             `validate:"ipv4"`
-	NetworkAddress string             `validate:"ipv4"`
-	NetworkMaskLen int                `validate:"min=24,max=28"`
+	SwitchID       types.ID `mapconv:"Switch.ID,omitempty"`
+	InternetID     types.ID `mapconv:"Switch.Internet.ID,omitempty"`
+	DefaultRoute   string
+	NextHop        string
+	StaticRoute    string
+	NetworkAddress string
+	NetworkMaskLen int
 	IPAddresses    []*SubnetIPAddress `mapconv:"[]IPAddresses,recursive"`
 }
 
@@ -24932,13 +24932,13 @@ func (o *Subnet) Validate() error {
 func (o *Subnet) setDefaults() interface{} {
 	return &struct {
 		ID             types.ID
-		SwitchID       types.ID           `mapconv:"Switch.ID,omitempty"`
-		InternetID     types.ID           `mapconv:"Switch.Internet.ID,omitempty"`
-		DefaultRoute   string             `validate:"ipv4"`
-		NextHop        string             `validate:"ipv4"`
-		StaticRoute    string             `validate:"ipv4"`
-		NetworkAddress string             `validate:"ipv4"`
-		NetworkMaskLen int                `validate:"min=24,max=28"`
+		SwitchID       types.ID `mapconv:"Switch.ID,omitempty"`
+		InternetID     types.ID `mapconv:"Switch.Internet.ID,omitempty"`
+		DefaultRoute   string
+		NextHop        string
+		StaticRoute    string
+		NetworkAddress string
+		NetworkMaskLen int
 		IPAddresses    []*SubnetIPAddress `mapconv:"[]IPAddresses,recursive"`
 	}{
 		ID:             o.GetID(),
@@ -25116,16 +25116,16 @@ func (o *SubnetIPAddress) SetIPAddress(v string) {
 // Switch represents API parameter/response structure
 type Switch struct {
 	ID                 types.ID
-	Name               string `validate:"required"`
-	Description        string `validate:"min=0,max=512"`
+	Name               string
+	Description        string
 	Tags               types.Tags
 	IconID             types.ID `mapconv:"Icon.ID"`
 	CreatedAt          time.Time
 	ModifiedAt         time.Time
 	Scope              types.EScope
 	ServerCount        int
-	NetworkMaskLen     int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-	DefaultRoute       string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
+	NetworkMaskLen     int             `mapconv:"UserSubnet.NetworkMaskLen"`
+	DefaultRoute       string          `mapconv:"UserSubnet.DefaultRoute"`
 	Subnets            []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
 	BridgeID           types.ID        `mapconv:"Bridge.ID,omitempty"`
 	HybridConnectionID types.ID        `mapconv:"HybridConnection.ID,omitempty"`
@@ -25140,16 +25140,16 @@ func (o *Switch) Validate() error {
 func (o *Switch) setDefaults() interface{} {
 	return &struct {
 		ID                 types.ID
-		Name               string `validate:"required"`
-		Description        string `validate:"min=0,max=512"`
+		Name               string
+		Description        string
 		Tags               types.Tags
 		IconID             types.ID `mapconv:"Icon.ID"`
 		CreatedAt          time.Time
 		ModifiedAt         time.Time
 		Scope              types.EScope
 		ServerCount        int
-		NetworkMaskLen     int             `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-		DefaultRoute       string          `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
+		NetworkMaskLen     int             `mapconv:"UserSubnet.NetworkMaskLen"`
+		DefaultRoute       string          `mapconv:"UserSubnet.DefaultRoute"`
 		Subnets            []*SwitchSubnet `json:",omitempty" mapconv:"[]Subnets,omitempty,recursive"`
 		BridgeID           types.ID        `mapconv:"Bridge.ID,omitempty"`
 		HybridConnectionID types.ID        `mapconv:"HybridConnection.ID,omitempty"`
@@ -25358,11 +25358,11 @@ func (o *Switch) SetHybridConnectionID(v types.ID) {
 // SwitchSubnet represents API parameter/response structure
 type SwitchSubnet struct {
 	ID                   types.ID
-	DefaultRoute         string `validate:"ipv4"`
-	NextHop              string `validate:"ipv4"`
-	StaticRoute          string `validate:"ipv4"`
-	NetworkAddress       string `validate:"ipv4"`
-	NetworkMaskLen       int    `validate:"min=24,max=28"`
+	DefaultRoute         string
+	NextHop              string
+	StaticRoute          string
+	NetworkAddress       string
+	NetworkMaskLen       int
 	Internet             *Internet
 	AssignedIPAddressMax string `mapconv:"IPAddresses.Max"`
 	AssignedIPAddressMin string `mapconv:"IPAddresses.Min"`
@@ -25377,11 +25377,11 @@ func (o *SwitchSubnet) Validate() error {
 func (o *SwitchSubnet) setDefaults() interface{} {
 	return &struct {
 		ID                   types.ID
-		DefaultRoute         string `validate:"ipv4"`
-		NextHop              string `validate:"ipv4"`
-		StaticRoute          string `validate:"ipv4"`
-		NetworkAddress       string `validate:"ipv4"`
-		NetworkMaskLen       int    `validate:"min=24,max=28"`
+		DefaultRoute         string
+		NextHop              string
+		StaticRoute          string
+		NetworkAddress       string
+		NetworkMaskLen       int
 		Internet             *Internet
 		AssignedIPAddressMax string `mapconv:"IPAddresses.Max"`
 		AssignedIPAddressMin string `mapconv:"IPAddresses.Min"`
@@ -25519,10 +25519,10 @@ func (o *SwitchSubnet) SetAssignedIPAddressMin(v string) {
 
 // SwitchCreateRequest represents API parameter/response structure
 type SwitchCreateRequest struct {
-	Name           string `validate:"required"`
-	NetworkMaskLen int    `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-	DefaultRoute   string `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
-	Description    string `validate:"min=0,max=512"`
+	Name           string
+	NetworkMaskLen int    `mapconv:"UserSubnet.NetworkMaskLen"`
+	DefaultRoute   string `mapconv:"UserSubnet.DefaultRoute"`
+	Description    string
 	Tags           types.Tags
 	IconID         types.ID `mapconv:"Icon.ID"`
 }
@@ -25535,10 +25535,10 @@ func (o *SwitchCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SwitchCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name           string `validate:"required"`
-		NetworkMaskLen int    `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-		DefaultRoute   string `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
-		Description    string `validate:"min=0,max=512"`
+		Name           string
+		NetworkMaskLen int    `mapconv:"UserSubnet.NetworkMaskLen"`
+		DefaultRoute   string `mapconv:"UserSubnet.DefaultRoute"`
+		Description    string
 		Tags           types.Tags
 		IconID         types.ID `mapconv:"Icon.ID"`
 	}{
@@ -25637,10 +25637,10 @@ func (o *SwitchCreateRequest) SetIconID(v types.ID) {
 
 // SwitchUpdateRequest represents API parameter/response structure
 type SwitchUpdateRequest struct {
-	Name           string `validate:"required"`
-	NetworkMaskLen int    `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-	DefaultRoute   string `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
-	Description    string `validate:"min=0,max=512"`
+	Name           string
+	NetworkMaskLen int    `mapconv:"UserSubnet.NetworkMaskLen"`
+	DefaultRoute   string `mapconv:"UserSubnet.DefaultRoute"`
+	Description    string
 	Tags           types.Tags
 	IconID         types.ID `mapconv:"Icon.ID"`
 }
@@ -25653,10 +25653,10 @@ func (o *SwitchUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *SwitchUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name           string `validate:"required"`
-		NetworkMaskLen int    `mapconv:"UserSubnet.NetworkMaskLen" validate:"min=1,max=32"`
-		DefaultRoute   string `mapconv:"UserSubnet.DefaultRoute" validate:"ipv4"`
-		Description    string `validate:"min=0,max=512"`
+		Name           string
+		NetworkMaskLen int    `mapconv:"UserSubnet.NetworkMaskLen"`
+		DefaultRoute   string `mapconv:"UserSubnet.DefaultRoute"`
+		Description    string
 		Tags           types.Tags
 		IconID         types.ID `mapconv:"Icon.ID"`
 	}{
@@ -25756,8 +25756,8 @@ func (o *SwitchUpdateRequest) SetIconID(v types.ID) {
 // VPCRouter represents API parameter/response structure
 type VPCRouter struct {
 	ID                      types.ID
-	Name                    string `validate:"required"`
-	Description             string `validate:"min=0,max=512"`
+	Name                    string
+	Description             string
 	Tags                    types.Tags
 	Availability            types.EAvailability
 	Class                   string
@@ -25783,8 +25783,8 @@ func (o *VPCRouter) Validate() error {
 func (o *VPCRouter) setDefaults() interface{} {
 	return &struct {
 		ID                      types.ID
-		Name                    string `validate:"required"`
-		Description             string `validate:"min=0,max=512"`
+		Name                    string
+		Description             string
 		Tags                    types.Tags
 		Availability            types.EAvailability
 		Class                   string
@@ -26349,8 +26349,8 @@ func (o *VPCRouterInterfaceSetting) SetIndex(v int) {
 
 // VPCRouterStaticNAT represents API parameter/response structure
 type VPCRouterStaticNAT struct {
-	GlobalAddress  string `mapconv:"GlobalAddress" validate:"ipv4"`
-	PrivateAddress string `mapconv:"PrivateAddress" validate:"ipv4"`
+	GlobalAddress  string `mapconv:"GlobalAddress"`
+	PrivateAddress string `mapconv:"PrivateAddress"`
 	Description    string
 }
 
@@ -26362,8 +26362,8 @@ func (o *VPCRouterStaticNAT) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *VPCRouterStaticNAT) setDefaults() interface{} {
 	return &struct {
-		GlobalAddress  string `mapconv:"GlobalAddress" validate:"ipv4"`
-		PrivateAddress string `mapconv:"PrivateAddress" validate:"ipv4"`
+		GlobalAddress  string `mapconv:"GlobalAddress"`
+		PrivateAddress string `mapconv:"PrivateAddress"`
 		Description    string
 	}{
 		GlobalAddress:  o.GetGlobalAddress(),
@@ -26410,7 +26410,7 @@ func (o *VPCRouterStaticNAT) SetDescription(v string) {
 type VPCRouterPortForwarding struct {
 	Protocol       types.EVPCRouterPortForwardingProtocol
 	GlobalPort     types.StringNumber
-	PrivateAddress string `mapconv:"PrivateAddress" validate:"ipv4"`
+	PrivateAddress string `mapconv:"PrivateAddress"`
 	PrivatePort    types.StringNumber
 	Description    string
 }
@@ -26425,7 +26425,7 @@ func (o *VPCRouterPortForwarding) setDefaults() interface{} {
 	return &struct {
 		Protocol       types.EVPCRouterPortForwardingProtocol
 		GlobalPort     types.StringNumber
-		PrivateAddress string `mapconv:"PrivateAddress" validate:"ipv4"`
+		PrivateAddress string `mapconv:"PrivateAddress"`
 		PrivatePort    types.StringNumber
 		Description    string
 	}{
@@ -26677,9 +26677,9 @@ func (o *VPCRouterFirewallRule) SetDescription(v string) {
 // VPCRouterDHCPServer represents API parameter/response structure
 type VPCRouterDHCPServer struct {
 	Interface  string
-	RangeStart string   `validate:"ipv4"`
-	RangeStop  string   `validate:"ipv4"`
-	DNSServers []string `validate:"dive,ipv4"`
+	RangeStart string
+	RangeStop  string
+	DNSServers []string
 }
 
 // Validate validates by field tags
@@ -26691,9 +26691,9 @@ func (o *VPCRouterDHCPServer) Validate() error {
 func (o *VPCRouterDHCPServer) setDefaults() interface{} {
 	return &struct {
 		Interface  string
-		RangeStart string   `validate:"ipv4"`
-		RangeStop  string   `validate:"ipv4"`
-		DNSServers []string `validate:"dive,ipv4"`
+		RangeStart string
+		RangeStop  string
+		DNSServers []string
 	}{
 		Interface:  o.GetInterface(),
 		RangeStart: o.GetRangeStart(),
@@ -26749,7 +26749,7 @@ func (o *VPCRouterDHCPServer) SetDNSServers(v []string) {
 // VPCRouterDHCPStaticMapping represents API parameter/response structure
 type VPCRouterDHCPStaticMapping struct {
 	MACAddress string
-	IPAddress  string `validate:"ipv4"`
+	IPAddress  string
 }
 
 // Validate validates by field tags
@@ -26761,7 +26761,7 @@ func (o *VPCRouterDHCPStaticMapping) Validate() error {
 func (o *VPCRouterDHCPStaticMapping) setDefaults() interface{} {
 	return &struct {
 		MACAddress string
-		IPAddress  string `validate:"ipv4"`
+		IPAddress  string
 	}{
 		MACAddress: o.GetMACAddress(),
 		IPAddress:  o.GetIPAddress(),
@@ -26794,8 +26794,8 @@ func (o *VPCRouterDHCPStaticMapping) SetIPAddress(v string) {
 
 // VPCRouterPPTPServer represents API parameter/response structure
 type VPCRouterPPTPServer struct {
-	RangeStart string `validate:"ipv4"`
-	RangeStop  string `validate:"ipv4"`
+	RangeStart string
+	RangeStop  string
 }
 
 // Validate validates by field tags
@@ -26806,8 +26806,8 @@ func (o *VPCRouterPPTPServer) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *VPCRouterPPTPServer) setDefaults() interface{} {
 	return &struct {
-		RangeStart string `validate:"ipv4"`
-		RangeStop  string `validate:"ipv4"`
+		RangeStart string
+		RangeStop  string
 	}{
 		RangeStart: o.GetRangeStart(),
 		RangeStop:  o.GetRangeStop(),
@@ -26840,8 +26840,8 @@ func (o *VPCRouterPPTPServer) SetRangeStop(v string) {
 
 // VPCRouterL2TPIPsecServer represents API parameter/response structure
 type VPCRouterL2TPIPsecServer struct {
-	RangeStart      string `validate:"ipv4"`
-	RangeStop       string `validate:"ipv4"`
+	RangeStart      string
+	RangeStop       string
 	PreSharedSecret string
 }
 
@@ -26853,8 +26853,8 @@ func (o *VPCRouterL2TPIPsecServer) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *VPCRouterL2TPIPsecServer) setDefaults() interface{} {
 	return &struct {
-		RangeStart      string `validate:"ipv4"`
-		RangeStop       string `validate:"ipv4"`
+		RangeStart      string
+		RangeStop       string
 		PreSharedSecret string
 	}{
 		RangeStart:      o.GetRangeStart(),
@@ -27363,13 +27363,13 @@ func (o *VPCRouterInterface) SetIndex(v int) {
 
 // VPCRouterCreateRequest represents API parameter/response structure
 type VPCRouterCreateRequest struct {
-	Name        string `validate:"required"`
-	Description string `validate:"min=0,max=512"`
+	Name        string
+	Description string
 	Tags        types.Tags
 	IconID      types.ID                  `mapconv:"Icon.ID"`
 	PlanID      types.ID                  `mapconv:"Plan.ID"`
 	Switch      *ApplianceConnectedSwitch `json:",omitempty" mapconv:"Remark.Switch,recursive"`
-	IPAddresses []string                  `mapconv:"Remark.[]Servers.IPAddress" validate:"min=1,max=2,dive,ipv4"`
+	IPAddresses []string                  `mapconv:"Remark.[]Servers.IPAddress"`
 	Settings    *VPCRouterSetting         `mapconv:",omitempty,recursive"`
 }
 
@@ -27381,13 +27381,13 @@ func (o *VPCRouterCreateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *VPCRouterCreateRequest) setDefaults() interface{} {
 	return &struct {
-		Name        string `validate:"required"`
-		Description string `validate:"min=0,max=512"`
+		Name        string
+		Description string
 		Tags        types.Tags
 		IconID      types.ID                  `mapconv:"Icon.ID"`
 		PlanID      types.ID                  `mapconv:"Plan.ID"`
 		Switch      *ApplianceConnectedSwitch `json:",omitempty" mapconv:"Remark.Switch,recursive"`
-		IPAddresses []string                  `mapconv:"Remark.[]Servers.IPAddress" validate:"min=1,max=2,dive,ipv4"`
+		IPAddresses []string                  `mapconv:"Remark.[]Servers.IPAddress"`
 		Settings    *VPCRouterSetting         `mapconv:",omitempty,recursive"`
 		Class       string
 	}{
@@ -27575,8 +27575,8 @@ func (o *ApplianceConnectedSwitch) SetScope(v types.EScope) {
 
 // VPCRouterUpdateRequest represents API parameter/response structure
 type VPCRouterUpdateRequest struct {
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
+	Name         string
+	Description  string
 	Tags         types.Tags
 	IconID       types.ID          `mapconv:"Icon.ID"`
 	Settings     *VPCRouterSetting `mapconv:",omitempty,recursive"`
@@ -27591,8 +27591,8 @@ func (o *VPCRouterUpdateRequest) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *VPCRouterUpdateRequest) setDefaults() interface{} {
 	return &struct {
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
+		Name         string
+		Description  string
 		Tags         types.Tags
 		IconID       types.ID          `mapconv:"Icon.ID"`
 		Settings     *VPCRouterSetting `mapconv:",omitempty,recursive"`
@@ -28074,7 +28074,7 @@ func (o *VPCRouterSiteToSiteIPsecVPNPeer) SetPeer(v string) {
 // WebAccel represents API parameter/response structure
 type WebAccel struct {
 	ID                 types.ID
-	Name               string `validate:"required"`
+	Name               string
 	DomainType         types.EWebAccelDomainType
 	Domain             string
 	Subdomain          string
@@ -28099,7 +28099,7 @@ func (o *WebAccel) Validate() error {
 func (o *WebAccel) setDefaults() interface{} {
 	return &struct {
 		ID                 types.ID
-		Name               string `validate:"required"`
+		Name               string
 		DomainType         types.EWebAccelDomainType
 		Domain             string
 		Subdomain          string
@@ -29153,8 +29153,8 @@ func (o *WebAccelDeleteCacheRequest) SetURL(v []string) {
 // Zone represents API parameter/response structure
 type Zone struct {
 	ID           types.ID
-	Name         string `validate:"required"`
-	Description  string `validate:"min=0,max=512"`
+	Name         string
+	Description  string
 	DisplayOrder int64
 	IsDummy      bool
 	VNCProxy     *VNCProxy      `json:",omitempty"`
@@ -29171,8 +29171,8 @@ func (o *Zone) Validate() error {
 func (o *Zone) setDefaults() interface{} {
 	return &struct {
 		ID           types.ID
-		Name         string `validate:"required"`
-		Description  string `validate:"min=0,max=512"`
+		Name         string
+		Description  string
 		DisplayOrder int64
 		IsDummy      bool
 		VNCProxy     *VNCProxy      `json:",omitempty"`


### PR DESCRIPTION
`internal/define`配下のモデル定義類から`validate`タグ関連を除去する。

---

現在開発を進めているusacloud/libsacloud services側でバリデーションを提供するようにし素のモデル側では一切のバリデーションを行わないようにする。これに伴い各フィールドに付与されていたvalidateタグを除去する。