### PR TITLE
cloud-init

### DIFF
--- a/v2/helper/builder/server/api_client.go
+++ b/v2/helper/builder/server/api_client.go
@@ -68,6 +68,7 @@ type CreateServerHandler interface {
 	InsertCDROM(ctx context.Context, zone string, id types.ID, insertParam *sacloud.InsertCDROMRequest) error
 	EjectCDROM(ctx context.Context, zone string, id types.ID, ejectParam *sacloud.EjectCDROMRequest) error
 	Boot(ctx context.Context, zone string, id types.ID) error
+	BootWithVariables(ctx context.Context, zone string, id types.ID, param *sacloud.ServerBootVariables) error
 	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error
 	ChangePlan(ctx context.Context, zone string, id types.ID, plan *sacloud.ServerChangePlanRequest) (*sacloud.Server, error)
 }

--- a/v2/helper/builder/server/api_client_test.go
+++ b/v2/helper/builder/server/api_client_test.go
@@ -133,6 +133,10 @@ func (d *dummyCreateServerHandler) Boot(ctx context.Context, zone string, id typ
 	return d.bootErr
 }
 
+func (d *dummyCreateServerHandler) BootWithVariables(ctx context.Context, zone string, id types.ID, param *sacloud.ServerBootVariables) error {
+	return d.bootErr
+}
+
 func (d *dummyCreateServerHandler) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
 	return d.shutdownErr
 }

