### PR TITLE
Set default value to Syslog.Port

### DIFF
--- a/v2/helper/query/previous_id_test.go
+++ b/v2/helper/query/previous_id_test.go
@@ -16,7 +16,6 @@ package query
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	internetBuilder "github.com/sacloud/libsacloud/v2/helper/builder/internet"
@@ -119,8 +118,6 @@ func TestReadRouter(t *testing.T) {
 }
 
 func TestReadProxyLB(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_PROXYLB_SERVER0")(t)
-
 	ctx := context.Background()
 	caller := testutil.SingletonAPICaller()
 
@@ -135,10 +132,6 @@ func TestReadProxyLB(t *testing.T) {
 		},
 		Timeout: &sacloud.ProxyLBTimeout{
 			InactiveSec: 10,
-		},
-		Syslog: &sacloud.ProxyLBSyslog{
-			Server: os.Getenv("SAKURACLOUD_PROXYLB_SERVER0"),
-			Port:   514,
 		},
 	})
 	if err != nil {

--- a/v2/internal/define/fields.go
+++ b/v2/internal/define/fields.go
@@ -1559,8 +1559,9 @@ func (f *fieldsDef) ProxyLBSyslog() *dsl.FieldDesc {
 					Type: meta.TypeString,
 				},
 				{
-					Name: "Port",
-					Type: meta.TypeInt,
+					Name:         "Port",
+					Type:         meta.TypeInt,
+					DefaultValue: `514`,
 				},
 			},
 		},

--- a/v2/sacloud/naked/proxylb.go
+++ b/v2/sacloud/naked/proxylb.go
@@ -108,6 +108,10 @@ func (s ProxyLBSetting) MarshalJSON() ([]byte, error) {
 	if s.Rules == nil {
 		s.Rules = make([]ProxyLBRule, 0)
 	}
+	// syslogは値がないと400エラーになるため両方空の場合はポートのデフォルト値だけ設定しておく
+	if s.Syslog.Server == "" && s.Syslog.Port == 0 {
+		s.Syslog.Port = 514
+	}
 
 	type alias ProxyLBSetting
 	tmp := alias(s)

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -20093,6 +20093,9 @@ func (o *ProxyLBSyslog) SetServer(v string) {
 
 // GetPort returns value of Port
 func (o *ProxyLBSyslog) GetPort() int {
+	if o.Port == 0 {
+		return 514
+	}
 	return o.Port
 }
 


### PR DESCRIPTION
closes #781 

ELB作成時にSyslogサーバ設定が空の場合400エラーが発生する。
エラーを回避するためにSyslog.ServerとSyslog.Portがゼロ値だった場合にはポートにデフォルト値(514)を設定する。