### PR TITLE
helper/service: Managed PKI

### DIFF
--- a/v2/helper/service/certificateauthority/apply_request.go
+++ b/v2/helper/service/certificateauthority/apply_request.go
@@ -1,0 +1,66 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/helper/validate"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type ApplyRequest struct {
+	ID types.ID `request:"-"`
+
+	Name        string `validate:"required"`
+	Description string `validate:"min=0,max=512"`
+	Tags        types.Tags
+	IconID      types.ID
+
+	Country          string
+	Organization     string
+	OrganizationUnit []string
+	CommonName       string
+	NotAfter         time.Time
+
+	Clients []*ClientCert // Note: API的に証明書の削除はできないため、指定した以上の証明書が存在する可能性がある
+	Servers []*ServerCert // Note: API的に証明書の削除はできないため、指定した以上の証明書が存在する可能性がある
+
+	WaitDuration time.Duration // 証明書発行待ち時間、省略した場合10秒
+}
+
+func (req *ApplyRequest) Validate() error {
+	return validate.Struct(req)
+}
+
+func (req *ApplyRequest) Builder(caller sacloud.APICaller) (*Builder, error) {
+	return &Builder{
+		ID:               req.ID,
+		Name:             req.Name,
+		Description:      req.Description,
+		Tags:             req.Tags,
+		IconID:           req.IconID,
+		Country:          req.Country,
+		Organization:     req.Organization,
+		OrganizationUnit: req.OrganizationUnit,
+		CommonName:       req.CommonName,
+		NotAfter:         req.NotAfter,
+		Clients:          req.Clients,
+		Servers:          req.Servers,
+		WaitDuration:     req.WaitDuration,
+		Client:           sacloud.NewCertificateAuthorityOp(caller),
+	}, nil
+}

--- a/v2/helper/service/certificateauthority/apply_service.go
+++ b/v2/helper/service/certificateauthority/apply_service.go
@@ -1,0 +1,36 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"context"
+)
+
+func (s *Service) Apply(req *ApplyRequest) (*CertificateAuthority, error) {
+	return s.ApplyWithContext(context.Background(), req)
+}
+
+func (s *Service) ApplyWithContext(ctx context.Context, req *ApplyRequest) (*CertificateAuthority, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	builder, err := req.Builder(s.caller)
+	if err != nil {
+		return nil, err
+	}
+
+	return builder.Build(ctx)
+}

