### PR TITLE
Set default timeout/retry-count for api.NewCaller()

### DIFF
--- a/v2/helper/api/caller.go
+++ b/v2/helper/api/caller.go
@@ -72,8 +72,14 @@ func newCaller(opts *CallerOptions) sacloud.APICaller {
 	if opts.HTTPRequestTimeout > 0 {
 		httpClient.Timeout = time.Duration(opts.HTTPRequestTimeout) * time.Second
 	}
+	if opts.HTTPRequestTimeout == 0 {
+		httpClient.Timeout = 300 * time.Second // デフォルト値
+	}
 	if opts.HTTPRequestRateLimit > 0 {
 		httpClient.Transport = &sacloud.RateLimitRoundTripper{RateLimitPerSec: opts.HTTPRequestRateLimit}
+	}
+	if opts.HTTPRequestRateLimit == 0 {
+		httpClient.Transport = &sacloud.RateLimitRoundTripper{RateLimitPerSec: 10} // デフォルト値
 	}
 
 	retryMax := sacloud.APIDefaultRetryMax

--- a/v2/sacloud/client.go
+++ b/v2/sacloud/client.go
@@ -47,7 +47,7 @@ var (
 	// APIDefaultAcceptLanguage デフォルトのAcceptLanguage
 	APIDefaultAcceptLanguage = ""
 	// APIDefaultRetryMax デフォルトのリトライ回数
-	APIDefaultRetryMax = 0
+	APIDefaultRetryMax = 10
 	// APIDefaultRetryWaitMin デフォルトのリトライ間隔(最小)
 	APIDefaultRetryWaitMin = 1 * time.Second
 	// APIDefaultRetryWaitMax デフォルトのリトライ間隔(最大)


### PR DESCRIPTION
closes #760 

api.NewCaller()でデフォルトのタイムアウト/レートリミット/リトライ回数を設定する。

- HTTPタイムアウト: 300秒
- レートリミット: 秒あたり10
- リトライ回数: 10回

api.NewCaller()ではこれらを明示的に0にすることができなくなるが、その場合は`sacloud.Client`を直接利用すれば設定可能。
api.NewCaller()の利用目的はAPIクライアント作成時のパラメータ設定の汎用化なので0にできないことは問題ないと思われる。(0にするのが特殊なケースなはず)