### PR TITLE
types.StringNumber: changed internal type from int64 to float64

### DIFF
--- a/v2/sacloud/types/string_number.go
+++ b/v2/sacloud/types/string_number.go
@@ -21,7 +21,7 @@ import (
 )
 
 // StringNumber 数値型を文字列で表す型
-type StringNumber int64
+type StringNumber float64
 
 // MarshalJSON implements json.Marshaler
 func (n *StringNumber) MarshalJSON() ([]byte, error) {
@@ -42,7 +42,7 @@ func (n *StringNumber) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &num); err != nil {
 		return err
 	}
-	number, err := num.Int64()
+	number, err := num.Float64()
 	if err != nil {
 		return err
 	}
@@ -55,7 +55,7 @@ func (n StringNumber) String() string {
 	if n.Int64() == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%d", n)
+	return strconv.FormatFloat(n.Float64(), 'f', -1, 64)
 }
 
 // Int returns the number as an int.
@@ -66,6 +66,11 @@ func (n StringNumber) Int() int {
 // Int64 returns the number as an int64.
 func (n StringNumber) Int64() int64 {
 	return int64(n)
+}
+
+// Float64 returns the number as an float64.
+func (n StringNumber) Float64() float64 {
+	return float64(n)
 }
 
 // ParseStringNumber 文字列からStringNumberへの変換

--- a/v2/sacloud/types/string_number_test.go
+++ b/v2/sacloud/types/string_number_test.go
@@ -30,6 +30,7 @@ func TestStringNumber(t *testing.T) {
 		{input: `"1"`, expect: StringNumber(1)},
 		{input: `0`, expect: StringNumber(0)},
 		{input: `1`, expect: StringNumber(1)},
+		{input: `1.1`, expect: StringNumber(1.1)},
 	}
 
 	for _, tc := range expects {


### PR DESCRIPTION
from: #835 

VPCルータにおいて文字列、かつfloat64を表す型が追加されている( #835 の`PercentageOfMemoryFree`)。
これに対応するために`types.StringNumber`において内部の型をfloat64に変更してstring/int/int64/float64を扱えるようにする。

typesに新たな型を追加しても良いが、既存のStringNumberをfloat64対応させた方が作業/影響ともに少ないと判断した。