### PR TITLE
Server: SendNMI

### DIFF
--- a/v2/helper/service/server/send_nmi_request.go
+++ b/v2/helper/service/server/send_nmi_request.go
@@ -1,0 +1,29 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"github.com/sacloud/libsacloud/v2/helper/validate"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type SendNMIRequest struct {
+	Zone string   `request:"-" validate:"required"`
+	ID   types.ID `request:"-" validate:"required"`
+}
+
+func (req *SendNMIRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/v2/helper/service/server/send_nmi_service.go
+++ b/v2/helper/service/server/send_nmi_service.go
@@ -1,0 +1,34 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+func (s *Service) SendNMI(req *SendNMIRequest) error {
+	return s.SendNMIWithContext(context.Background(), req)
+}
+
+func (s *Service) SendNMIWithContext(ctx context.Context, req *SendNMIRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	client := sacloud.NewServerOp(s.caller)
+	return client.SendNMI(ctx, req.Zone, req.ID)
+}

--- a/v2/internal/define/server.go
+++ b/v2/internal/define/server.go
@@ -167,6 +167,9 @@ var serverAPI = &dsl.Resource{
 			RequestEnvelope: dsl.RequestEnvelopeFromModel(serverSendKeyParam),
 		},
 
+		// send NMI
+		ops.WithIDAction(serverAPIName, "SendNMI", http.MethodPut, "qemu/nmi"),
+
 		// get vnc proxy
 		{
 			ResourceName: serverAPIName,

--- a/v2/sacloud/fake/ops_server.go
+++ b/v2/sacloud/fake/ops_server.go
@@ -355,6 +355,15 @@ func (o *ServerOp) SendKey(ctx context.Context, zone string, id types.ID, keyboa
 	return nil
 }
 
+// SendNMI is fake implementation
+func (o *ServerOp) SendNMI(ctx context.Context, zone string, id types.ID) error {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetVNCProxy is fake implementation
 func (o *ServerOp) GetVNCProxy(ctx context.Context, zone string, id types.ID) (*sacloud.VNCProxyInfo, error) {
 	_, err := o.Read(ctx, zone, id)

--- a/v2/sacloud/stub/zz_api_stubs.go
+++ b/v2/sacloud/stub/zz_api_stubs.go
@@ -3974,6 +3974,11 @@ type ServerSendKeyStubResult struct {
 	Err error
 }
 
+// ServerSendNMIStubResult is expected values of the SendNMI operation
+type ServerSendNMIStubResult struct {
+	Err error
+}
+
 // ServerGetVNCProxyStubResult is expected values of the GetVNCProxy operation
 type ServerGetVNCProxyStubResult struct {
 	VNCProxyInfo *sacloud.VNCProxyInfo
@@ -4007,6 +4012,7 @@ type ServerStub struct {
 	ShutdownStubResult        *ServerShutdownStubResult
 	ResetStubResult           *ServerResetStubResult
 	SendKeyStubResult         *ServerSendKeyStubResult
+	SendNMIStubResult         *ServerSendNMIStubResult
 	GetVNCProxyStubResult     *ServerGetVNCProxyStubResult
 	MonitorStubResult         *ServerMonitorStubResult
 	MonitorCPUStubResult      *ServerMonitorCPUStubResult
@@ -4119,6 +4125,14 @@ func (s *ServerStub) SendKey(ctx context.Context, zone string, id types.ID, keyb
 		log.Fatal("ServerStub.SendKeyStubResult is not set")
 	}
 	return s.SendKeyStubResult.Err
+}
+
+// SendNMI is API call with trace log
+func (s *ServerStub) SendNMI(ctx context.Context, zone string, id types.ID) error {
+	if s.SendNMIStubResult == nil {
+		log.Fatal("ServerStub.SendNMIStubResult is not set")
+	}
+	return s.SendNMIStubResult.Err
 }
 
 // GetVNCProxy is API call with trace log

--- a/v2/sacloud/trace/zz_api_tracer.go
+++ b/v2/sacloud/trace/zz_api_tracer.go
@@ -8764,6 +8764,37 @@ func (t *ServerTracer) SendKey(ctx context.Context, zone string, id types.ID, ke
 	return err
 }
 
+// SendNMI is API call with trace log
+func (t *ServerTracer) SendNMI(ctx context.Context, zone string, id types.ID) error {
+	log.Println("[TRACE] ServerAPI.SendNMI start")
+	targetArguments := struct {
+		Argzone string
+		Argid   types.ID `json:"id"`
+	}{
+		Argzone: zone,
+		Argid:   id,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ServerAPI.SendNMI end")
+	}()
+
+	err := t.Internal.SendNMI(ctx, zone, id)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
 // GetVNCProxy is API call with trace log
 func (t *ServerTracer) GetVNCProxy(ctx context.Context, zone string, id types.ID) (*sacloud.VNCProxyInfo, error) {
 	log.Println("[TRACE] ServerAPI.GetVNCProxy start")

--- a/v2/sacloud/zz_api_ops.go
+++ b/v2/sacloud/zz_api_ops.go
@@ -9580,6 +9580,35 @@ func (o *ServerOp) SendKey(ctx context.Context, zone string, id types.ID, keyboa
 	return nil
 }
 
+// SendNMI is API call
+func (o *ServerOp) SendNMI(ctx context.Context, zone string, id types.ID) error {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/qemu/nmi", pathBuildParameter)
+	if err != nil {
+		return err
+	}
+	// build request body
+	var body interface{}
+
+	// do request
+	_, err = o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	// build results
+
+	return nil
+}
+
 // GetVNCProxy is API call
 func (o *ServerOp) GetVNCProxy(ctx context.Context, zone string, id types.ID) (*VNCProxyInfo, error) {
 	// build request URL

--- a/v2/sacloud/zz_apis.go
+++ b/v2/sacloud/zz_apis.go
@@ -539,6 +539,7 @@ type ServerAPI interface {
 	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *ShutdownOption) error
 	Reset(ctx context.Context, zone string, id types.ID) error
 	SendKey(ctx context.Context, zone string, id types.ID, keyboardParam *SendKeyRequest) error
+	SendNMI(ctx context.Context, zone string, id types.ID) error
 	GetVNCProxy(ctx context.Context, zone string, id types.ID) (*VNCProxyInfo, error)
 	Monitor(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*CPUTimeActivity, error)
 	MonitorCPU(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*CPUTimeActivity, error)


### PR DESCRIPTION
closes #732 

NMI送信APIの実装

```go
type ServerAPI interface {
	// 追加
	SendNMI(ctx context.Context, zone string, id types.ID) error
}
```

```go
// serviceに以下2つを追加

func (s *Service) SendNMI(req *SendNMIRequest) error
func (s *Service) SendNMIWithContext(ctx context.Context, req *SendNMIRequest) error
```