### PR TITLE
Added helper/plans package to track IDs when changing plans

### DIFF
--- a/v2/helper/plans/change_plan.go
+++ b/v2/helper/plans/change_plan.go
@@ -1,0 +1,172 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plans
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sacloud/libsacloud/v2/pkg/size"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+var (
+	PreviousIDTagName = "@previous-id"
+	maxTags           = 10 // タグ上限数
+)
+
+// ChangeServerPlan 現在のIDをタグとして保持しつつプランを変更する
+//
+// もしすでにタグが上限(10)まで付与されている場合はプラン変更だけ行う
+func ChangeServerPlan(
+	ctx context.Context,
+	caller sacloud.APICaller,
+	zone string,
+	id types.ID,
+	cpu int,
+	memoryGB int,
+	commitment types.ECommitment,
+	generation types.EPlanGeneration,
+) (*sacloud.Server, error) {
+	serverOp := sacloud.NewServerOp(caller)
+	server, err := serverOp.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(server.Tags) < maxTags {
+		server.Tags = AppendPreviousIDTagIfAbsent(server.Tags, server.ID)
+
+		updated, err := serverOp.Update(ctx, zone, server.ID, &sacloud.ServerUpdateRequest{
+			Name:            server.Name,
+			Description:     server.Description,
+			Tags:            server.Tags,
+			IconID:          server.IconID,
+			PrivateHostID:   server.PrivateHostID,
+			InterfaceDriver: server.InterfaceDriver,
+		})
+		if err != nil {
+			return nil, err
+		}
+		server = updated
+	}
+
+	return serverOp.ChangePlan(ctx, zone, server.ID, &sacloud.ServerChangePlanRequest{
+		CPU:                  cpu,
+		MemoryMB:             memoryGB * size.GiB,
+		ServerPlanGeneration: generation,
+		ServerPlanCommitment: commitment,
+	})
+}
+
+// ChangeRouterPlan 現在のIDをタグとして保持しつつプランを変更する
+//
+// もしすでにタグが上限(10)まで付与されている場合はプラン変更だけ行う
+func ChangeRouterPlan(
+	ctx context.Context,
+	caller sacloud.APICaller,
+	zone string,
+	id types.ID,
+	bandWidth int,
+) (*sacloud.Internet, error) {
+	internetOp := sacloud.NewInternetOp(caller)
+	router, err := internetOp.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(router.Tags) < maxTags {
+		router.Tags = AppendPreviousIDTagIfAbsent(router.Tags, router.ID)
+
+		updated, err := internetOp.Update(ctx, zone, router.ID, &sacloud.InternetUpdateRequest{
+			Name:        router.Name,
+			Description: router.Description,
+			Tags:        router.Tags,
+			IconID:      router.IconID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		router = updated
+	}
+
+	return internetOp.UpdateBandWidth(ctx, zone, router.ID, &sacloud.InternetUpdateBandWidthRequest{
+		BandWidthMbps: bandWidth,
+	})
+}
+
+// ChangeProxyLBPlan 現在のIDをタグとして保持しつつプランを変更する
+//
+// もしすでにタグが上限(10)まで付与されている場合はプラン変更だけ行う
+func ChangeProxyLBPlan(
+	ctx context.Context,
+	caller sacloud.APICaller,
+	id types.ID,
+	cps int,
+) (*sacloud.ProxyLB, error) {
+	elbOp := sacloud.NewProxyLBOp(caller)
+	elb, err := elbOp.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(elb.Tags) < maxTags {
+		elb.Tags = AppendPreviousIDTagIfAbsent(elb.Tags, elb.ID)
+
+		updated, err := elbOp.Update(ctx, elb.ID, &sacloud.ProxyLBUpdateRequest{
+			HealthCheck:   elb.HealthCheck,
+			SorryServer:   elb.SorryServer,
+			BindPorts:     elb.BindPorts,
+			Servers:       elb.Servers,
+			Rules:         elb.Rules,
+			LetsEncrypt:   elb.LetsEncrypt,
+			StickySession: elb.StickySession,
+			Timeout:       elb.Timeout,
+			Gzip:          elb.Gzip,
+			Syslog:        elb.Syslog,
+			SettingsHash:  elb.SettingsHash,
+			Name:          elb.Name,
+			Description:   elb.Description,
+			Tags:          elb.Tags,
+			IconID:        elb.IconID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		elb = updated
+	}
+
+	return elbOp.ChangePlan(ctx, elb.ID, &sacloud.ProxyLBChangePlanRequest{
+		ServiceClass: types.ProxyLBServiceClass(types.EProxyLBPlan(cps), elb.Region),
+	})
+}
+
+func AppendPreviousIDTagIfAbsent(tags types.Tags, currentID types.ID) types.Tags {
+	if len(tags) > maxTags {
+		return tags
+	}
+	// すでに付けられたPreviousIDタグを消す
+	updated := types.Tags{}
+	for _, t := range tags {
+		if !strings.HasPrefix(t, PreviousIDTagName) {
+			updated = append(updated, t)
+		}
+	}
+	updated = append(updated, fmt.Sprintf("%s=%s", PreviousIDTagName, currentID))
+	updated.Sort()
+	return updated
+}

--- a/v2/helper/service/proxylb/update_service.go
+++ b/v2/helper/service/proxylb/update_service.go
@@ -18,9 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/sacloud/libsacloud/v2/helper/plans"
 	"github.com/sacloud/libsacloud/v2/pkg/util"
-	"github.com/sacloud/libsacloud/v2/sacloud/types"
-
 	"github.com/sacloud/libsacloud/v2/sacloud"
 )
 
@@ -50,9 +49,7 @@ func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*s
 	}
 
 	if !util.IsEmpty(req.Plan) && updated.Plan != *req.Plan {
-		return client.ChangePlan(ctx, req.ID, &sacloud.ProxyLBChangePlanRequest{
-			ServiceClass: types.ProxyLBServiceClass(*req.Plan, updated.Region),
-		})
+		return plans.ChangeProxyLBPlan(ctx, s.caller, updated.ID, req.Plan.Int())
 	}
 
 	return updated, err

--- a/v2/helper/service/server/change_plan_service.go
+++ b/v2/helper/service/server/change_plan_service.go
@@ -18,9 +18,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sacloud/libsacloud/v2/sacloud/types"
-
+	"github.com/sacloud/libsacloud/v2/helper/plans"
 	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
 func (s *Service) ChangePlan(req *ChangePlanRequest) (*sacloud.Server, error) {
@@ -60,5 +60,7 @@ func (s *Service) ChangePlanWithContext(ctx context.Context, req *ChangePlanRequ
 		changeReq.ServerPlanCommitment = req.ServerPlanCommitment
 	}
 
-	return client.ChangePlan(ctx, req.Zone, req.ID, changeReq)
+	return plans.ChangeServerPlan(ctx, s.caller, req.Zone, req.ID,
+		changeReq.CPU, changeReq.GetMemoryGB(),
+		changeReq.ServerPlanCommitment, changeReq.ServerPlanGeneration)
 }


### PR DESCRIPTION
closes #778 

プラン変更時にIDが変更されるサーバ/エンハンスドロードバランサ/ルータについて、プラン変更前のIDをトラッキングするためのパッケージ`helper/plans`を追加

- プラン変更時に`@previous-id=xxx`というタグを付与する
- タグがすでに上限(10個)付与されている場合はプラン変更だけ行う
- 既存のbuilderやserviceでも対応

Note: builderにおいてはパラメータ指定したタグと結果が異なる(`@previous-id`の分)ことがあるが、そのハンドリングはクライアント側の責務とする。
また、従来通り`@previous-id`を付与したくない場合はsacloud.xxxAPIを直接利用するようにする。