### PR TITLE
VPCRouter version

### DIFF
--- a/v2/helper/builder/vpcrouter/builder.go
+++ b/v2/helper/builder/vpcrouter/builder.go
@@ -35,6 +35,7 @@ type Builder struct {
 	Tags                  types.Tags
 	IconID                types.ID
 	PlanID                types.ID
+	Version               int
 	NICSetting            NICSettingHolder
 	AdditionalNICSettings []AdditionalNICSettingHolder
 	RouterSetting         *RouterSetting
@@ -185,6 +186,7 @@ func (b *Builder) Build(ctx context.Context, zone string) (*sacloud.VPCRouter, e
 				PlanID:      b.PlanID,
 				Switch:      b.NICSetting.getConnectedSwitch(),
 				IPAddresses: b.NICSetting.getIPAddresses(),
+				Version:     b.Version,
 				Settings: &sacloud.VPCRouterSetting{
 					VRID:                      b.RouterSetting.VRID,
 					InternetConnectionEnabled: b.RouterSetting.InternetConnectionEnabled,

--- a/v2/helper/builder/vpcrouter/builder_test.go
+++ b/v2/helper/builder/vpcrouter/builder_test.go
@@ -66,6 +66,7 @@ func TestBuilder_Build(t *testing.T) {
 					Description: "description",
 					Tags:        types.Tags{"tag1", "tag2"},
 					PlanID:      types.VPCRouterPlans.Standard,
+					Version:     1,
 					NICSetting:  &StandardNICSetting{},
 					AdditionalNICSettings: []AdditionalNICSettingHolder{
 						&AdditionalStandardNICSetting{

--- a/v2/helper/service/vpcrouter/apply_request.go
+++ b/v2/helper/service/vpcrouter/apply_request.go
@@ -35,7 +35,8 @@ type ApplyRequest struct {
 	Tags        types.Tags
 	IconID      types.ID
 
-	PlanID                types.ID                     `validate:"required"`
+	PlanID                types.ID `validate:"required"`
+	Version               int
 	NICSetting            NICSettingHolder             // StandardNICSetting または PremiumNICSetting を指定する
 	AdditionalNICSettings []AdditionalNICSettingHolder // AdditionalStandardNICSetting または AdditionalPremiumNICSetting を指定する
 	RouterSetting         *RouterSetting
@@ -71,6 +72,7 @@ func (req *ApplyRequest) Builder(caller sacloud.APICaller) *vpcRouterBuilder.Bui
 		Tags:                  req.Tags,
 		IconID:                req.IconID,
 		PlanID:                req.PlanID,
+		Version:               req.Version,
 		NICSetting:            req.nicSetting(),
 		AdditionalNICSettings: req.additionalNICSetting(),
 		RouterSetting:         req.routerSetting(),

--- a/v2/helper/service/vpcrouter/create_request.go
+++ b/v2/helper/service/vpcrouter/create_request.go
@@ -28,6 +28,7 @@ type CreateRequest struct {
 	IconID      types.ID
 
 	PlanID                types.ID `validate:"required"`
+	Version               int
 	NICSetting            *PremiumNICSetting
 	AdditionalNICSettings []*AdditionalPremiumNICSetting
 	RouterSetting         *RouterSetting
@@ -51,6 +52,7 @@ func (req *CreateRequest) ApplyRequest() *ApplyRequest {
 		Tags:                  req.Tags,
 		IconID:                req.IconID,
 		PlanID:                req.PlanID,
+		Version:               req.Version,
 		NICSetting:            req.NICSetting,
 		AdditionalNICSettings: additionalNICs,
 		RouterSetting:         req.RouterSetting,

--- a/v2/helper/service/vpcrouter/create_standard_request.go
+++ b/v2/helper/service/vpcrouter/create_standard_request.go
@@ -27,6 +27,8 @@ type CreateStandardRequest struct {
 	Tags        types.Tags
 	IconID      types.ID
 
+	Version int
+
 	AdditionalNICSettings []*AdditionalStandardNICSetting
 	RouterSetting         *RouterSetting
 	NoWait                bool
@@ -49,6 +51,7 @@ func (req *CreateStandardRequest) ApplyRequest() *ApplyRequest {
 		Tags:                  req.Tags,
 		IconID:                req.IconID,
 		PlanID:                types.VPCRouterPlans.Standard,
+		Version:               req.Version,
 		NICSetting:            &StandardNICSetting{},
 		AdditionalNICSettings: additionalNICs,
 		RouterSetting:         req.RouterSetting,

--- a/v2/helper/service/vpcrouter/create_standard_test.go
+++ b/v2/helper/service/vpcrouter/create_standard_test.go
@@ -34,6 +34,7 @@ func TestVPCRouterService_convertCreateStandardRequest(t *testing.T) {
 				Description: "desc",
 				Tags:        types.Tags{"tag1", "tag2"},
 				IconID:      101,
+				Version:     2,
 				AdditionalNICSettings: []*AdditionalStandardNICSetting{
 					{
 						SwitchID:       103,
@@ -67,6 +68,7 @@ func TestVPCRouterService_convertCreateStandardRequest(t *testing.T) {
 				Tags:        types.Tags{"tag1", "tag2"},
 				IconID:      101,
 				PlanID:      types.VPCRouterPlans.Standard,
+				Version:     2,
 				NICSetting:  &StandardNICSetting{},
 				AdditionalNICSettings: []AdditionalNICSettingHolder{
 					&AdditionalStandardNICSetting{

--- a/v2/helper/service/vpcrouter/create_test.go
+++ b/v2/helper/service/vpcrouter/create_test.go
@@ -35,6 +35,7 @@ func TestVPCRouterService_convertCreateRequest(t *testing.T) {
 				Tags:        types.Tags{"tag1", "tag2"},
 				IconID:      101,
 				PlanID:      types.VPCRouterPlans.Premium,
+				Version:     1,
 				NICSetting: &PremiumNICSetting{
 					SwitchID:         102,
 					IPAddresses:      []string{"192.168.0.101", "192.168.0.102"},
@@ -75,6 +76,7 @@ func TestVPCRouterService_convertCreateRequest(t *testing.T) {
 				Tags:        types.Tags{"tag1", "tag2"},
 				IconID:      101,
 				PlanID:      types.VPCRouterPlans.Premium,
+				Version:     1,
 				NICSetting: &PremiumNICSetting{
 					SwitchID:         102,
 					IPAddresses:      []string{"192.168.0.101", "192.168.0.102"},

--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -577,6 +577,17 @@ func (f *fieldsDef) AppliancePlanID() *dsl.FieldDesc {
 	}
 }
 
+func (f *fieldsDef) ApplianceVPCRouterVersion() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Version",
+		Tags: &dsl.FieldTags{
+			MapConv: "Remark.Router.VPCRouterVersion",
+		},
+		Type:         meta.TypeInt,
+		DefaultValue: `2`,
+	}
+}
+
 func (f *fieldsDef) ApplianceSwitchID() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "SwitchID",

--- a/v2/internal/define/vpc_router.go
+++ b/v2/internal/define/vpc_router.go
@@ -127,6 +127,8 @@ var (
 			fields.CreatedAt(),
 			// plan
 			fields.AppliancePlanID(),
+			// version
+			fields.ApplianceVPCRouterVersion(),
 			// settings
 			{
 				Name: "Settings",
@@ -184,6 +186,9 @@ var (
 
 			// TODO remarkとsettings.Interfaces両方に設定する必要がある。うまい方法が思いつかないため当面は利用者側で両方に設定する方法としておく
 			fields.ApplianceIPAddresses(),
+
+			// version
+			fields.ApplianceVPCRouterVersion(),
 
 			{
 				Name: "Settings",

--- a/v2/sacloud/fake/ops_vpc_router.go
+++ b/v2/sacloud/fake/ops_vpc_router.go
@@ -51,6 +51,9 @@ func (o *VPCRouterOp) Create(ctx context.Context, zone string, param *sacloud.VP
 	result.Availability = types.Availabilities.Migrating
 	result.ZoneID = zoneIDs[zone]
 	result.SettingsHash = ""
+	if result.Version == 0 {
+		result.Version = 2
+	}
 
 	ifOp := NewInterfaceOp()
 	swOp := NewSwitchOp()

--- a/v2/sacloud/naked/appliance.go
+++ b/v2/sacloud/naked/appliance.go
@@ -33,11 +33,17 @@ type ApplianceRemark struct {
 	DBConf          *ApplianceRemarkDBConf        `json:",omitempty" yaml:"db_conf,omitempty" structs:",omitempty"`        // for database
 	SourceAppliance *ApplianceSource              `json:",omitempty" yaml:"db_conf,omitempty" structs:",omitempty"`        // for database
 	MobileGateway   *ApplianceRemarkMobileGateway `json:",omitempty" yaml:"mobile_gateway,omitempty" structs:",omitempty"` // for mobile gateway
+	Router          *ApplianceRemarkRouter        `json:",omitempty" yaml:"router,omitempty" structs:",omitempty"`         // for vpc router
 }
 
 // ApplianceRemarkMobileGateway モバイルゲートウェイのグローバルIP
 type ApplianceRemarkMobileGateway struct {
 	GlobalAddress string
+}
+
+// ApplianceRemarkRouter VPCルータのバージョンなど
+type ApplianceRemarkRouter struct {
+	VPCRouterVersion int `json:",omitempty" yaml:"vpc_router_version,omitempty" structs:",omitempty"`
 }
 
 // ApplianceSource クローン元アプライアンス データベースのクローン時に利用

--- a/v2/sacloud/test/vpc_router_op_test.go
+++ b/v2/sacloud/test/vpc_router_op_test.go
@@ -432,6 +432,7 @@ var (
 		Availability:   types.Availabilities.Available,
 		InstanceStatus: types.ServerInstanceStatuses.Up,
 		PlanID:         withRouterCreateVPCRouterParam.PlanID,
+		Version:        2,
 		Settings:       withRouterCreateVPCRouterParam.Settings,
 	}
 	withRouterUpdateVPCRouterParam = &sacloud.VPCRouterUpdateRequest{
@@ -448,6 +449,7 @@ var (
 		Availability:   types.Availabilities.Available,
 		InstanceStatus: types.ServerInstanceStatuses.Up,
 		PlanID:         withRouterCreateVPCRouterParam.PlanID,
+		Version:        2,
 		Settings:       withRouterUpdateVPCRouterParam.Settings,
 		IconID:         testIconID,
 	}
@@ -460,6 +462,7 @@ var (
 		Availability:   types.Availabilities.Available,
 		InstanceStatus: types.ServerInstanceStatuses.Up,
 		PlanID:         withRouterCreateVPCRouterParam.PlanID,
+		Version:        2,
 		Settings:       withRouterUpdateVPCRouterToMinParam.Settings,
 	}
 )

--- a/v2/sacloud/test/vpc_router_op_test.go
+++ b/v2/sacloud/test/vpc_router_op_test.go
@@ -111,6 +111,7 @@ var (
 		Availability:   types.Availabilities.Available,
 		InstanceStatus: types.ServerInstanceStatuses.Up,
 		PlanID:         createVPCRouterParam.PlanID,
+		Version:        2,
 		Settings:       createVPCRouterParam.Settings,
 	}
 	updateVPCRouterParam = &sacloud.VPCRouterUpdateRequest{
@@ -126,6 +127,7 @@ var (
 		Availability:   types.Availabilities.Available,
 		InstanceStatus: types.ServerInstanceStatuses.Up,
 		PlanID:         createVPCRouterParam.PlanID,
+		Version:        2,
 	}
 )
 

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -25891,6 +25891,7 @@ type VPCRouter struct {
 	IconID                  types.ID `mapconv:"Icon.ID"`
 	CreatedAt               time.Time
 	PlanID                  types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
+	Version                 int                         `mapconv:"Remark.Router.VPCRouterVersion"`
 	Settings                *VPCRouterSetting           `mapconv:",omitempty,recursive"`
 	SettingsHash            string                      `json:",omitempty" mapconv:",omitempty"`
 	InstanceHostName        string                      `mapconv:"Instance.Host.Name"`
@@ -25918,6 +25919,7 @@ func (o *VPCRouter) setDefaults() interface{} {
 		IconID                  types.ID `mapconv:"Icon.ID"`
 		CreatedAt               time.Time
 		PlanID                  types.ID                    `mapconv:"Remark.Plan.ID/Plan.ID"`
+		Version                 int                         `mapconv:"Remark.Router.VPCRouterVersion"`
 		Settings                *VPCRouterSetting           `mapconv:",omitempty,recursive"`
 		SettingsHash            string                      `json:",omitempty" mapconv:",omitempty"`
 		InstanceHostName        string                      `mapconv:"Instance.Host.Name"`
@@ -25936,6 +25938,7 @@ func (o *VPCRouter) setDefaults() interface{} {
 		IconID:                  o.GetIconID(),
 		CreatedAt:               o.GetCreatedAt(),
 		PlanID:                  o.GetPlanID(),
+		Version:                 o.GetVersion(),
 		Settings:                o.GetSettings(),
 		SettingsHash:            o.GetSettingsHash(),
 		InstanceHostName:        o.GetInstanceHostName(),
@@ -26075,6 +26078,19 @@ func (o *VPCRouter) GetPlanID() types.ID {
 // SetPlanID sets value to PlanID
 func (o *VPCRouter) SetPlanID(v types.ID) {
 	o.PlanID = v
+}
+
+// GetVersion returns value of Version
+func (o *VPCRouter) GetVersion() int {
+	if o.Version == 0 {
+		return 2
+	}
+	return o.Version
+}
+
+// SetVersion sets value to Version
+func (o *VPCRouter) SetVersion(v int) {
+	o.Version = v
 }
 
 // GetSettings returns value of Settings
@@ -27497,6 +27513,7 @@ type VPCRouterCreateRequest struct {
 	PlanID      types.ID                  `mapconv:"Plan.ID"`
 	Switch      *ApplianceConnectedSwitch `json:",omitempty" mapconv:"Remark.Switch,recursive"`
 	IPAddresses []string                  `mapconv:"Remark.[]Servers.IPAddress"`
+	Version     int                       `mapconv:"Remark.Router.VPCRouterVersion"`
 	Settings    *VPCRouterSetting         `mapconv:",omitempty,recursive"`
 }
 
@@ -27515,6 +27532,7 @@ func (o *VPCRouterCreateRequest) setDefaults() interface{} {
 		PlanID      types.ID                  `mapconv:"Plan.ID"`
 		Switch      *ApplianceConnectedSwitch `json:",omitempty" mapconv:"Remark.Switch,recursive"`
 		IPAddresses []string                  `mapconv:"Remark.[]Servers.IPAddress"`
+		Version     int                       `mapconv:"Remark.Router.VPCRouterVersion"`
 		Settings    *VPCRouterSetting         `mapconv:",omitempty,recursive"`
 		Class       string
 	}{
@@ -27525,6 +27543,7 @@ func (o *VPCRouterCreateRequest) setDefaults() interface{} {
 		PlanID:      o.GetPlanID(),
 		Switch:      o.GetSwitch(),
 		IPAddresses: o.GetIPAddresses(),
+		Version:     o.GetVersion(),
 		Settings:    o.GetSettings(),
 		Class:       "vpcrouter",
 	}
@@ -27618,6 +27637,19 @@ func (o *VPCRouterCreateRequest) GetIPAddresses() []string {
 // SetIPAddresses sets value to IPAddresses
 func (o *VPCRouterCreateRequest) SetIPAddresses(v []string) {
 	o.IPAddresses = v
+}
+
+// GetVersion returns value of Version
+func (o *VPCRouterCreateRequest) GetVersion() int {
+	if o.Version == 0 {
+		return 2
+	}
+	return o.Version
+}
+
+// SetVersion sets value to Version
+func (o *VPCRouterCreateRequest) SetVersion(v int) {
+	o.Version = v
 }
 
 // GetSettings returns value of Settings


### PR DESCRIPTION
VPCルータ作成時にバージョン指定を可能にする。デフォルトは`2`。