### PR TITLE
Wait for a certificate to be issued when creating a CA

### DIFF
--- a/v2/helper/service/certificateauthority/builder.go
+++ b/v2/helper/service/certificateauthority/builder.go
@@ -107,13 +107,7 @@ func (b *Builder) create(ctx context.Context) (*CertificateAuthority, error) {
 		return nil, err
 	}
 
-	shouldWait := false
 	for _, cc := range b.Clients {
-		// URLまたはeメールの場合は待つ必要なし
-		if cc.IssuanceMethod == types.CertificateAuthorityIssuanceMethods.PublicKey ||
-			cc.IssuanceMethod == types.CertificateAuthorityIssuanceMethods.CSR {
-			shouldWait = true
-		}
 		_, err := b.Client.AddClient(ctx, created.ID, &sacloud.CertificateAuthorityAddClientParam{
 			Country:                   cc.Country,
 			Organization:              cc.Organization,
@@ -130,8 +124,6 @@ func (b *Builder) create(ctx context.Context) (*CertificateAuthority, error) {
 		}
 	}
 	for _, sc := range b.Servers {
-		shouldWait = true
-
 		_, err := b.Client.AddServer(ctx, created.ID, &sacloud.CertificateAuthorityAddServerParam{
 			Country:                   sc.Country,
 			Organization:              sc.Organization,
@@ -147,10 +139,7 @@ func (b *Builder) create(ctx context.Context) (*CertificateAuthority, error) {
 		}
 	}
 
-	if shouldWait {
-		b.wait(ctx)
-	}
-
+	b.wait(ctx) // create時はCAの証明書発行待ちが必要
 	return read(ctx, b.Client, created.ID)
 }
 


### PR DESCRIPTION
helper/serviceにてCA作成後にCAの証明書が発行されるまで待つように修正

従来はclients/serversが指定された場合のみ待っていたが、作成時はCA自体についても証明書発行を待つ必要があったため。