### PR TITLE
SimpleMonitor: Added LatestLogs field to HealthStatus()

### DIFF
--- a/v2/internal/define/simple_monitor.go
+++ b/v2/internal/define/simple_monitor.go
@@ -207,6 +207,7 @@ var (
 			fields.Def("LastCheckedAt", meta.TypeTime),
 			fields.Def("LastHealthChangedAt", meta.TypeTime),
 			fields.Def("Health", meta.Static(types.ESimpleMonitorHealth(""))),
+			fields.Def("LatestLogs", meta.TypeStringSlice),
 		},
 	}
 )

--- a/v2/sacloud/naked/simple_monitor.go
+++ b/v2/sacloud/naked/simple_monitor.go
@@ -101,4 +101,5 @@ type SimpleMonitorHealthCheckStatus struct {
 	LastCheckedAt       *time.Time                 `json:",omitempty" yaml:"last_checked_at,omitempty" structs:",omitempty"`
 	LastHealthChangedAt *time.Time                 `json:",omitempty" yaml:"last_health_changed_at,omitempty" structs:",omitempty"`
 	Health              types.ESimpleMonitorHealth `json:",omitempty" yaml:"health,omitempty" structs:",omitempty"`
+	LatestLogs          []string                   `json:",omitempty" yaml:"latest_logs,omitempty" structs:",omitempty"`
 }

--- a/v2/sacloud/test/simple_monitor_op_test.go
+++ b/v2/sacloud/test/simple_monitor_op_test.go
@@ -286,6 +286,11 @@ func TestSimpleMonitorOp_StatusAndHealth(t *testing.T) {
 					if !assert.NotNil(t, healthStatus) {
 						return errors.New("unexpected state: SimpleMonitorHealthStatus")
 					}
+					if isAccTest() {
+						if !assert.NotEmpty(t, healthStatus.LatestLogs) {
+							return errors.New("unexpected state: SimpleMonitorHealthStatus.LatestLogs")
+						}
+					}
 					return nil
 				},
 			},

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -25493,6 +25493,7 @@ type SimpleMonitorHealthStatus struct {
 	LastCheckedAt       time.Time
 	LastHealthChangedAt time.Time
 	Health              types.ESimpleMonitorHealth
+	LatestLogs          []string
 }
 
 // Validate validates by field tags
@@ -25506,10 +25507,12 @@ func (o *SimpleMonitorHealthStatus) setDefaults() interface{} {
 		LastCheckedAt       time.Time
 		LastHealthChangedAt time.Time
 		Health              types.ESimpleMonitorHealth
+		LatestLogs          []string
 	}{
 		LastCheckedAt:       o.GetLastCheckedAt(),
 		LastHealthChangedAt: o.GetLastHealthChangedAt(),
 		Health:              o.GetHealth(),
+		LatestLogs:          o.GetLatestLogs(),
 	}
 }
 
@@ -25541,6 +25544,16 @@ func (o *SimpleMonitorHealthStatus) GetHealth() types.ESimpleMonitorHealth {
 // SetHealth sets value to Health
 func (o *SimpleMonitorHealthStatus) SetHealth(v types.ESimpleMonitorHealth) {
 	o.Health = v
+}
+
+// GetLatestLogs returns value of LatestLogs
+func (o *SimpleMonitorHealthStatus) GetLatestLogs() []string {
+	return o.LatestLogs
+}
+
+// SetLatestLogs sets value to LatestLogs
+func (o *SimpleMonitorHealthStatus) SetLatestLogs(v []string) {
+	o.LatestLogs = v
 }
 
 /*************************************************


### PR DESCRIPTION
closes #772 

シンプル監視の`HealthStatus()`に`LatestLogs`フィールドを追加

Note: `LatestLogs`はfakeモードでは非対応