### PR TITLE
Add internet plans

### DIFF
--- a/v2/sacloud/types/internet_constants.go
+++ b/v2/sacloud/types/internet_constants.go
@@ -15,7 +15,10 @@
 package types
 
 // InternetBandWidths 設定可能な帯域幅の値リスト
-var InternetBandWidths = []int{100, 250, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000}
+var InternetBandWidths = []int{
+	100, 250, 500, 1000, 1500, 2000, 2500, 3000, 3500, 4000, 4500, 5000,
+	5500, 6000, 6500, 7000, 7500, 8000, 8500, 9000, 9500, 10000,
+}
 
 // InternetNetworkMaskLengths 設定可能なネットワークマスク長の値リスト
 var InternetNetworkMaskLengths = []int{26, 27, 28}


### PR DESCRIPTION
東京第2ゾーンのルータ+スイッチに5,500Mbps〜10,000Mbpsプランを追加する。

Note: libsacloudのAPIとしてはゾーンと紐づけたバリデーションを行なっていないため東京第2ゾーン以外でも5,500Mbps以上のプランを指定できる(さくらのクラウド側APIでエラーとなる)。必要であればクライアント側でバリデーションを実装する。
