### PR TITLE
Fixed parameter handling in server's plan change API

### DIFF
--- a/v2/helper/builder/server/builder.go
+++ b/v2/helper/builder/server/builder.go
@@ -441,6 +441,7 @@ type serverState struct {
 	interfaceDriver types.EInterfaceDriver
 	memoryGB        int
 	cpu             int
+	commitment      types.ECommitment
 	nic             *nicState   // hash
 	additionalNICs  []*nicState // hash
 	diskCount       int
@@ -461,6 +462,7 @@ func (b *Builder) desiredState() *serverState {
 		interfaceDriver: b.InterfaceDriver,
 		memoryGB:        b.MemoryGB,
 		cpu:             b.CPU,
+		commitment:      b.Commitment,
 		nic:             nic,
 		additionalNICs:  additionalNICs,
 		diskCount:       len(b.DiskBuilders),
@@ -513,6 +515,7 @@ func (b *Builder) currentState(server *sacloud.Server) *serverState {
 		interfaceDriver: server.InterfaceDriver,
 		memoryGB:        server.GetMemoryGB(),
 		cpu:             server.CPU,
+		commitment:      server.ServerPlanCommitment,
 		nic:             nic,
 		additionalNICs:  additionalNICs,
 		diskCount:       len(server.Disks),

--- a/v2/helper/builder/server/builder_test.go
+++ b/v2/helper/builder/server/builder_test.go
@@ -668,6 +668,24 @@ func TestBuilder_IsNeedShutdown(t *testing.T) {
 			},
 		},
 		{
+			msg:    "changed: Commitment",
+			expect: true,
+			err:    nil,
+			in: &Builder{
+				ServerID: types.ID(1),
+				CPU:      1,
+				Client: &APIClient{
+					Server: &dummyCreateServerHandler{
+						server: &sacloud.Server{
+							ID:                   types.ID(1),
+							CPU:                  1,
+							ServerPlanCommitment: types.Commitments.DedicatedCPU,
+						},
+					},
+				},
+			},
+		},
+		{
 			msg:    "changed: add NIC",
 			expect: true,
 			err:    nil,

--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -183,6 +183,9 @@ func (f *fieldsDef) MemoryMB() *dsl.FieldDesc {
 func (f *fieldsDef) Generation() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "ServerPlanGeneration",
+		Tags: &dsl.FieldTags{
+			JSON: "Generation,omitempty",
+		},
 		Type: meta.TypePlanGeneration,
 	}
 }
@@ -191,7 +194,7 @@ func (f *fieldsDef) Commitment() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "ServerPlanCommitment",
 		Tags: &dsl.FieldTags{
-			MapConv: "Commitment",
+			JSON: "Commitment,omitempty",
 		},
 		Type:         meta.TypeCommitment,
 		DefaultValue: "types.Commitments.Standard",

--- a/v2/internal/define/server.go
+++ b/v2/internal/define/server.go
@@ -358,7 +358,7 @@ var (
 			fields.CPU(),
 			fields.MemoryMB(),
 			fields.Generation(),
-			fields.ServerPlanCommitment(),
+			fields.Commitment(),
 		},
 		NakedType: meta.Static(naked.ServerPlan{}),
 	}

--- a/v2/sacloud/zz_envelopes.go
+++ b/v2/sacloud/zz_envelopes.go
@@ -2289,8 +2289,8 @@ type serverDeleteWithDisksRequestEnvelope struct {
 type serverChangePlanRequestEnvelope struct {
 	CPU                  int                   `json:",omitempty"`
 	MemoryMB             int                   `json:",omitempty"`
-	ServerPlanGeneration types.EPlanGeneration `json:",omitempty"`
-	ServerPlanCommitment types.ECommitment     `json:",omitempty" mapconv:"ServerPlan.Commitment"`
+	ServerPlanGeneration types.EPlanGeneration `json:"Generation,omitempty"`
+	ServerPlanCommitment types.ECommitment     `json:"Commitment,omitempty"`
 }
 
 // serverChangePlanResponseEnvelope is envelop of API response

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -21748,8 +21748,8 @@ func (o *ServerDeleteWithDisksRequest) SetIDs(v []types.ID) {
 type ServerChangePlanRequest struct {
 	CPU                  int
 	MemoryMB             int
-	ServerPlanGeneration types.EPlanGeneration
-	ServerPlanCommitment types.ECommitment `json:",omitempty" mapconv:"ServerPlan.Commitment"`
+	ServerPlanGeneration types.EPlanGeneration `json:"Generation,omitempty"`
+	ServerPlanCommitment types.ECommitment     `json:"Commitment,omitempty"`
 }
 
 // Validate validates by field tags
@@ -21762,8 +21762,8 @@ func (o *ServerChangePlanRequest) setDefaults() interface{} {
 	return &struct {
 		CPU                  int
 		MemoryMB             int
-		ServerPlanGeneration types.EPlanGeneration
-		ServerPlanCommitment types.ECommitment `json:",omitempty" mapconv:"ServerPlan.Commitment"`
+		ServerPlanGeneration types.EPlanGeneration `json:"Generation,omitempty"`
+		ServerPlanCommitment types.ECommitment     `json:"Commitment,omitempty"`
 	}{
 		CPU:                  o.GetCPU(),
 		MemoryMB:             o.GetMemoryMB(),


### PR DESCRIPTION
- サーバのプラン変更APIにおいてCommitmentが正しく受け渡されない問題を修正
- builderにおける再起動要否の確認時にCommitmentが考慮されていなかった問題を修正