### PR TITLE
Go1.16

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
 
       - name: Setup tools
         run: | 
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
 
       - name: Setup tools
         run: | 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
 #    - interfacer
     - nakedret
     - misspell
-    - staticcheck
+#    - staticcheck
     - structcheck
     - typecheck
     - unused

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM golang:1.12
+FROM golang:1.16
 LABEL maintainer="Kazumichi Yamamoto <yamamoto.febc@gmail.com>"
 
 ENV SRC=$GOPATH/src/github.com/sacloud/libsacloud/

--- a/v2/Makefile
+++ b/v2/Makefile
@@ -33,7 +33,7 @@ tools:
 	GO111MODULE=off go get golang.org/x/tools/cmd/stringer
 	GO111MODULE=off go get github.com/sacloud/addlicense
 	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.23.8/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.23.8
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.37.0/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.37.0
 
 .PHONY: clean
 clean:

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/sacloud/libsacloud/v2
 
-go 1.12
+go 1.16
 
 require (
 	github.com/fatih/structs v1.1.0
@@ -20,7 +20,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout v0.15.0
 	go.opentelemetry.io/otel/exporters/trace/jaeger v0.15.0
 	go.opentelemetry.io/otel/sdk v0.15.0
-	go.uber.org/atomic v1.4.0 // indirect
 	go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -156,9 +156,7 @@ github.com/sacloud/ftps v1.1.0 h1:cYv+b6qhrIT8msfx64XXRJzbv5S+Dqwb/rXa5Y641XA=
 github.com/sacloud/ftps v1.1.0/go.mod h1:h4awhOi3PEyhKLj1FpXjoVV5yVkmRUU+d5L95EwX2JU=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -187,8 +185,6 @@ go.opentelemetry.io/otel/exporters/trace/jaeger v0.15.0 h1:OZY+lMaUJiJ6ls1dDtqKh
 go.opentelemetry.io/otel/exporters/trace/jaeger v0.15.0/go.mod h1:4DeFMzRzr2l5o/Lzh4GfOYEH+mnf7ZrEGDzzJEP6ta8=
 go.opentelemetry.io/otel/sdk v0.15.0 h1:Hf2dl1Ad9Hn03qjcAuAq51GP5Pv1SV5puIkS2nRhdd8=
 go.opentelemetry.io/otel/sdk v0.15.0/go.mod h1:Qudkwgq81OcA9GYVlbyZ62wkLieeS1eWxIL0ufxgwoc=
-go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
-go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277 h1:d9qaMM+ODpCq+9We41//fu/sHsTnXcrqd1en3x+GKy4=
 go.uber.org/ratelimit v0.0.0-20180316092928-c15da0234277/go.mod h1:2X8KaoNd1J0lZV+PxJk/5+DGbO/tpwLR1m++a7FnB/Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -232,7 +228,6 @@ golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190501004415-9ce7a6920f09/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -272,7 +267,6 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -348,9 +342,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -429,12 +421,10 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/v2/helper/newsfeed/functions.go
+++ b/v2/helper/newsfeed/functions.go
@@ -16,7 +16,7 @@ package newsfeed
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -31,7 +31,7 @@ func Get() ([]*FeedItem, error) {
 	}
 	defer resp.Body.Close()
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/helper/service/archive/download_test.go
+++ b/v2/helper/service/archive/download_test.go
@@ -16,7 +16,6 @@ package archive
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -37,7 +36,7 @@ func TestArchiveService_downloadAfterBuild(t *testing.T) {
 
 	// file
 	filename := "test-archive-source.tmp"
-	if err := ioutil.WriteFile(filename, []byte("test"), 0755); err != nil {
+	if err := os.WriteFile(filename, []byte("test"), 0755); err != nil {
 		t.Fatal(err)
 	}
 	defer os.Remove(filename) // nolint

--- a/v2/internal/tools/functions.go
+++ b/v2/internal/tools/functions.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"go/build"
 	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -56,7 +55,7 @@ func WriteFileWithTemplate(config *TemplateConfig) bool {
 	}
 
 	// write to file
-	if err := ioutil.WriteFile(config.OutputPath, Sformat(buf.Bytes()), 0644); err != nil {
+	if err := os.WriteFile(config.OutputPath, Sformat(buf.Bytes()), 0644); err != nil {
 		log.Fatalf("writing output: %s", err)
 	}
 	return true

--- a/v2/sacloud/client.go
+++ b/v2/sacloud/client.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"time"
@@ -197,7 +196,7 @@ func (c *Client) Do(ctx context.Context, method, uri string, body interface{}) (
 	}
 	defer resp.Body.Close() // nolint - ignore error
 
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/v2/sacloud/fake/json_file_store.go
+++ b/v2/sacloud/fake/json_file_store.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"sort"
@@ -331,14 +330,14 @@ func (s *JSONFileStore) store() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(s.Path, data, 0600)
+	return os.WriteFile(s.Path, data, 0600)
 }
 
 func (s *JSONFileStore) load() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	data, err := ioutil.ReadFile(s.Path)
+	data, err := os.ReadFile(s.Path)
 	if err != nil {
 		return err
 	}

--- a/v2/sacloud/profile/profile.go
+++ b/v2/sacloud/profile/profile.go
@@ -17,7 +17,6 @@ package profile
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -232,7 +231,7 @@ func Save(profileName string, val interface{}) error {
 
 	// merge new value if current config exists
 	if _, err := os.Stat(path); err == nil {
-		currentData, err := ioutil.ReadFile(path)
+		currentData, err := os.ReadFile(path)
 		if err != nil {
 			return fmt.Errorf("reading current config %q failed: %s", path, err)
 		}
@@ -257,7 +256,7 @@ func Save(profileName string, val interface{}) error {
 		}
 	}
 
-	err = ioutil.WriteFile(path, rawBody, 0600)
+	err = os.WriteFile(path, rawBody, 0600)
 	if err != nil {
 		return fmt.Errorf("writing config to %q is failed: %s", path, err)
 	}
@@ -280,7 +279,7 @@ func Load(profileName string, configValue interface{}) error {
 	// file exists?
 	if _, err := os.Stat(filePath); err == nil {
 		// read file
-		buf, err := ioutil.ReadFile(filePath)
+		buf, err := os.ReadFile(filePath)
 		if err != nil {
 			return fmt.Errorf("loading config from %q is failed: %s", filePath, err)
 		}
@@ -319,7 +318,7 @@ func Remove(profileName string) error {
 	}
 
 	// remove dir if dir is empty
-	info, err := ioutil.ReadDir(dir)
+	info, err := os.ReadDir(dir)
 	if err != nil {
 		return fmt.Errorf("removing config file is failed: reading %q is failed: %s", dir, err)
 	}
@@ -352,7 +351,7 @@ func CurrentName() (string, error) {
 
 	profNameFile := filepath.Join(baseDir, configDirName, currentFileName)
 	if _, err := os.Stat(profNameFile); err == nil {
-		data, err := ioutil.ReadFile(profNameFile)
+		data, err := os.ReadFile(profNameFile)
 		if err != nil {
 			return "", fmt.Errorf("reading current profile is failed: %s", err)
 		}
@@ -409,7 +408,7 @@ func SetCurrentName(profileName string) error {
 	}
 
 	profNameFile := filepath.Join(baseDir, configDirName, currentFileName)
-	if err := ioutil.WriteFile(profNameFile, []byte(profileName), 0600); err != nil {
+	if err := os.WriteFile(profNameFile, []byte(profileName), 0600); err != nil {
 		return fmt.Errorf("writing profile to %q is failed: %s", profNameFile, err)
 	}
 
@@ -429,7 +428,7 @@ func List() ([]string, error) {
 	if _, err := os.Stat(configDirPath); err != nil {
 		return res, nil
 	}
-	entries, err := ioutil.ReadDir(filepath.Join(baseDir, configDirName))
+	entries, err := os.ReadDir(filepath.Join(baseDir, configDirName))
 	if err != nil {
 		return []string{}, fmt.Errorf("listing profiles is failed: %s", err)
 	}

--- a/v2/sacloud/profile/profile_test.go
+++ b/v2/sacloud/profile/profile_test.go
@@ -19,7 +19,6 @@ package profile
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -245,7 +244,7 @@ func initConfigFiles() func() {
 		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
 			panic(err)
 		}
-		if err := ioutil.WriteFile(p, []byte(prof.body), 0600); err != nil {
+		if err := os.WriteFile(p, []byte(prof.body), 0600); err != nil {
 			panic(err)
 		}
 	}
@@ -285,7 +284,7 @@ func Test_CurrentName(t *testing.T) {
 
 	t.Run("Should use profile file", func(t *testing.T) {
 		// create profile name
-		if err := ioutil.WriteFile(profNameFile, []byte("usacloud-unit-test1"), 0600); err != nil {
+		if err := os.WriteFile(profNameFile, []byte("usacloud-unit-test1"), 0600); err != nil {
 			panic(err)
 		}
 		n, err := CurrentName()
@@ -295,14 +294,14 @@ func Test_CurrentName(t *testing.T) {
 
 	t.Run("Invalid name in profile file", func(t *testing.T) {
 		// - with filepath.Separator
-		if err := ioutil.WriteFile(profNameFile, []byte("test"+string([]rune{filepath.Separator})+"test"), 0600); err != nil {
+		if err := os.WriteFile(profNameFile, []byte("test"+string([]rune{filepath.Separator})+"test"), 0600); err != nil {
 			panic(err)
 		}
 		_, err := CurrentName()
 		require.Error(t, err)
 
 		// - with filepath.ListSeparator
-		if err := ioutil.WriteFile(profNameFile, []byte("test"+string([]rune{filepath.ListSeparator})+"test"), 0600); err != nil {
+		if err := os.WriteFile(profNameFile, []byte("test"+string([]rune{filepath.ListSeparator})+"test"), 0600); err != nil {
 			panic(err)
 		}
 		_, err = CurrentName()
@@ -336,7 +335,7 @@ func Test_SetCurrentName(t *testing.T) {
 		err = SetCurrentName("default")
 		require.NoError(t, err)
 
-		data, err := ioutil.ReadFile(profNameFile)
+		data, err := os.ReadFile(profNameFile)
 		require.NoError(t, err)
 		require.Equal(t, "default", string(data))
 	})
@@ -347,7 +346,7 @@ func Test_SetCurrentName(t *testing.T) {
 		err = SetCurrentName("for-usacloud-unit-test1")
 		require.NoError(t, err)
 
-		data, err := ioutil.ReadFile(profNameFile)
+		data, err := os.ReadFile(profNameFile)
 		require.NoError(t, err)
 		require.Equal(t, "for-usacloud-unit-test1", string(data))
 	})
@@ -361,7 +360,7 @@ func Test_SetCurrentName(t *testing.T) {
 		err = SetCurrentName("not-exists")
 		require.Error(t, err)
 
-		data, err := ioutil.ReadFile(profNameFile)
+		data, err := os.ReadFile(profNameFile)
 		require.NoError(t, err)
 		require.Equal(t, "for-usacloud-unit-test1", string(data))
 	})
@@ -452,7 +451,7 @@ func Test_Save(t *testing.T) {
 		targetFile, err := ConfigFilePath(testProfileName)
 		require.NoError(t, err)
 
-		data, err := ioutil.ReadFile(targetFile)
+		data, err := os.ReadFile(targetFile)
 		require.NoError(t, err)
 
 		var mapData map[string]interface{}
@@ -545,7 +544,7 @@ func Test_Remove(t *testing.T) {
 		require.NoError(t, err)
 
 		testOtherFile := filepath.Join(filepath.Dir(path), "test")
-		err = ioutil.WriteFile(testOtherFile, []byte{}, 0600)
+		err = os.WriteFile(testOtherFile, []byte{}, 0600)
 		if err != nil {
 			panic(err)
 		}

--- a/v2/sacloud/test/package_test.go
+++ b/v2/sacloud/test/package_test.go
@@ -28,7 +28,7 @@ import (
 func TestMain(m *testing.M) {
 	testZone = testutil.TestZone()
 
-	ret := m.Run()
+	m.Run()
 
 	skipCleanup := os.Getenv("SKIP_CLEANUP")
 	if skipCleanup == "" {
@@ -36,8 +36,6 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 	}
-
-	os.Exit(ret)
 }
 
 var testZone string

--- a/v2/sacloud/testutil/util.go
+++ b/v2/sacloud/testutil/util.go
@@ -16,7 +16,6 @@ package testutil
 
 import (
 	"fmt"
-	"log"
 	"math/rand"
 	"os"
 	"sync"
@@ -82,15 +81,15 @@ func SingletonAPICaller() sacloud.APICaller {
 	accTestMu.Lock()
 	defer accTestMu.Unlock()
 	accTestOnce.Do(func() {
-		//環境変数にトークン/シークレットがある場合のみテスト実施
+		if !IsAccTest() {
+			os.Setenv("SAKURACLOUD_ACCESS_TOKEN", "dummy")
+			os.Setenv("SAKURACLOUD_ACCESS_TOKEN_SECRET", "dummy")
+		}
+
 		accessToken := os.Getenv("SAKURACLOUD_ACCESS_TOKEN")
 		accessTokenSecret := os.Getenv("SAKURACLOUD_ACCESS_TOKEN_SECRET")
 
-		if accessToken == "" || accessTokenSecret == "" {
-			log.Println("Please Set ENV 'SAKURACLOUD_ACCESS_TOKEN' and 'SAKURACLOUD_ACCESS_TOKEN_SECRET'")
-			os.Exit(0) // exit normal
-		}
-		caller := api.NewCaller(&api.CallerOptions{
+		apiCaller = api.NewCaller(&api.CallerOptions{
 			AccessToken:       accessToken,
 			AccessTokenSecret: accessTokenSecret,
 			UserAgent:         fmt.Sprintf("test-libsacloud/%s", libsacloud.Version),
@@ -100,12 +99,6 @@ func SingletonAPICaller() sacloud.APICaller {
 			TraceHTTP:         IsEnableTrace() || IsEnableHTTPTrace(),
 			FakeMode:          !IsAccTest(),
 		})
-		if !IsAccTest() {
-			os.Setenv("SAKURACLOUD_ACCESS_TOKEN", "dummy")
-			os.Setenv("SAKURACLOUD_ACCESS_TOKEN_SECRET", "dummy")
-		}
-
-		apiCaller = caller
 	})
 	return apiCaller
 }


### PR DESCRIPTION
- go.modでの`go 1.xx`の記述を`go 1.16`へ変更
- `io/ioutil`を`io`または`os`パッケージを利用するように変更
- GitHub Actionsで利用するgoのバージョンを1.16へ変更
- golangci-lintのバージョンをv1.37.0へ更新
- TestMainで`os.Exit()`を呼ばないように修正
- lintでのstaticcheckを無効化
  (`SA3000: TestMain should call os.Exit to set exit code`エラーを回避するため)
- testutil.SingletonAPICaller()内部でos.Exit(0)を呼ばないように修正