### PR TITLE
ELB: SubjectAltNames

### DIFF
--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -1426,6 +1426,10 @@ func (f *fieldsDef) ProxyLBLetsEncrypt() *dsl.FieldDesc {
 					Name: "Enabled",
 					Type: meta.TypeFlag,
 				},
+				{
+					Name: "SubjectAltNames",
+					Type: meta.TypeStringSlice,
+				},
 			},
 		},
 		Tags: &dsl.FieldTags{

--- a/v2/internal/define/proxylb.go
+++ b/v2/internal/define/proxylb.go
@@ -303,6 +303,7 @@ var (
 						fields.Def("PrivateKey", meta.TypeString),
 						fields.Def("CertificateEndDate", meta.TypeTime),
 						fields.Def("CertificateCommonName", meta.TypeString),
+						fields.Def("CertificateAltNames", meta.TypeString),
 					},
 				},
 			},
@@ -317,6 +318,7 @@ var (
 						fields.Def("PrivateKey", meta.TypeString),
 						fields.Def("CertificateEndDate", meta.TypeTime),
 						fields.Def("CertificateCommonName", meta.TypeString),
+						fields.Def("CertificateAltNames", meta.TypeString),
 					},
 				},
 				Tags: &dsl.FieldTags{

--- a/v2/sacloud/naked/proxylb_test.go
+++ b/v2/sacloud/naked/proxylb_test.go
@@ -16,6 +16,7 @@ package naked
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -61,5 +62,97 @@ func TestProxyLBCertificates_UnmarshalJSON(t *testing.T) {
 		if string(data) != tc.expect {
 			t.Fatalf("got unexpected JSON: expected: %s got: %s", tc.expect, data)
 		}
+	}
+}
+
+func TestProxyLBACMESetting_UnmarshalJSON(t *testing.T) {
+	type fields struct {
+		Enabled         bool
+		CommonName      string
+		SubjectAltNames []string
+	}
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "unmarshal",
+			fields: fields{
+				Enabled:         true,
+				CommonName:      "example.com",
+				SubjectAltNames: []string{"test1.example.com", "test2.example.com", "test3.example.com", "test4.example.com"},
+			},
+			args: args{
+				data: []byte(`{"Enabled":true,"CommonName":"example.com","SubjectAltNames":"test1.example.com\ntest2.example.com,test3.example.com test4.example.com"}`),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &ProxyLBACMESetting{
+				Enabled:         tt.fields.Enabled,
+				CommonName:      tt.fields.CommonName,
+				SubjectAltNames: tt.fields.SubjectAltNames,
+			}
+			if err := p.UnmarshalJSON(tt.args.data); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			expect := &ProxyLBACMESetting{
+				Enabled:         tt.fields.Enabled,
+				CommonName:      tt.fields.CommonName,
+				SubjectAltNames: tt.fields.SubjectAltNames,
+			}
+			if !reflect.DeepEqual(p, expect) {
+				t.Errorf("MarshalJSON() got = %v, want %v", p, expect)
+			}
+		})
+	}
+}
+
+func TestProxyLBACMESetting_MarshalJSON(t *testing.T) {
+	type fields struct {
+		Enabled         bool
+		CommonName      string
+		SubjectAltNames []string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name: "marshal",
+			fields: fields{
+				Enabled:         true,
+				CommonName:      "example.com",
+				SubjectAltNames: []string{"test1.example.com", "test2.example.com", "test3.example.com", "test4.example.com"},
+			},
+			want:    []byte(`{"Enabled":true,"CommonName":"example.com","SubjectAltNames":"test1.example.com,test2.example.com,test3.example.com,test4.example.com"}`),
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := ProxyLBACMESetting{
+				Enabled:         tt.fields.Enabled,
+				CommonName:      tt.fields.CommonName,
+				SubjectAltNames: tt.fields.SubjectAltNames,
+			}
+			got, err := p.MarshalJSON()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("MarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("MarshalJSON() got = %v, want %v", string(got), string(tt.want))
+			}
+		})
 	}
 }

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -19311,8 +19311,9 @@ func (o *ProxyLBRule) SetServerGroup(v string) {
 
 // ProxyLBACMESetting represents API parameter/response structure
 type ProxyLBACMESetting struct {
-	CommonName string
-	Enabled    bool
+	CommonName      string
+	Enabled         bool
+	SubjectAltNames []string
 }
 
 // Validate validates by field tags
@@ -19323,11 +19324,13 @@ func (o *ProxyLBACMESetting) Validate() error {
 // setDefaults implements sacloud.argumentDefaulter
 func (o *ProxyLBACMESetting) setDefaults() interface{} {
 	return &struct {
-		CommonName string
-		Enabled    bool
+		CommonName      string
+		Enabled         bool
+		SubjectAltNames []string
 	}{
-		CommonName: o.GetCommonName(),
-		Enabled:    o.GetEnabled(),
+		CommonName:      o.GetCommonName(),
+		Enabled:         o.GetEnabled(),
+		SubjectAltNames: o.GetSubjectAltNames(),
 	}
 }
 
@@ -19349,6 +19352,16 @@ func (o *ProxyLBACMESetting) GetEnabled() bool {
 // SetEnabled sets value to Enabled
 func (o *ProxyLBACMESetting) SetEnabled(v bool) {
 	o.Enabled = v
+}
+
+// GetSubjectAltNames returns value of SubjectAltNames
+func (o *ProxyLBACMESetting) GetSubjectAltNames() []string {
+	return o.SubjectAltNames
+}
+
+// SetSubjectAltNames sets value to SubjectAltNames
+func (o *ProxyLBACMESetting) SetSubjectAltNames(v []string) {
+	o.SubjectAltNames = v
 }
 
 /*************************************************
@@ -20178,6 +20191,7 @@ type ProxyLBPrimaryCert struct {
 	PrivateKey              string
 	CertificateEndDate      time.Time
 	CertificateCommonName   string
+	CertificateAltNames     string
 }
 
 // Validate validates by field tags
@@ -20193,12 +20207,14 @@ func (o *ProxyLBPrimaryCert) setDefaults() interface{} {
 		PrivateKey              string
 		CertificateEndDate      time.Time
 		CertificateCommonName   string
+		CertificateAltNames     string
 	}{
 		ServerCertificate:       o.GetServerCertificate(),
 		IntermediateCertificate: o.GetIntermediateCertificate(),
 		PrivateKey:              o.GetPrivateKey(),
 		CertificateEndDate:      o.GetCertificateEndDate(),
 		CertificateCommonName:   o.GetCertificateCommonName(),
+		CertificateAltNames:     o.GetCertificateAltNames(),
 	}
 }
 
@@ -20252,6 +20268,16 @@ func (o *ProxyLBPrimaryCert) SetCertificateCommonName(v string) {
 	o.CertificateCommonName = v
 }
 
+// GetCertificateAltNames returns value of CertificateAltNames
+func (o *ProxyLBPrimaryCert) GetCertificateAltNames() string {
+	return o.CertificateAltNames
+}
+
+// SetCertificateAltNames sets value to CertificateAltNames
+func (o *ProxyLBPrimaryCert) SetCertificateAltNames(v string) {
+	o.CertificateAltNames = v
+}
+
 /*************************************************
 * ProxyLBAdditionalCert
 *************************************************/
@@ -20263,6 +20289,7 @@ type ProxyLBAdditionalCert struct {
 	PrivateKey              string
 	CertificateEndDate      time.Time
 	CertificateCommonName   string
+	CertificateAltNames     string
 }
 
 // Validate validates by field tags
@@ -20278,12 +20305,14 @@ func (o *ProxyLBAdditionalCert) setDefaults() interface{} {
 		PrivateKey              string
 		CertificateEndDate      time.Time
 		CertificateCommonName   string
+		CertificateAltNames     string
 	}{
 		ServerCertificate:       o.GetServerCertificate(),
 		IntermediateCertificate: o.GetIntermediateCertificate(),
 		PrivateKey:              o.GetPrivateKey(),
 		CertificateEndDate:      o.GetCertificateEndDate(),
 		CertificateCommonName:   o.GetCertificateCommonName(),
+		CertificateAltNames:     o.GetCertificateAltNames(),
 	}
 }
 
@@ -20335,6 +20364,16 @@ func (o *ProxyLBAdditionalCert) GetCertificateCommonName() string {
 // SetCertificateCommonName sets value to CertificateCommonName
 func (o *ProxyLBAdditionalCert) SetCertificateCommonName(v string) {
 	o.CertificateCommonName = v
+}
+
+// GetCertificateAltNames returns value of CertificateAltNames
+func (o *ProxyLBAdditionalCert) GetCertificateAltNames() string {
+	return o.CertificateAltNames
+}
+
+// SetCertificateAltNames sets value to CertificateAltNames
+func (o *ProxyLBAdditionalCert) SetCertificateAltNames(v string) {
+	o.CertificateAltNames = v
 }
 
 /*************************************************


### PR DESCRIPTION
closes #740 

SAN(`SubjectAltNames`)を追加する。

## API仕様

```js
{
  "CommonServiceItem": {
    "Settings": {
      "ProxyLB": {
        "LetsEncrypt": {
          "Enabled": true,
          "CommonName": "example.com",
          "SubjectAltNames": "www1.example.com\nwww2.example.com"
        }
      }
    }
  }
}
```

Note: 
  - `SubjectAltNames`は配列ではなく文字列で指定
  - スペース/カンマ/改行(\n)区切りで指定する
  - 区切り文字は混在可能

混在の例:   
```
        "LetsEncrypt": {
          "Enabled": true,
          "CommonName": "test1.example.com",
          "SubjectAltNames": "test2.example.com\ntest3.example.com,test4.example.com test5.example.com"
        }
```

## 実装

libsacloud上ではSubjectAltNamesを[]stringで表現した。  

```go
// ProxyLBACMESetting represents API parameter/response structure
type ProxyLBACMESetting struct {
	CommonName      string
	Enabled         bool
	SubjectAltNames []string
}
```

JSONのMarshal/Unmarshal時に文字列とスライスの相互変換が行われる。
スライス->文字列への変換時はカンマ区切りに固定となる。  
この変換はnakedパッケージレベルで実装されている。

この実装の影響で、GETで取得したデータを用いてPUTする際に同等だが表現が異なってしまうことがあるが実用上は大きな問題はないと思われる。

