### PR TITLE
Fake: shorten duration for background tasks

### DIFF
--- a/v2/helper/api/caller.go
+++ b/v2/helper/api/caller.go
@@ -166,4 +166,8 @@ func SetupFakeDefaults() {
 	defaults.DefaultPowerHelperShutdownRetrySpan = defaultInterval
 	defaults.DefaultPowerHelperInitialRequestRetrySpan = defaultInterval
 	defaults.DefaultPowerHelperInitialRequestTimeout = defaultInterval * 100
+
+	fake.PowerOnDuration = time.Millisecond
+	fake.PowerOffDuration = time.Millisecond
+	fake.DiskCopyDuration = time.Millisecond
 }

--- a/v2/sacloud/fake/timer.go
+++ b/v2/sacloud/fake/timer.go
@@ -137,7 +137,7 @@ func startPowerOn(resourceKey, zone string, readFunc func() (interface{}, error)
 
 func startPowerOff(resourceKey, zone string, readFunc func() (interface{}, error)) {
 	counter := 0
-	ticker := time.NewTicker(PowerOnDuration)
+	ticker := time.NewTicker(PowerOffDuration)
 	go func() {
 		defer ticker.Stop()
 		for {


### PR DESCRIPTION
closes #750 

Fakeドライバーでのバックグラウンドタスク(電源操作/ディスクコピー)の処理間隔を短くすることでレースコンディション発生を低減する。

Note: 根本対応は別途行う。