### PR TITLE
helper/power: retry when received 409+still_creating error

### DIFF
--- a/v2/helper/api/caller.go
+++ b/v2/helper/api/caller.go
@@ -133,17 +133,7 @@ func newCaller(opts *CallerOptions) sacloud.APICaller {
 		// note: exact once
 		fake.SwitchFactoryFuncToFake()
 
-		defaultInterval := 10 * time.Millisecond
-
-		// update default polling intervals: libsacloud/sacloud
-		sacloud.DefaultStatePollingInterval = defaultInterval
-		sacloud.DefaultDBStatusPollingInterval = defaultInterval
-		// update default polling intervals: libsacloud/utils/setup
-		defaults.DefaultDeleteWaitInterval = defaultInterval
-		defaults.DefaultProvisioningWaitInterval = defaultInterval
-		defaults.DefaultPollingInterval = defaultInterval
-		// update default polling intervals: libsacloud/utils/builder
-		defaults.DefaultNICUpdateWaitDuration = defaultInterval
+		SetupFakeDefaults()
 	}
 
 	if opts.DefaultZone != "" {
@@ -157,4 +147,23 @@ func newCaller(opts *CallerOptions) sacloud.APICaller {
 		sacloud.SakuraCloudAPIRoot = opts.APIRootURL
 	}
 	return caller
+}
+
+func SetupFakeDefaults() {
+	defaultInterval := 10 * time.Millisecond
+
+	// update default polling intervals: libsacloud/sacloud
+	sacloud.DefaultStatePollingInterval = defaultInterval
+	sacloud.DefaultDBStatusPollingInterval = defaultInterval
+	// update default polling intervals: libsacloud/helper/setup
+	defaults.DefaultDeleteWaitInterval = defaultInterval
+	defaults.DefaultProvisioningWaitInterval = defaultInterval
+	defaults.DefaultPollingInterval = defaultInterval
+	// update default polling intervals: libsacloud/helper/builder
+	defaults.DefaultNICUpdateWaitDuration = defaultInterval
+	// update default timeouts and span: libsacloud/helper/power
+	defaults.DefaultPowerHelperBootRetrySpan = defaultInterval
+	defaults.DefaultPowerHelperShutdownRetrySpan = defaultInterval
+	defaults.DefaultPowerHelperInitialRequestRetrySpan = defaultInterval
+	defaults.DefaultPowerHelperInitialRequestTimeout = defaultInterval * 10
 }

--- a/v2/helper/api/caller.go
+++ b/v2/helper/api/caller.go
@@ -165,5 +165,5 @@ func SetupFakeDefaults() {
 	defaults.DefaultPowerHelperBootRetrySpan = defaultInterval
 	defaults.DefaultPowerHelperShutdownRetrySpan = defaultInterval
 	defaults.DefaultPowerHelperInitialRequestRetrySpan = defaultInterval
-	defaults.DefaultPowerHelperInitialRequestTimeout = defaultInterval * 10
+	defaults.DefaultPowerHelperInitialRequestTimeout = defaultInterval * 100
 }

--- a/v2/helper/builder/server/builder_test.go
+++ b/v2/helper/builder/server/builder_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sacloud/libsacloud/v2/helper/api"
 	"github.com/sacloud/libsacloud/v2/helper/builder"
 	"github.com/sacloud/libsacloud/v2/helper/builder/disk"
 	"github.com/sacloud/libsacloud/v2/helper/power"
@@ -28,10 +29,15 @@ import (
 	"github.com/sacloud/libsacloud/v2/sacloud/ostype"
 	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
-	"golang.org/x/crypto/ssh"
-
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/ssh"
 )
+
+func init() {
+	if !testutil.IsAccTest() {
+		api.SetupFakeDefaults()
+	}
+}
 
 func TestBuilder_setDefaults(t *testing.T) {
 	in := &Builder{}

--- a/v2/helper/defaults/defaults.go
+++ b/v2/helper/defaults/defaults.go
@@ -34,6 +34,15 @@ var (
 
 	// DefaultPollingInterval ポーリング処理の間隔
 	DefaultPollingInterval = 5 * time.Second
+
+	// DefaultPowerHelperBootRetrySpan helper/powerでの起動リクエストリトライ間隔
+	DefaultPowerHelperBootRetrySpan = 20 * time.Second
+	// DefaultPowerHelperShutdownRetrySpan helper/powerでのシャットダウンリクエストリトライ間隔
+	DefaultPowerHelperShutdownRetrySpan = 20 * time.Second
+	// DefaultPowerHelperInitialRequestTimeout helper/powerでの初回電源リクエスト成功までのタイムアウト
+	DefaultPowerHelperInitialRequestTimeout = 30 * time.Minute
+	// DefaultPowerHelperInitialRequestRetrySpan helper/powerでの初回リクエスト409+still_creating時のリトライ間隔
+	DefaultPowerHelperInitialRequestRetrySpan = 20 * time.Second
 )
 
 // for builder package

--- a/v2/helper/power/power.go
+++ b/v2/helper/power/power.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/sacloud/libsacloud/v2/helper/defaults"
@@ -189,7 +190,12 @@ type handler interface {
 	read() (interface{}, error)
 }
 
+var mu sync.Mutex
+
 func initDefaults() {
+	mu.Lock()
+	defer mu.Unlock()
+
 	if BootRetrySpan == 0 {
 		BootRetrySpan = defaults.DefaultPowerHelperBootRetrySpan
 	}

--- a/v2/helper/power/power_test.go
+++ b/v2/helper/power/power_test.go
@@ -36,8 +36,8 @@ func TestPowerHandler(t *testing.T) {
 	ShutdownRetrySpan = time.Millisecond
 	defer func() {
 		sacloud.DefaultStatePollingInterval = defaultInterval
-		BootRetrySpan = DefaultBootRetrySpan
-		ShutdownRetrySpan = DefaultShutdownRetrySpan
+		BootRetrySpan = 0
+		ShutdownRetrySpan = 0
 	}()
 
 	ctx := context.Background()
@@ -120,7 +120,6 @@ func (d *dummyPowerHandler) SetInstanceStatus(v types.EServerInstanceStatus) {
 }
 
 func TestPower_powerRequestWithRetry(t *testing.T) {
-	// TODO 後でdefaultsに切り出す
 	InitialRequestRetrySpan = 1 * time.Millisecond
 	InitialRequestTimeout = 100 * time.Millisecond
 

--- a/v2/sacloud/error.go
+++ b/v2/sacloud/error.go
@@ -44,7 +44,20 @@ func IsNoResultsError(err error) bool {
 	return ok
 }
 
-// NoResultError APIが返した応答に処理すべきデータが含まれていない場合を示すエラー型
+// IsStillCreatingError 指定のerrorがAPI呼び出し時の409エラー、かつエラーコードがstill_creatingであるか判定
+func IsStillCreatingError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if apiError, ok := err.(APIError); ok {
+		return apiError.ResponseCode() == http.StatusConflict && apiError.Code() == "still_creating"
+	}
+
+	return false
+}
+
+// NoResultsError APIが返した応答に処理すべきデータが含まれていない場合を示すエラー型
 type NoResultsError struct {
 	error
 }


### PR DESCRIPTION
closes #742 

`helper/power`で起動/シャットダウン待ちを行う際、初回の電源リクエストで409 + `still_creating`を受け取った場合にリトライする。  
デフォルトでは20秒間隔でリトライし30分でタイムアウトする。