### PR TITLE
Added RaiseErrorWithUnknownState option to StatePollingWaiter

### DIFF
--- a/v2/sacloud/state.go
+++ b/v2/sacloud/state.go
@@ -128,6 +128,9 @@ type StatePollingWaiter struct {
 	Timeout time.Duration // タイムアウト
 	// PollingInterval ポーリング間隔
 	PollingInterval time.Duration
+
+	// RaiseErrorWithUnknownState State(AvailabilityとInstanceStatus)が予期しない値だった場合にエラーとするか
+	RaiseErrorWithUnknownState bool
 }
 
 func (w *StatePollingWaiter) validateFields() {
@@ -287,7 +290,11 @@ func (w *StatePollingWaiter) handleAvailability(state accessor.Availability) (bo
 	case w.isInAvailability(v, w.PendingAvailability):
 		return false, nil
 	default:
-		return false, fmt.Errorf("got unexpected value of Availability: got %q", v)
+		var err error
+		if w.RaiseErrorWithUnknownState {
+			err = fmt.Errorf("got unexpected value of Availability: got %q", v)
+		}
+		return false, err
 	}
 }
 
@@ -302,7 +309,11 @@ func (w *StatePollingWaiter) handleInstanceState(state accessor.InstanceStatus) 
 	case w.isInInstanceStatus(v, w.PendingInstanceStatus):
 		return false, nil
 	default:
-		return false, fmt.Errorf("got unexpected value of InstanceState: got %q", v)
+		var err error
+		if w.RaiseErrorWithUnknownState {
+			err = fmt.Errorf("got unexpected value of InstanceState: got %q", v)
+		}
+		return false, err
 	}
 }
 


### PR DESCRIPTION
デフォルトのStateWaiterであるStatePollingWaiterに`RaiseErrorWithUnknownState`オプションを追加する。

---

StateWaiterのWaitForState/AsyncWaitForStateではリソースの任意の状態を待ち合わせる機能を提供している。  
またStateWaiterのデフォルト実装としてStatePollingWaiterを提供している。

StatePollingWaiterは通常以下のように利用する。

- StateCheckFuncを指定することで任意の判定を行う

または

- 期待するAvailability or InstanceStatusを指定しておくことで対象リソースと比較して判定する
  (`TargetXXX`と`PendingXXX`を指定する)

2番目の方法を利用する場合、明示していないAvailability or InstanceStatusを受け取った場合はWaitForStateなどがエラーを返す。
この挙動はテストなどでAvailability or InstanceStatusを利用しない(意識しない)リソースをコード上で操作する際にクライアント側にそれらを意識させてしまう問題がある。

```go
// テストコードなどでServerやStateWaiterを利用したいコードの断片
testServer := &Server{
	ID:                      1,
	Name:                    "foobar",
	
	// 必要がなくてもInstanceStatusやAvailabilityを指定しておかないとStateWaiterでエラーとなる
	InstanceStatus:          types.ServerInstanceStatuses.Up,
	Availability: types.Availabilities.Available,
}

// 本来は以下だけでいいはず
testServer := &Server{
	ID:                      1,
	Name:                    "foobar",
}
```

この問題を解決するため、StatePollingWaiterに`RaiseErrorWithUnknownState`オプションを追加する。
`RaiseErrorWithUnknownState`がtrueの場合は従来と同等に不明なstateを受け取ったらエラーとし、falseの場合はそのままWait処理を継続するようにする。

`RaiseErrorWithUnknownState`のデフォルト値は`false`であるためbreaking-changeとなるが、通常はユーティリティなどでStatePollingWaiterは隠蔽されている、かつStatePollingWaiterを直接使っている例は少ないため、ほとんどのクライアントではコードの変更は不要なはず。