### PR TITLE
SimpleMonitor: HTTP/2

### DIFF
--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -1181,6 +1181,10 @@ func (f *fieldsDef) SimpleMonitorHealthCheck() *dsl.FieldDesc {
 					Name: "RemainingDays",
 					Type: meta.TypeInt,
 				},
+				{
+					Name: "HTTP2",
+					Type: meta.TypeStringFlag,
+				},
 			},
 		},
 		Tags: &dsl.FieldTags{

--- a/v2/sacloud/naked/simple_monitor.go
+++ b/v2/sacloud/naked/simple_monitor.go
@@ -74,6 +74,7 @@ type SimpleMonitorHealthCheck struct {
 	SNMPVersion       string                       `json:",omitempty" yaml:"snmp_version,omitempty" structs:",omitempty"`        // SNMP監視 SNMPバージョン
 	OID               string                       `json:",omitempty" yaml:"oid,omitempty" structs:",omitempty"`                 // SNMP監視 OID
 	RemainingDays     int                          `json:",omitempty" yaml:"remaining_days,omitempty" structs:",omitempty"`      // SSL証明書 有効残日数
+	HTTP2             types.StringFlag             `yaml:"http2"`                                                                // HTTPS監視の場合にHTTP/2を利用するか
 }
 
 // SimpleMonitorNotifyEmail Eメールでの通知設定

--- a/v2/sacloud/test/simple_monitor_op_test.go
+++ b/v2/sacloud/test/simple_monitor_op_test.go
@@ -135,6 +135,7 @@ var (
 			Host:              "libsacloud-test-upd.usacloud.jp",
 			BasicAuthUsername: "username-upd",
 			BasicAuthPassword: "password-upd",
+			HTTP2:             true,
 		},
 		NotifyEmailEnabled: types.StringFalse,
 		NotifyEmailHTML:    types.StringFalse,

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -23775,6 +23775,7 @@ type SimpleMonitorHealthCheck struct {
 	SNMPVersion       string
 	OID               string
 	RemainingDays     int
+	HTTP2             types.StringFlag
 }
 
 // Validate validates by field tags
@@ -23799,6 +23800,7 @@ func (o *SimpleMonitorHealthCheck) setDefaults() interface{} {
 		SNMPVersion       string
 		OID               string
 		RemainingDays     int
+		HTTP2             types.StringFlag
 	}{
 		Protocol:          o.GetProtocol(),
 		Port:              o.GetPort(),
@@ -23814,6 +23816,7 @@ func (o *SimpleMonitorHealthCheck) setDefaults() interface{} {
 		SNMPVersion:       o.GetSNMPVersion(),
 		OID:               o.GetOID(),
 		RemainingDays:     o.GetRemainingDays(),
+		HTTP2:             o.GetHTTP2(),
 	}
 }
 
@@ -23955,6 +23958,16 @@ func (o *SimpleMonitorHealthCheck) GetRemainingDays() int {
 // SetRemainingDays sets value to RemainingDays
 func (o *SimpleMonitorHealthCheck) SetRemainingDays(v int) {
 	o.RemainingDays = v
+}
+
+// GetHTTP2 returns value of HTTP2
+func (o *SimpleMonitorHealthCheck) GetHTTP2() types.StringFlag {
+	return o.HTTP2
+}
+
+// SetHTTP2 sets value to HTTP2
+func (o *SimpleMonitorHealthCheck) SetHTTP2(v types.StringFlag) {
+	o.HTTP2 = v
 }
 
 /*************************************************


### PR DESCRIPTION
シンプル監視のHTTPS監視においてHTTP/2対応クライアントでの監視を有効にするためのフラグを追加