--- a/v2/helper/service/certificateauthority/builder.go
+++ b/v2/helper/service/certificateauthority/builder.go
@@ -1,0 +1,259 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"context"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+// Builder マネージドPKI(CA)のビルダー
+type Builder struct {
+	ID types.ID // 新規登録時は空にする
+
+	Name        string
+	Description string
+	Tags        types.Tags
+	IconID      types.ID
+
+	Country          string
+	Organization     string
+	OrganizationUnit []string
+	CommonName       string
+	NotAfter         time.Time
+
+	Clients []*ClientCert // Note: API的に証明書の削除はできないため、指定した以上の証明書が存在する可能性がある
+	Servers []*ServerCert // Note: API的に証明書の削除はできないため、指定した以上の証明書が存在する可能性がある
+
+	Client       sacloud.CertificateAuthorityAPI
+	WaitDuration time.Duration // 証明書発行待ち時間、省略した場合10秒
+}
+
+// ClientCert クライアント証明書のリクエストパラメータ
+type ClientCert struct {
+	ID string // 新規登録時は空にする
+
+	Country                   string
+	Organization              string
+	OrganizationUnit          []string
+	CommonName                string
+	NotAfter                  time.Time
+	IssuanceMethod            string
+	EMail                     string
+	CertificateSigningRequest string
+	PublicKey                 string
+}
+
+// ServerCert サーバ証明書のリクエストパラメータ
+type ServerCert struct {
+	ID string // 新規作成時は空にする
+
+	Country                   string
+	Organization              string
+	OrganizationUnit          []string
+	CommonName                string
+	NotAfter                  time.Time
+	SANs                      []string
+	CertificateSigningRequest string
+	PublicKey                 string
+}
+
+// CertificateAuthority sacloud/CertificateAuthorityのラッパー
+//
+// CA/クライアント/サーバの詳細情報を保持する
+type CertificateAuthority struct {
+	sacloud.CertificateAuthority
+
+	Detail  *sacloud.CertificateAuthorityDetail
+	Clients []*sacloud.CertificateAuthorityClient
+	Servers []*sacloud.CertificateAuthorityServer
+}
+
+func (b *Builder) Build(ctx context.Context) (*CertificateAuthority, error) {
+	if b.ID.IsEmpty() {
+		return b.create(ctx)
+	}
+	return b.update(ctx)
+}
+
+func (b *Builder) create(ctx context.Context) (*CertificateAuthority, error) {
+	created, err := b.Client.Create(ctx, &sacloud.CertificateAuthorityCreateRequest{
+		Name:             b.Name,
+		Description:      b.Description,
+		Tags:             b.Tags,
+		IconID:           b.IconID,
+		Country:          b.Country,
+		Organization:     b.Organization,
+		OrganizationUnit: b.OrganizationUnit,
+		CommonName:       b.CommonName,
+		NotAfter:         b.NotAfter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	shouldWait := false
+	for _, cc := range b.Clients {
+		// URLまたはeメールの場合は待つ必要なし
+		if cc.IssuanceMethod == "public_key" || cc.IssuanceMethod == "csr" {
+			shouldWait = true
+		}
+		_, err := b.Client.AddClient(ctx, created.ID, &sacloud.CertificateAuthorityAddClientParam{
+			Country:                   cc.Country,
+			Organization:              cc.Organization,
+			OrganizationUnit:          cc.OrganizationUnit,
+			CommonName:                cc.CommonName,
+			NotAfter:                  cc.NotAfter,
+			IssuanceMethod:            cc.IssuanceMethod,
+			EMail:                     cc.EMail,
+			CertificateSigningRequest: cc.CertificateSigningRequest,
+			PublicKey:                 cc.PublicKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, sc := range b.Servers {
+		shouldWait = true
+
+		_, err := b.Client.AddServer(ctx, created.ID, &sacloud.CertificateAuthorityAddServerParam{
+			Country:                   sc.Country,
+			Organization:              sc.Organization,
+			OrganizationUnit:          sc.OrganizationUnit,
+			CommonName:                sc.CommonName,
+			NotAfter:                  sc.NotAfter,
+			SANs:                      sc.SANs,
+			CertificateSigningRequest: sc.CertificateSigningRequest,
+			PublicKey:                 sc.PublicKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if shouldWait {
+		b.wait(ctx)
+	}
+
+	return read(ctx, b.Client, created.ID)
+}
+
+func (b *Builder) update(ctx context.Context) (*CertificateAuthority, error) {
+	updated, err := b.Client.Update(ctx, b.ID, &sacloud.CertificateAuthorityUpdateRequest{
+		Name:        b.Name,
+		Description: b.Description,
+		Tags:        b.Tags,
+		IconID:      b.IconID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	shouldWait := false
+	for _, cc := range b.Clients {
+		if cc.ID != "" {
+			continue
+		}
+		// URLまたはeメールの場合は待つ必要なし
+		if cc.IssuanceMethod == "public_key" || cc.IssuanceMethod == "csr" {
+			shouldWait = true
+		}
+		_, err := b.Client.AddClient(ctx, updated.ID, &sacloud.CertificateAuthorityAddClientParam{
+			Country:                   cc.Country,
+			Organization:              cc.Organization,
+			OrganizationUnit:          cc.OrganizationUnit,
+			CommonName:                cc.CommonName,
+			NotAfter:                  cc.NotAfter,
+			IssuanceMethod:            cc.IssuanceMethod,
+			EMail:                     cc.EMail,
+			CertificateSigningRequest: cc.CertificateSigningRequest,
+			PublicKey:                 cc.PublicKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	for _, sc := range b.Servers {
+		if sc.ID != "" {
+			continue
+		}
+
+		shouldWait = true
+
+		_, err := b.Client.AddServer(ctx, updated.ID, &sacloud.CertificateAuthorityAddServerParam{
+			Country:                   sc.Country,
+			Organization:              sc.Organization,
+			OrganizationUnit:          sc.OrganizationUnit,
+			CommonName:                sc.CommonName,
+			NotAfter:                  sc.NotAfter,
+			SANs:                      sc.SANs,
+			CertificateSigningRequest: sc.CertificateSigningRequest,
+			PublicKey:                 sc.PublicKey,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if shouldWait {
+		b.wait(ctx)
+	}
+
+	return read(ctx, b.Client, updated.ID)
+}
+
+func (b *Builder) wait(ctx context.Context) {
+	// Note: 本来はクライアント/サーバ証明書ごとに状態を確認し証明書の発行が行われたか待つべきだが
+	// 実装が煩雑となる & 現状だと数秒程度で発行されるため、数秒スリープすることで代わりとする
+	wait := 10 * time.Second
+	if b.WaitDuration > 0 {
+		wait = b.WaitDuration
+	}
+	time.Sleep(wait)
+}
+
+func read(ctx context.Context, apiClient sacloud.CertificateAuthorityAPI, id types.ID) (*CertificateAuthority, error) {
+	current, err := apiClient.Read(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	ca := &CertificateAuthority{CertificateAuthority: *current}
+
+	// detail
+	detail, err := apiClient.Detail(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	ca.Detail = detail
+
+	// clients
+	clients, err := apiClient.ListClients(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	ca.Clients = clients.CertificateAuthority
+
+	// servers
+	servers, err := apiClient.ListServers(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	ca.Servers = servers.CertificateAuthority
+
+	return ca, nil
+}

--- a/v2/helper/service/certificateauthority/create_request.go
+++ b/v2/helper/service/certificateauthority/create_request.go
@@ -1,0 +1,61 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/helper/validate"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type CreateRequest struct {
+	Name        string `validate:"required"`
+	Description string `validate:"min=0,max=512"`
+	Tags        types.Tags
+	IconID      types.ID
+
+	Country          string
+	Organization     string
+	OrganizationUnit []string
+	CommonName       string
+	NotAfter         time.Time
+
+	Clients []*ClientCert // Note: API的に証明書の削除はできないため、指定した以上の証明書が存在する可能性がある
+	Servers []*ServerCert // Note: API的に証明書の削除はできないため、指定した以上の証明書が存在する可能性がある
+
+	WaitDuration time.Duration // 証明書発行待ち時間、省略した場合10秒
+}
+
+func (req *CreateRequest) Validate() error {
+	return validate.Struct(req)
+}
+
+func (req *CreateRequest) ApplyRequest() *ApplyRequest {
+	return &ApplyRequest{
+		Name:             req.Name,
+		Description:      req.Description,
+		Tags:             req.Tags,
+		IconID:           req.IconID,
+		Country:          req.Country,
+		Organization:     req.Organization,
+		OrganizationUnit: req.OrganizationUnit,
+		CommonName:       req.CommonName,
+		NotAfter:         req.NotAfter,
+		Clients:          req.Clients,
+		Servers:          req.Servers,
+		WaitDuration:     req.WaitDuration,
+	}
+}

--- a/v2/helper/service/certificateauthority/create_service.go
+++ b/v2/helper/service/certificateauthority/create_service.go
@@ -1,0 +1,31 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"context"
+)
+
+func (s *Service) Create(req *CreateRequest) (*CertificateAuthority, error) {
+	return s.CreateWithContext(context.Background(), req)
+}
+
+func (s *Service) CreateWithContext(ctx context.Context, req *CreateRequest) (*CertificateAuthority, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	return s.ApplyWithContext(ctx, req.ApplyRequest())
+}

--- a/v2/helper/service/certificateauthority/delete_request.go
+++ b/v2/helper/service/certificateauthority/delete_request.go
@@ -1,0 +1,30 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"github.com/sacloud/libsacloud/v2/helper/validate"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type DeleteRequest struct {
+	ID types.ID `request:"-" validate:"required"`
+
+	FailIfNotFound bool `request:"-"`
+}
+
+func (req *DeleteRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/v2/helper/service/certificateauthority/delete_service.go
+++ b/v2/helper/service/certificateauthority/delete_service.go
@@ -1,0 +1,38 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/helper/service"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+func (s *Service) Delete(req *DeleteRequest) error {
+	return s.DeleteWithContext(context.Background(), req)
+}
+
+func (s *Service) DeleteWithContext(ctx context.Context, req *DeleteRequest) error {
+	if err := req.Validate(); err != nil {
+		return err
+	}
+
+	client := sacloud.NewCertificateAuthorityOp(s.caller)
+	if err := client.Delete(ctx, req.ID); err != nil {
+		return service.HandleNotFoundError(err, !req.FailIfNotFound)
+	}
+	return nil
+}

--- a/v2/helper/service/certificateauthority/find_request.go
+++ b/v2/helper/service/certificateauthority/find_request.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"github.com/sacloud/libsacloud/v2/helper/service"
+	"github.com/sacloud/libsacloud/v2/helper/validate"
+	"github.com/sacloud/libsacloud/v2/pkg/util"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/search"
+)
+
+type FindRequest struct {
+	Names []string `request:"-"`
+	Tags  []string `request:"-"`
+
+	Sort  search.SortKeys
+	Count int
+	From  int
+}
+
+func (req *FindRequest) Validate() error {
+	return validate.Struct(req)
+}
+
+func (req *FindRequest) ToRequestParameter() (*sacloud.FindCondition, error) {
+	condition := &sacloud.FindCondition{
+		Filter: map[search.FilterKey]interface{}{},
+	}
+	if err := service.RequestConvertTo(req, condition); err != nil {
+		return nil, err
+	}
+
+	if !util.IsEmpty(req.Names) {
+		condition.Filter[search.Key("Name")] = search.AndEqual(req.Names...)
+	}
+	if !util.IsEmpty(req.Tags) {
+		condition.Filter[search.Key("Tags.Name")] = search.TagsAndEqual(req.Tags...)
+	}
+	return condition, nil
+}

--- a/v2/helper/service/certificateauthority/find_service.go
+++ b/v2/helper/service/certificateauthority/find_service.go
@@ -1,0 +1,43 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+func (s *Service) Find(req *FindRequest) ([]*sacloud.CertificateAuthority, error) {
+	return s.FindWithContext(context.Background(), req)
+}
+
+func (s *Service) FindWithContext(ctx context.Context, req *FindRequest) ([]*sacloud.CertificateAuthority, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	params, err := req.ToRequestParameter()
+	if err != nil {
+		return nil, err
+	}
+
+	client := sacloud.NewCertificateAuthorityOp(s.caller)
+	found, err := client.Find(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	return found.CertificateAuthorities, nil
+}

--- a/v2/helper/service/certificateauthority/read_request.go
+++ b/v2/helper/service/certificateauthority/read_request.go
@@ -1,0 +1,28 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"github.com/sacloud/libsacloud/v2/helper/validate"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type ReadRequest struct {
+	ID types.ID `request:"-" validate:"required"`
+}
+
+func (req *ReadRequest) Validate() error {
+	return validate.Struct(req)
+}

--- a/v2/helper/service/certificateauthority/read_service.go
+++ b/v2/helper/service/certificateauthority/read_service.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"context"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+)
+
+func (s *Service) Read(req *ReadRequest) (*CertificateAuthority, error) {
+	return s.ReadWithContext(context.Background(), req)
+}
+
+func (s *Service) ReadWithContext(ctx context.Context, req *ReadRequest) (*CertificateAuthority, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+	return read(ctx, sacloud.NewCertificateAuthorityOp(s.caller), req.ID)
+}

--- a/v2/helper/service/certificateauthority/service.go
+++ b/v2/helper/service/certificateauthority/service.go
@@ -1,0 +1,27 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import "github.com/sacloud/libsacloud/v2/sacloud"
+
+// Service provides a high-level API of for CertificateAuthority
+type Service struct {
+	caller sacloud.APICaller
+}
+
+// New returns new service instance of CertificateAuthority
+func New(caller sacloud.APICaller) *Service {
+	return &Service{caller: caller}
+}

--- a/v2/helper/service/certificateauthority/service_test.go
+++ b/v2/helper/service/certificateauthority/service_test.go
@@ -44,19 +44,19 @@ func TestCertificateAuthorityService_CRUD(t *testing.T) {
 					Tags:             types.Tags{"tag1", "tag2"},
 					Country:          "JP",
 					Organization:     "usacloud",
-					OrganizationUnit: []string{"ou1","ou2"},
+					OrganizationUnit: []string{"ou1", "ou2"},
 					CommonName:       "www.usacloud.jp",
 					NotAfter:         time.Now().Add(365 * 24 * time.Hour),
-					Clients:          []*ClientCert{
+					Clients: []*ClientCert{
 						{
-							Country:                   "JP",
-							Organization:              "usacloud",
-							CommonName:                "client.usacloud.jp",
-							NotAfter:                  time.Now().Add(365 * 24 * time.Hour),
-							IssuanceMethod:            "url",
+							Country:        "JP",
+							Organization:   "usacloud",
+							CommonName:     "client.usacloud.jp",
+							NotAfter:       time.Now().Add(365 * 24 * time.Hour),
+							IssuanceMethod: "url",
 						},
 					},
-					WaitDuration:     0,
+					WaitDuration: 0,
 				})
 			},
 		},

--- a/v2/helper/service/certificateauthority/service_test.go
+++ b/v2/helper/service/certificateauthority/service_test.go
@@ -1,0 +1,74 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"testing"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/testutil"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+func TestCertificateAuthorityService_CRUD(t *testing.T) {
+	if !testutil.IsAccTest() {
+		t.Skip("TestCertificateAuthorityService_CRUD only exec when running an Acceptance Test")
+	}
+
+	svc := New(testutil.SingletonAPICaller())
+	name := testutil.ResourceName("ca")
+
+	testutil.RunCRUD(t, &testutil.CRUDTestCase{
+		Parallel:           true,
+		PreCheck:           nil,
+		SetupAPICallerFunc: testutil.SingletonAPICaller,
+		Setup:              nil,
+		Create: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, _ sacloud.APICaller) (interface{}, error) {
+				return svc.Create(&CreateRequest{
+					Name:             name,
+					Description:      "test",
+					Tags:             types.Tags{"tag1", "tag2"},
+					Country:          "JP",
+					Organization:     "usacloud",
+					OrganizationUnit: []string{"ou1","ou2"},
+					CommonName:       "www.usacloud.jp",
+					NotAfter:         time.Now().Add(365 * 24 * time.Hour),
+					Clients:          []*ClientCert{
+						{
+							Country:                   "JP",
+							Organization:              "usacloud",
+							CommonName:                "client.usacloud.jp",
+							NotAfter:                  time.Now().Add(365 * 24 * time.Hour),
+							IssuanceMethod:            "url",
+						},
+					},
+					WaitDuration:     0,
+				})
+			},
+		},
+		Read: &testutil.CRUDTestFunc{
+			Func: func(ctx *testutil.CRUDTestContext, _ sacloud.APICaller) (interface{}, error) {
+				return svc.Read(&ReadRequest{ID: ctx.ID})
+			},
+		},
+		Delete: &testutil.CRUDTestDeleteFunc{
+			Func: func(ctx *testutil.CRUDTestContext, _ sacloud.APICaller) error {
+				return svc.Delete(&DeleteRequest{ID: ctx.ID})
+			},
+		},
+	})
+}

--- a/v2/helper/service/certificateauthority/update_request.go
+++ b/v2/helper/service/certificateauthority/update_request.go
@@ -1,0 +1,68 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"context"
+	"time"
+
+	"github.com/sacloud/libsacloud/v2/helper/service"
+	"github.com/sacloud/libsacloud/v2/helper/validate"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
+)
+
+type UpdateRequest struct {
+	ID types.ID `request:"-" validate:"required"`
+
+	Name        *string     `request:",omitempty" validate:"omitempty,min=1"`
+	Description *string     `request:",omitempty" validate:"omitempty,min=1,max=512"`
+	Tags        *types.Tags `request:",omitempty"`
+	IconID      *types.ID   `request:",omitempty"`
+
+	Clients []*ClientCert `request:",omitempty"` // Note: API的に証明書の削除はできないため、指定した以上の証明書が存在する可能性がある
+	Servers []*ServerCert `request:",omitempty"` // Note: API的に証明書の削除はできないため、指定した以上の証明書が存在する可能性がある
+
+	WaitDuration time.Duration // 証明書発行待ち時間、省略した場合10秒
+}
+
+func (req *UpdateRequest) Validate() error {
+	return validate.Struct(req)
+}
+
+func (req *UpdateRequest) ApplyRequest(ctx context.Context, caller sacloud.APICaller) (*ApplyRequest, error) {
+	client := sacloud.NewCertificateAuthorityOp(caller)
+	current, err := client.Read(ctx, req.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	applyRequest := &ApplyRequest{
+		ID:          req.ID,
+		Name:        current.Name,
+		Description: current.Description,
+		Tags:        current.Tags,
+		IconID:      current.IconID,
+
+		Clients:      req.Clients,
+		Servers:      req.Servers,
+		WaitDuration: req.WaitDuration,
+	}
+
+	if err := service.RequestConvertTo(req, applyRequest); err != nil {
+		return nil, err
+	}
+	return applyRequest, nil
+}

--- a/v2/helper/service/certificateauthority/update_service.go
+++ b/v2/helper/service/certificateauthority/update_service.go
@@ -1,0 +1,37 @@
+// Copyright 2016-2021 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package certificateauthority
+
+import (
+	"context"
+	"fmt"
+)
+
+func (s *Service) Update(req *UpdateRequest) (*CertificateAuthority, error) {
+	return s.UpdateWithContext(context.Background(), req)
+}
+
+func (s *Service) UpdateWithContext(ctx context.Context, req *UpdateRequest) (*CertificateAuthority, error) {
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	applyRequest, err := req.ApplyRequest(ctx, s.caller)
+	if err != nil {
+		return nil, fmt.Errorf("processing request parameter failed: %s", err)
+	}
+
+	return s.ApplyWithContext(ctx, applyRequest)
+}


### PR DESCRIPTION
#802 の後続PR

マネージドPKI向けの`helper/service`を追加する

Note1: 発行済みの証明書を削除する仕組みはないため、Service.Updateでのクライアント証明書/サーバ証明書の指定と戻り値が一致しないケースがある。

例: Updateでクライアント証明書としてAとBの2つを指定しても一度Cという証明書を発行していた場合は[A,B,C]の3つが返る

Note2: Readがsacloud.xxAPIのラッパーではなくservice側で定義したラッパー型を返す。
これはCAの詳細 + クライアント証明書の詳細 + サーバ証明書の詳細を含むもの。