### PR TITLE
ELB: Gzip

### DIFF
--- a/v2/helper/service/proxylb/create_request.go
+++ b/v2/helper/service/proxylb/create_request.go
@@ -34,6 +34,7 @@ type CreateRequest struct {
 	Rules          []*sacloud.ProxyLBRule
 	LetsEncrypt    *sacloud.ProxyLBACMESetting
 	StickySession  *sacloud.ProxyLBStickySession
+	Gzip           *sacloud.ProxyLBGzip
 	Timeout        *sacloud.ProxyLBTimeout
 	UseVIPFailover bool
 	Region         types.EProxyLBRegion

--- a/v2/helper/service/proxylb/update_request.go
+++ b/v2/helper/service/proxylb/update_request.go
@@ -36,6 +36,7 @@ type UpdateRequest struct {
 	Rules         *[]*sacloud.ProxyLBRule       `request:",omitempty"`
 	LetsEncrypt   *sacloud.ProxyLBACMESetting   `request:",omitempty"`
 	StickySession *sacloud.ProxyLBStickySession `request:",omitempty"`
+	Gzip          *sacloud.ProxyLBGzip          `request:",omitempty"`
 	Timeout       *sacloud.ProxyLBTimeout       `request:",omitempty"`
 	SettingsHash  string
 }

--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -1456,6 +1456,24 @@ func (f *fieldsDef) ProxyLBStickySession() *dsl.FieldDesc {
 	}
 }
 