--- a/v2/helper/power/handlers.go
+++ b/v2/helper/power/handlers.go
@@ -16,6 +16,7 @@ package power
 
 import (
 	"context"
+	"strings"
 
 	"github.com/sacloud/libsacloud/v2/sacloud"
 	"github.com/sacloud/libsacloud/v2/sacloud/types"
@@ -25,17 +26,23 @@ import (
 type ServerAPI interface {
 	Read(ctx context.Context, zone string, id types.ID) (*sacloud.Server, error)
 	Boot(ctx context.Context, zone string, id types.ID) error
+	BootWithVariables(ctx context.Context, zone string, id types.ID, param *sacloud.ServerBootVariables) error
 	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error
 }
 
 type serverHandler struct {
-	ctx    context.Context
-	client ServerAPI
-	zone   string
-	id     types.ID
+	ctx       context.Context
+	client    ServerAPI
+	zone      string
+	id        types.ID
+	variables []string
 }
 
 func (h *serverHandler) boot() error {
+	if len(h.variables) > 0 {
+		userData := strings.Join(h.variables, "\n")
+		return h.client.BootWithVariables(h.ctx, h.zone, h.id, &sacloud.ServerBootVariables{UserData: userData})
+	}
 	return h.client.Boot(h.ctx, h.zone, h.id)
 }
 

--- a/v2/helper/power/power.go
+++ b/v2/helper/power/power.go
@@ -45,12 +45,16 @@ var (
  ***********************************************/
 
 // BootServer 起動
-func BootServer(ctx context.Context, client ServerAPI, zone string, id types.ID) error {
+//
+// variablesが指定された場合、PUT /server/:id/powerのCloudInit用のパラメータとして渡される
+// variablesが複数指定された場合は改行で結合される
+func BootServer(ctx context.Context, client ServerAPI, zone string, id types.ID, variables ...string) error {
 	return boot(ctx, &serverHandler{
-		ctx:    ctx,
-		client: client,
-		zone:   zone,
-		id:     id,
+		ctx:       ctx,
+		client:    client,
+		zone:      zone,
+		id:        id,
+		variables: variables,
 	})
 }
 

--- a/v2/helper/service/server/boot_request.go
+++ b/v2/helper/service/server/boot_request.go
@@ -23,6 +23,8 @@ type BootRequest struct {
 	Zone string   `request:"-" validate:"required"`
 	ID   types.ID `request:"-" validate:"required"`
 
+	UserData string `request:"-"`
+
 	NoWait bool `request:"-"`
 }
 

--- a/v2/helper/service/server/boot_service.go
+++ b/v2/helper/service/server/boot_service.go
@@ -29,10 +29,18 @@ func (s *Service) BootWithContext(ctx context.Context, req *BootRequest) error {
 	if err := req.Validate(); err != nil {
 		return err
 	}
-
 	client := sacloud.NewServerOp(s.caller)
+
 	if req.NoWait {
+		if req.UserData != "" {
+			return client.BootWithVariables(ctx, req.Zone, req.ID, &sacloud.ServerBootVariables{UserData: req.UserData})
+		}
 		return client.Boot(ctx, req.Zone, req.ID)
 	}
-	return power.BootServer(ctx, client, req.Zone, req.ID)
+
+	var userData []string
+	if req.UserData != "" {
+		userData = []string{req.UserData}
+	}
+	return power.BootServer(ctx, client, req.Zone, req.ID, userData...)
 }

--- a/v2/internal/define/models.go
+++ b/v2/internal/define/models.go
@@ -508,6 +508,23 @@ func (m *modelsDef) vncProxyModel() *dsl.Model {
 	}
 }
 
+func (m *modelsDef) serverBootVariables() *dsl.Model {
+	return &dsl.Model{
+		Name:      "ServerBootVariables",
+		NakedType: meta.Static(naked.ServerBootParameter{}),
+		Fields: []*dsl.FieldDesc{
+			{
+				Name: "UserData",
+				Type: meta.TypeString,
+				Tags: &dsl.FieldTags{
+					MapConv: "CloudInit.UserData,omitempty",
+					JSON:    ",omitempty",
+				},
+			},
+		},
+	}
+}
+
 func (m *modelsDef) sourceArchiveInfo() *dsl.Model {
 	return &dsl.Model{
 		Name: "SourceArchiveInfo",

--- a/v2/internal/define/server.go
+++ b/v2/internal/define/server.go
@@ -154,6 +154,25 @@ var serverAPI = &dsl.Resource{
 		ops.Shutdown(serverAPIName),
 		ops.Reset(serverAPIName),
 
+		// cloud-init(Bootにパラメータを追加したもの)
+		{
+			ResourceName: serverAPIName,
+			Name:         "BootWithVariables",
+			PathFormat:   dsl.IDAndSuffixPathFormat("power"),
+			Method:       http.MethodPut,
+			LockLevel:    dsl.LockLevelGlobal,
+			RequestEnvelope: dsl.RequestEnvelope(
+				&dsl.EnvelopePayloadDesc{
+					Type: meta.Static(naked.ServerBootVariables{}),
+					Name: "UserBootVariables",
+				},
+			),
+			Arguments: dsl.Arguments{
+				dsl.ArgumentID,
+				dsl.MappableArgument("param", models.serverBootVariables(), "UserBootVariables"),
+			},
+		},
+
 		// send key
 		{
 			ResourceName: serverAPIName,

--- a/v2/sacloud/fake/ops_server.go
+++ b/v2/sacloud/fake/ops_server.go
@@ -312,6 +312,11 @@ func (o *ServerOp) Boot(ctx context.Context, zone string, id types.ID) error {
 	return err
 }
 
+// BootWithVariables is fake implementation
+func (o *ServerOp) BootWithVariables(ctx context.Context, zone string, id types.ID, param *sacloud.ServerBootVariables) error {
+	return o.Boot(ctx, zone, id) // paramは非対応
+}
+
 // Shutdown is fake implementation
 func (o *ServerOp) Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *sacloud.ShutdownOption) error {
 	value, err := o.Read(ctx, zone, id)

--- a/v2/sacloud/naked/server.go
+++ b/v2/sacloud/naked/server.go
@@ -60,3 +60,20 @@ type MouseRequestButtons struct {
 type DeleteServerWithDiskParameter struct {
 	WithDisk []types.ID
 }
+
+// ServerBootParameter サーバ起動時に指定可能なパラメータ
+type ServerBootParameter struct {
+	UserBootVariables *ServerBootVariables
+}
+
+// ServerBootVariables サーバ起動時に指定可能なパラメータ、現時点ではcloud-initにのみ対応
+type ServerBootVariables struct {
+	CloudInit *CloudInitParameter
+}
+
+// CloudInitParameter cloud-initに渡すUserData
+//
+// Note: libsacloudレベルではUserData(cloud-config)は文字列として扱い中身までは関知しない
+type CloudInitParameter struct {
+	UserData string
+}

--- a/v2/sacloud/stub/zz_api_stubs.go
+++ b/v2/sacloud/stub/zz_api_stubs.go
@@ -4070,6 +4070,11 @@ type ServerResetStubResult struct {
 	Err error
 }
 
+// ServerBootWithVariablesStubResult is expected values of the BootWithVariables operation
+type ServerBootWithVariablesStubResult struct {
+	Err error
+}
+
 // ServerSendKeyStubResult is expected values of the SendKey operation
 type ServerSendKeyStubResult struct {
 	Err error
@@ -4100,23 +4105,24 @@ type ServerMonitorCPUStubResult struct {
 
 // ServerStub is for trace ServerOp operations
 type ServerStub struct {
-	FindStubResult            *ServerFindStubResult
-	CreateStubResult          *ServerCreateStubResult
-	ReadStubResult            *ServerReadStubResult
-	UpdateStubResult          *ServerUpdateStubResult
-	DeleteStubResult          *ServerDeleteStubResult
-	DeleteWithDisksStubResult *ServerDeleteWithDisksStubResult
-	ChangePlanStubResult      *ServerChangePlanStubResult
-	InsertCDROMStubResult     *ServerInsertCDROMStubResult
-	EjectCDROMStubResult      *ServerEjectCDROMStubResult
-	BootStubResult            *ServerBootStubResult
-	ShutdownStubResult        *ServerShutdownStubResult
-	ResetStubResult           *ServerResetStubResult
-	SendKeyStubResult         *ServerSendKeyStubResult
-	SendNMIStubResult         *ServerSendNMIStubResult
-	GetVNCProxyStubResult     *ServerGetVNCProxyStubResult
-	MonitorStubResult         *ServerMonitorStubResult
-	MonitorCPUStubResult      *ServerMonitorCPUStubResult
+	FindStubResult              *ServerFindStubResult
+	CreateStubResult            *ServerCreateStubResult
+	ReadStubResult              *ServerReadStubResult
+	UpdateStubResult            *ServerUpdateStubResult
+	DeleteStubResult            *ServerDeleteStubResult
+	DeleteWithDisksStubResult   *ServerDeleteWithDisksStubResult
+	ChangePlanStubResult        *ServerChangePlanStubResult
+	InsertCDROMStubResult       *ServerInsertCDROMStubResult
+	EjectCDROMStubResult        *ServerEjectCDROMStubResult
+	BootStubResult              *ServerBootStubResult
+	ShutdownStubResult          *ServerShutdownStubResult
+	ResetStubResult             *ServerResetStubResult
+	BootWithVariablesStubResult *ServerBootWithVariablesStubResult
+	SendKeyStubResult           *ServerSendKeyStubResult
+	SendNMIStubResult           *ServerSendNMIStubResult
+	GetVNCProxyStubResult       *ServerGetVNCProxyStubResult
+	MonitorStubResult           *ServerMonitorStubResult
+	MonitorCPUStubResult        *ServerMonitorCPUStubResult
 }
 
 // NewServerStub creates new ServerStub instance
@@ -4218,6 +4224,14 @@ func (s *ServerStub) Reset(ctx context.Context, zone string, id types.ID) error 
 		log.Fatal("ServerStub.ResetStubResult is not set")
 	}
 	return s.ResetStubResult.Err
+}
+
+// BootWithVariables is API call with trace log
+func (s *ServerStub) BootWithVariables(ctx context.Context, zone string, id types.ID, param *sacloud.ServerBootVariables) error {
+	if s.BootWithVariablesStubResult == nil {
+		log.Fatal("ServerStub.BootWithVariablesStubResult is not set")
+	}
+	return s.BootWithVariablesStubResult.Err
 }
 
 // SendKey is API call with trace log

--- a/v2/sacloud/trace/zz_api_tracer.go
+++ b/v2/sacloud/trace/zz_api_tracer.go
@@ -8936,6 +8936,39 @@ func (t *ServerTracer) Reset(ctx context.Context, zone string, id types.ID) erro
 	return err
 }
 
+// BootWithVariables is API call with trace log
+func (t *ServerTracer) BootWithVariables(ctx context.Context, zone string, id types.ID, param *sacloud.ServerBootVariables) error {
+	log.Println("[TRACE] ServerAPI.BootWithVariables start")
+	targetArguments := struct {
+		Argzone  string
+		Argid    types.ID                     `json:"id"`
+		Argparam *sacloud.ServerBootVariables `json:"param"`
+	}{
+		Argzone:  zone,
+		Argid:    id,
+		Argparam: param,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] ServerAPI.BootWithVariables end")
+	}()
+
+	err := t.Internal.BootWithVariables(ctx, zone, id, param)
+	targetResults := struct {
+		Error error
+	}{
+		Error: err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return err
+}
+
 // SendKey is API call with trace log
 func (t *ServerTracer) SendKey(ctx context.Context, zone string, id types.ID, keyboardParam *sacloud.SendKeyRequest) error {
 	log.Println("[TRACE] ServerAPI.SendKey start")

--- a/v2/sacloud/zz_api_ops.go
+++ b/v2/sacloud/zz_api_ops.go
@@ -9780,6 +9780,47 @@ func (o *ServerOp) Reset(ctx context.Context, zone string, id types.ID) error {
 	return nil
 }
 
+// BootWithVariables is API call
+func (o *ServerOp) BootWithVariables(ctx context.Context, zone string, id types.ID, param *ServerBootVariables) error {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"param":      param,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/power", pathBuildParameter)
+	if err != nil {
+		return err
+	}
+	lockKey, err := buildURL("GlobalLock", pathBuildParameter)
+	if err != nil {
+		return err
+	}
+	apiLocker.Lock(lockKey)
+	defer apiLocker.Unlock(lockKey)
+	// build request body
+	var body interface{}
+	v, err := o.transformBootWithVariablesArgs(id, param)
+	if err != nil {
+		return err
+	}
+	body = v
+
+	// do request
+	_, err = o.Client.Do(ctx, "PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	// build results
+
+	return nil
+}
+
 // SendKey is API call
 func (o *ServerOp) SendKey(ctx context.Context, zone string, id types.ID, keyboardParam *SendKeyRequest) error {
 	// build request URL

--- a/v2/sacloud/zz_api_transformers.go
+++ b/v2/sacloud/zz_api_transformers.go
@@ -6066,6 +6066,36 @@ func (o *ServerOp) transformShutdownArgs(id types.ID, shutdownOption *ShutdownOp
 	return v, nil
 }
 
+func (o *ServerOp) transformBootWithVariablesArgs(id types.ID, param *ServerBootVariables) (*serverBootWithVariablesRequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if param == nil {
+		param = &ServerBootVariables{}
+	}
+	var arg1 interface{} = param
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:"UserBootVariables,recursive"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &serverBootWithVariablesRequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
 func (o *ServerOp) transformSendKeyArgs(id types.ID, keyboardParam *SendKeyRequest) (*serverSendKeyRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))

--- a/v2/sacloud/zz_apis.go
+++ b/v2/sacloud/zz_apis.go
@@ -552,6 +552,7 @@ type ServerAPI interface {
 	Boot(ctx context.Context, zone string, id types.ID) error
 	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *ShutdownOption) error
 	Reset(ctx context.Context, zone string, id types.ID) error
+	BootWithVariables(ctx context.Context, zone string, id types.ID, param *ServerBootVariables) error
 	SendKey(ctx context.Context, zone string, id types.ID, keyboardParam *SendKeyRequest) error
 	SendNMI(ctx context.Context, zone string, id types.ID) error
 	GetVNCProxy(ctx context.Context, zone string, id types.ID) (*VNCProxyInfo, error)

--- a/v2/sacloud/zz_envelopes.go
+++ b/v2/sacloud/zz_envelopes.go
@@ -2374,6 +2374,11 @@ type serverShutdownRequestEnvelope struct {
 	Force bool `json:",omitempty"`
 }
 
+// serverBootWithVariablesRequestEnvelope is envelop of API request
+type serverBootWithVariablesRequestEnvelope struct {
+	UserBootVariables *naked.ServerBootVariables `json:",omitempty"`
+}
+
 // serverSendKeyRequestEnvelope is envelop of API request
 type serverSendKeyRequestEnvelope struct {
 	Key  string   `json:",omitempty"`

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -22808,6 +22808,39 @@ func (o *EjectCDROMRequest) GetInt64ID() int64 {
 }
 
 /*************************************************
+* ServerBootVariables
+*************************************************/
+
+// ServerBootVariables represents API parameter/response structure
+type ServerBootVariables struct {
+	UserData string `json:",omitempty" mapconv:"CloudInit.UserData,omitempty"`
+}
+
+// Validate validates by field tags
+func (o *ServerBootVariables) Validate() error {
+	return validate.Struct(o)
+}
+
+// setDefaults implements sacloud.argumentDefaulter
+func (o *ServerBootVariables) setDefaults() interface{} {
+	return &struct {
+		UserData string `json:",omitempty" mapconv:"CloudInit.UserData,omitempty"`
+	}{
+		UserData: o.GetUserData(),
+	}
+}
+
+// GetUserData returns value of UserData
+func (o *ServerBootVariables) GetUserData() string {
+	return o.UserData
+}
+
+// SetUserData sets value to UserData
+func (o *ServerBootVariables) SetUserData(v string) {
+	o.UserData = v
+}
+
+/*************************************************
 * SendKeyRequest
 *************************************************/
 


### PR DESCRIPTION
サーバの電源操作時にUserDataを指定可能にする。

```go
type ServerAPI interface {
	Boot(ctx context.Context, zone string, id types.ID) error
	// 以下を追加
	BootWithVariables(ctx context.Context, zone string, id types.ID, param *ServerBootVariables) error
}

// ServerBootVariables represents API parameter/response structure
type ServerBootVariables struct {
	UserData string `json:",omitempty" mapconv:"CloudInit.UserData,omitempty"`
}
```

また、helperにも同様のパラメータを追加する。

- builder
- service

Note: `Boot`と`BootWithVariables`は実質的には同じAPI(同じエンドポイント/同じパラメータ)を持つが、互換性確保のために`BootWithVariables`を追加して対応した。
また、helperについてもパラメータ追加で対応することで互換性を確保している。