### PR TITLE
ESME: DomainName

### DIFF
--- a/v2/helper/service/esme/send_message_request.go
+++ b/v2/helper/service/esme/send_message_request.go
@@ -26,6 +26,7 @@ type SendMessageRequest struct {
 	Destination string `validate:"required"`
 	Sender      string `validate:"required"`
 	OTP         string
+	DomainName  string
 }
 
 func (req *SendMessageRequest) Validate() error {
@@ -37,11 +38,13 @@ func (req *SendMessageRequest) ToRequestParameter() interface{} {
 		return &sacloud.ESMESendMessageWithGeneratedOTPRequest{
 			Destination: req.Destination,
 			Sender:      req.Sender,
+			DomainName:  req.DomainName,
 		}
 	}
 	return &sacloud.ESMESendMessageWithInputtedOTPRequest{
 		Destination: req.Destination,
 		Sender:      req.Sender,
+		DomainName:  req.DomainName,
 		OTP:         req.OTP,
 	}
 }

--- a/v2/internal/define/esme.go
+++ b/v2/internal/define/esme.go
@@ -197,6 +197,7 @@ var (
 			// common fields
 			fields.Def("Destination", meta.TypeString), // 宛先 81開始
 			fields.Def("Sender", meta.TypeString),
+			fields.Def("DomainName", meta.TypeString),
 		},
 	}
 
@@ -214,6 +215,7 @@ var (
 			// common fields
 			fields.Def("Destination", meta.TypeString), // 宛先 81開始
 			fields.Def("Sender", meta.TypeString),
+			fields.Def("DomainName", meta.TypeString),
 			fields.Def("OTP", meta.TypeString),
 		},
 	}

--- a/v2/sacloud/naked/esme.go
+++ b/v2/sacloud/naked/esme.go
@@ -44,6 +44,7 @@ type ESME struct {
 type ESMESendSMSRequest struct {
 	Destination  string              `json:"destination,omitempty" yaml:"destination,omitempty" structs:",omitempty"` // 宛先 現在は81(+81)開始固定
 	Sender       string              `json:"sender,omitempty" yaml:"sender,omitempty" structs:",omitempty"`           // 送信者名 本文中に反映される
+	DomainName   string              `json:"domain_name,omitempty" yaml:"domain_name,omitempty" structs:",omitempty"` // Web OTPを利用する際に本文中に記載されるオリジン(FQDNで指定)
 	OTPOperation types.EOTPOperation `json:"otpOperation,omitempty" yaml:"otp_operation,omitempty" structs:",omitempty"`
 	OTP          string              `json:"otp,omitempty" yaml:"otp,omitempty" structs:",omitempty"` // ワンタイムパスワード、OTPOperationがinputの場合に使用する
 }

--- a/v2/sacloud/test/esme_op_test.go
+++ b/v2/sacloud/test/esme_op_test.go
@@ -71,6 +71,7 @@ func TestESMEOpCRUD(t *testing.T) {
 					_, err := client.SendMessageWithGeneratedOTP(ctx, ctx.ID, &sacloud.ESMESendMessageWithGeneratedOTPRequest{
 						Destination: destination,
 						Sender:      "libsacloud-test",
+						DomainName:  "www.example.com",
 					})
 					return nil, err
 				},
@@ -93,6 +94,7 @@ func TestESMEOpCRUD(t *testing.T) {
 					_, err := client.SendMessageWithInputtedOTP(ctx, ctx.ID, &sacloud.ESMESendMessageWithInputtedOTPRequest{
 						Destination: destination,
 						Sender:      "libsacloud-test",
+						DomainName:  "www.example.com",
 						OTP:         "397397",
 					})
 					return nil, err

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -9166,6 +9166,7 @@ func (o *ESMESendMessageResult) SetOTP(v string) {
 type ESMESendMessageWithGeneratedOTPRequest struct {
 	Destination string
 	Sender      string
+	DomainName  string
 }
 
 // Validate validates by field tags
@@ -9178,10 +9179,12 @@ func (o *ESMESendMessageWithGeneratedOTPRequest) setDefaults() interface{} {
 	return &struct {
 		Destination  string
 		Sender       string
+		DomainName   string
 		OTPOperation types.EOTPOperation
 	}{
 		Destination:  o.GetDestination(),
 		Sender:       o.GetSender(),
+		DomainName:   o.GetDomainName(),
 		OTPOperation: "generate",
 	}
 }
@@ -9206,6 +9209,16 @@ func (o *ESMESendMessageWithGeneratedOTPRequest) SetSender(v string) {
 	o.Sender = v
 }
 
+// GetDomainName returns value of DomainName
+func (o *ESMESendMessageWithGeneratedOTPRequest) GetDomainName() string {
+	return o.DomainName
+}
+
+// SetDomainName sets value to DomainName
+func (o *ESMESendMessageWithGeneratedOTPRequest) SetDomainName(v string) {
+	o.DomainName = v
+}
+
 /*************************************************
 * ESMESendMessageWithInputtedOTPRequest
 *************************************************/
@@ -9214,6 +9227,7 @@ func (o *ESMESendMessageWithGeneratedOTPRequest) SetSender(v string) {
 type ESMESendMessageWithInputtedOTPRequest struct {
 	Destination string
 	Sender      string
+	DomainName  string
 	OTP         string
 }
 
@@ -9227,11 +9241,13 @@ func (o *ESMESendMessageWithInputtedOTPRequest) setDefaults() interface{} {
 	return &struct {
 		Destination  string
 		Sender       string
+		DomainName   string
 		OTP          string
 		OTPOperation types.EOTPOperation
 	}{
 		Destination:  o.GetDestination(),
 		Sender:       o.GetSender(),
+		DomainName:   o.GetDomainName(),
 		OTP:          o.GetOTP(),
 		OTPOperation: "input",
 	}
@@ -9255,6 +9271,16 @@ func (o *ESMESendMessageWithInputtedOTPRequest) GetSender() string {
 // SetSender sets value to Sender
 func (o *ESMESendMessageWithInputtedOTPRequest) SetSender(v string) {
 	o.Sender = v
+}
+
+// GetDomainName returns value of DomainName
+func (o *ESMESendMessageWithInputtedOTPRequest) GetDomainName() string {
+	return o.DomainName
+}
+
+// SetDomainName sets value to DomainName
+func (o *ESMESendMessageWithInputtedOTPRequest) SetDomainName(v string) {
+	o.DomainName = v
 }
 
 // GetOTP returns value of OTP


### PR DESCRIPTION
closes #728 

WebOTPでSMS本文に埋め込まれるFQDNを指定するためのパラメータ`DomainName`を追加する。