+func (f *fieldsDef) ProxyLBGzip() *dsl.FieldDesc {
+	return &dsl.FieldDesc{
+		Name: "Gzip",
+		Type: &dsl.Model{
+			Name: "ProxyLBGzip",
+			Fields: []*dsl.FieldDesc{
+				{
+					Name: "Enabled",
+					Type: meta.TypeFlag,
+				},
+			},
+		},
+		Tags: &dsl.FieldTags{
+			MapConv: "Settings.ProxyLB.Gzip,recursive",
+		},
+	}
+}
+
 func (f *fieldsDef) ProxyLBTimeout() *dsl.FieldDesc {
 	return &dsl.FieldDesc{
 		Name: "Timeout",

--- a/v2/internal/define/proxylb.go
+++ b/v2/internal/define/proxylb.go
@@ -183,6 +183,7 @@ var (
 			fields.ProxyLBRules(),
 			fields.ProxyLBLetsEncrypt(),
 			fields.ProxyLBStickySession(),
+			fields.ProxyLBGzip(),
 			fields.ProxyLBTimeout(),
 			fields.SettingsHash(),
 
@@ -221,6 +222,7 @@ var (
 			fields.ProxyLBLetsEncrypt(),
 			fields.ProxyLBStickySession(),
 			fields.ProxyLBTimeout(),
+			fields.ProxyLBGzip(),
 
 			// status
 			fields.ProxyLBUseVIPFailover(),
@@ -248,6 +250,7 @@ var (
 			fields.ProxyLBLetsEncrypt(),
 			fields.ProxyLBStickySession(),
 			fields.ProxyLBTimeout(),
+			fields.ProxyLBGzip(),
 			// settings hash
 			fields.SettingsHash(),
 
@@ -272,6 +275,7 @@ var (
 			fields.ProxyLBLetsEncrypt(),
 			fields.ProxyLBStickySession(),
 			fields.ProxyLBTimeout(),
+			fields.ProxyLBGzip(),
 			// settings hash
 			fields.SettingsHash(),
 		},

--- a/v2/sacloud/naked/proxylb.go
+++ b/v2/sacloud/naked/proxylb.go
@@ -93,6 +93,7 @@ type ProxyLBSetting struct {
 	LetsEncrypt   *ProxyLBACMESetting  `json:",omitempty" yaml:"lets_encrypt,omitempty" structs:",omitempty"` // Let's encryptでの証明書取得設定
 	StickySession ProxyLBStickySession `yaml:"sticky_session"`                                                // StickySession
 	Timeout       ProxyLBTimeout       `json:",omitempty" yaml:"timeout,omitempty" structs:",omitempty"`      // タイムアウト
+	Gzip          ProxyLBGzip          `yaml:"gzip"`                                                          // Gzip
 }
 
 // MarshalJSON nullの場合に空配列を出力するための実装
@@ -158,14 +159,19 @@ type ProxyLBRule struct {
 
 // ProxyLBACMESetting Let's Encryptでの証明書取得設定
 type ProxyLBACMESetting struct {
-	Enabled    bool
+	Enabled    bool   `yaml:"enabled"`
 	CommonName string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
 }
 
 // ProxyLBStickySession セッション維持(Sticky session)設定
 type ProxyLBStickySession struct {
-	Enabled bool
+	Enabled bool   `yaml:"enabled"`
 	Method  string `json:",omitempty" yaml:"method,omitempty" structs:",omitempty"`
+}
+
+// ProxyLBGzip Gzip圧縮設定
+type ProxyLBGzip struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // ProxyLBTimeout 実サーバの通信タイムアウト

--- a/v2/sacloud/state_test.go
+++ b/v2/sacloud/state_test.go
@@ -131,7 +131,7 @@ func TestStatePollingWaiter_withStateCheckFunc(t *testing.T) {
 				return &dummyState{}, errors.New("dummy")
 			},
 			StateCheckFunc:  testStateCheckFunc,
-			Timeout:         10 * time.Millisecond,
+			Timeout:         100 * time.Millisecond,
 			PollingInterval: 1 * time.Millisecond,
 		}
 		ctx := context.Background()
@@ -175,7 +175,7 @@ func TestStatePollingWaiter_withTargetStates(t *testing.T) {
 				return &dummyInstanceStatus{status: status}, nil
 			},
 			TargetInstanceStatus: []types.EServerInstanceStatus{types.ServerInstanceStatuses.Up},
-			Timeout:              10 * time.Millisecond,
+			Timeout:              100 * time.Millisecond,
 			PollingInterval:      1 * time.Millisecond,
 		}
 		ctx := context.Background()
@@ -189,7 +189,7 @@ func TestStatePollingWaiter_withTargetStates(t *testing.T) {
 				return &dummyInstanceStatus{status: "unknown-instance-status"}, nil
 			},
 			TargetInstanceStatus:       []types.EServerInstanceStatus{types.ServerInstanceStatuses.Up},
-			Timeout:                    10 * time.Millisecond,
+			Timeout:                    100 * time.Millisecond,
 			PollingInterval:            1 * time.Millisecond,
 			RaiseErrorWithUnknownState: true,
 		}
@@ -213,7 +213,7 @@ func TestStatePollingWaiter_withTargetStates(t *testing.T) {
 				return &dummyInstanceStatus{availability: availability}, nil
 			},
 			TargetAvailability: []types.EAvailability{types.Availabilities.Available},
-			Timeout:            10 * time.Millisecond,
+			Timeout:            100 * time.Millisecond,
 			PollingInterval:    1 * time.Millisecond,
 		}
 		ctx := context.Background()
@@ -228,7 +228,7 @@ func TestStatePollingWaiter_withTargetStates(t *testing.T) {
 				return &dummyInstanceStatus{availability: "unknown-availability"}, nil
 			},
 			TargetAvailability:         []types.EAvailability{types.Availabilities.Available},
-			Timeout:                    10 * time.Millisecond,
+			Timeout:                    100 * time.Millisecond,
 			PollingInterval:            1 * time.Millisecond,
 			RaiseErrorWithUnknownState: true,
 		}

--- a/v2/sacloud/test/proxylb_op_test.go
+++ b/v2/sacloud/test/proxylb_op_test.go
@@ -184,6 +184,9 @@ func initProxyLBVariables() {
 			Method:  "cookie",
 			Enabled: true,
 		},
+		Gzip: &sacloud.ProxyLBGzip{
+			Enabled: true,
+		},
 		Timeout: &sacloud.ProxyLBTimeout{
 			InactiveSec: 30,
 		},
@@ -204,6 +207,7 @@ func initProxyLBVariables() {
 		Rules:          createProxyLBParam.Rules,
 		LetsEncrypt:    createProxyLBParam.LetsEncrypt,
 		StickySession:  createProxyLBParam.StickySession,
+		Gzip:           createProxyLBParam.Gzip,
 		Timeout:        createProxyLBParam.Timeout,
 		UseVIPFailover: createProxyLBParam.UseVIPFailover,
 		Region:         createProxyLBParam.Region,
@@ -265,6 +269,9 @@ func initProxyLBVariables() {
 			Enabled: false,
 		},
 		StickySession: &sacloud.ProxyLBStickySession{
+			Enabled: false,
+		},
+		Gzip: &sacloud.ProxyLBGzip{
 			Enabled: false,
 		},
 		Timeout: &sacloud.ProxyLBTimeout{

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -18575,6 +18575,7 @@ type ProxyLB struct {
 	Rules            []*ProxyLBRule        `mapconv:"Settings.ProxyLB.[]Rules,recursive"`
 	LetsEncrypt      *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
 	StickySession    *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
+	Gzip             *ProxyLBGzip          `mapconv:"Settings.ProxyLB.Gzip,recursive"`
 	Timeout          *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
 	SettingsHash     string                `json:",omitempty" mapconv:",omitempty"`
 	UseVIPFailover   bool                  `mapconv:"Status.UseVIPFailover"`
@@ -18608,6 +18609,7 @@ func (o *ProxyLB) setDefaults() interface{} {
 		Rules            []*ProxyLBRule        `mapconv:"Settings.ProxyLB.[]Rules,recursive"`
 		LetsEncrypt      *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
 		StickySession    *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
+		Gzip             *ProxyLBGzip          `mapconv:"Settings.ProxyLB.Gzip,recursive"`
 		Timeout          *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
 		SettingsHash     string                `json:",omitempty" mapconv:",omitempty"`
 		UseVIPFailover   bool                  `mapconv:"Status.UseVIPFailover"`
@@ -18632,6 +18634,7 @@ func (o *ProxyLB) setDefaults() interface{} {
 		Rules:            o.GetRules(),
 		LetsEncrypt:      o.GetLetsEncrypt(),
 		StickySession:    o.GetStickySession(),
+		Gzip:             o.GetGzip(),
 		Timeout:          o.GetTimeout(),
 		SettingsHash:     o.GetSettingsHash(),
 		UseVIPFailover:   o.GetUseVIPFailover(),
@@ -18840,6 +18843,16 @@ func (o *ProxyLB) GetStickySession() *ProxyLBStickySession {
 // SetStickySession sets value to StickySession
 func (o *ProxyLB) SetStickySession(v *ProxyLBStickySession) {
 	o.StickySession = v
+}
+
+// GetGzip returns value of Gzip
+func (o *ProxyLB) GetGzip() *ProxyLBGzip {
+	return o.Gzip
+}
+
+// SetGzip sets value to Gzip
+func (o *ProxyLB) SetGzip(v *ProxyLBGzip) {
+	o.Gzip = v
 }
 
 // GetTimeout returns value of Timeout
@@ -19385,6 +19398,39 @@ func (o *ProxyLBStickySession) SetEnabled(v bool) {
 }
 
 /*************************************************
+* ProxyLBGzip
+*************************************************/
+
+// ProxyLBGzip represents API parameter/response structure
+type ProxyLBGzip struct {
+	Enabled bool
+}
+
+// Validate validates by field tags
+func (o *ProxyLBGzip) Validate() error {
+	return validate.Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ProxyLBGzip) setDefaults() interface{} {
+	return &struct {
+		Enabled bool
+	}{
+		Enabled: o.GetEnabled(),
+	}
+}
+
+// GetEnabled returns value of Enabled
+func (o *ProxyLBGzip) GetEnabled() bool {
+	return o.Enabled
+}
+
+// SetEnabled sets value to Enabled
+func (o *ProxyLBGzip) SetEnabled(v bool) {
+	o.Enabled = v
+}
+
+/*************************************************
 * ProxyLBTimeout
 *************************************************/
 
@@ -19435,6 +19481,7 @@ type ProxyLBCreateRequest struct {
 	LetsEncrypt    *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
 	StickySession  *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
 	Timeout        *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+	Gzip           *ProxyLBGzip          `mapconv:"Settings.ProxyLB.Gzip,recursive"`
 	UseVIPFailover bool                  `mapconv:"Status.UseVIPFailover"`
 	Region         types.EProxyLBRegion  `mapconv:"Status.Region"`
 	Name           string
@@ -19460,6 +19507,7 @@ func (o *ProxyLBCreateRequest) setDefaults() interface{} {
 		LetsEncrypt    *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
 		StickySession  *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
 		Timeout        *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+		Gzip           *ProxyLBGzip          `mapconv:"Settings.ProxyLB.Gzip,recursive"`
 		UseVIPFailover bool                  `mapconv:"Status.UseVIPFailover"`
 		Region         types.EProxyLBRegion  `mapconv:"Status.Region"`
 		Name           string
@@ -19477,6 +19525,7 @@ func (o *ProxyLBCreateRequest) setDefaults() interface{} {
 		LetsEncrypt:    o.GetLetsEncrypt(),
 		StickySession:  o.GetStickySession(),
 		Timeout:        o.GetTimeout(),
+		Gzip:           o.GetGzip(),
 		UseVIPFailover: o.GetUseVIPFailover(),
 		Region:         o.GetRegion(),
 		Name:           o.GetName(),
@@ -19577,6 +19626,16 @@ func (o *ProxyLBCreateRequest) SetTimeout(v *ProxyLBTimeout) {
 	o.Timeout = v
 }
 
+// GetGzip returns value of Gzip
+func (o *ProxyLBCreateRequest) GetGzip() *ProxyLBGzip {
+	return o.Gzip
+}
+
+// SetGzip sets value to Gzip
+func (o *ProxyLBCreateRequest) SetGzip(v *ProxyLBGzip) {
+	o.Gzip = v
+}
+
 // GetUseVIPFailover returns value of UseVIPFailover
 func (o *ProxyLBCreateRequest) GetUseVIPFailover() bool {
 	return o.UseVIPFailover
@@ -19671,6 +19730,7 @@ type ProxyLBUpdateRequest struct {
 	LetsEncrypt   *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
 	StickySession *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
 	Timeout       *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+	Gzip          *ProxyLBGzip          `mapconv:"Settings.ProxyLB.Gzip,recursive"`
 	SettingsHash  string                `json:",omitempty" mapconv:",omitempty"`
 	Name          string
 	Description   string
@@ -19694,6 +19754,7 @@ func (o *ProxyLBUpdateRequest) setDefaults() interface{} {
 		LetsEncrypt   *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
 		StickySession *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
 		Timeout       *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+		Gzip          *ProxyLBGzip          `mapconv:"Settings.ProxyLB.Gzip,recursive"`
 		SettingsHash  string                `json:",omitempty" mapconv:",omitempty"`
 		Name          string
 		Description   string
@@ -19708,6 +19769,7 @@ func (o *ProxyLBUpdateRequest) setDefaults() interface{} {
 		LetsEncrypt:   o.GetLetsEncrypt(),
 		StickySession: o.GetStickySession(),
 		Timeout:       o.GetTimeout(),
+		Gzip:          o.GetGzip(),
 		SettingsHash:  o.GetSettingsHash(),
 		Name:          o.GetName(),
 		Description:   o.GetDescription(),
@@ -19796,6 +19858,16 @@ func (o *ProxyLBUpdateRequest) SetTimeout(v *ProxyLBTimeout) {
 	o.Timeout = v
 }
 
+// GetGzip returns value of Gzip
+func (o *ProxyLBUpdateRequest) GetGzip() *ProxyLBGzip {
+	return o.Gzip
+}
+
+// SetGzip sets value to Gzip
+func (o *ProxyLBUpdateRequest) SetGzip(v *ProxyLBGzip) {
+	o.Gzip = v
+}
+
 // GetSettingsHash returns value of SettingsHash
 func (o *ProxyLBUpdateRequest) GetSettingsHash() string {
 	return o.SettingsHash
@@ -19880,6 +19952,7 @@ type ProxyLBUpdateSettingsRequest struct {
 	LetsEncrypt   *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
 	StickySession *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
 	Timeout       *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+	Gzip          *ProxyLBGzip          `mapconv:"Settings.ProxyLB.Gzip,recursive"`
 	SettingsHash  string                `json:",omitempty" mapconv:",omitempty"`
 }
 
@@ -19899,6 +19972,7 @@ func (o *ProxyLBUpdateSettingsRequest) setDefaults() interface{} {
 		LetsEncrypt   *ProxyLBACMESetting   `mapconv:"Settings.ProxyLB.LetsEncrypt,recursive"`
 		StickySession *ProxyLBStickySession `mapconv:"Settings.ProxyLB.StickySession,recursive"`
 		Timeout       *ProxyLBTimeout       `json:",omitempty" mapconv:"Settings.ProxyLB.Timeout,recursive,omitempty"`
+		Gzip          *ProxyLBGzip          `mapconv:"Settings.ProxyLB.Gzip,recursive"`
 		SettingsHash  string                `json:",omitempty" mapconv:",omitempty"`
 	}{
 		HealthCheck:   o.GetHealthCheck(),
@@ -19909,6 +19983,7 @@ func (o *ProxyLBUpdateSettingsRequest) setDefaults() interface{} {
 		LetsEncrypt:   o.GetLetsEncrypt(),
 		StickySession: o.GetStickySession(),
 		Timeout:       o.GetTimeout(),
+		Gzip:          o.GetGzip(),
 		SettingsHash:  o.GetSettingsHash(),
 	}
 }
@@ -19991,6 +20066,16 @@ func (o *ProxyLBUpdateSettingsRequest) GetTimeout() *ProxyLBTimeout {
 // SetTimeout sets value to Timeout
 func (o *ProxyLBUpdateSettingsRequest) SetTimeout(v *ProxyLBTimeout) {
 	o.Timeout = v
+}
+
+// GetGzip returns value of Gzip
+func (o *ProxyLBUpdateSettingsRequest) GetGzip() *ProxyLBGzip {
+	return o.Gzip
+}
+
+// SetGzip sets value to Gzip
+func (o *ProxyLBUpdateSettingsRequest) SetGzip(v *ProxyLBGzip) {
+	o.Gzip = v
 }
 
 // GetSettingsHash returns value of SettingsHash


### PR DESCRIPTION
closes #736 gzip圧縮への対応 

### APIに追加されたパラメータ
```js
{
  "CommonServiceItem": {
    "Settings": {
      "ProxyLB": {
        "Gzip": {
          "Enabled": true
        }
    }
}
```

無効にするときは`Enabled:false`を指定する