### PR TITLE
VPCRouter: PercentageOfMemoryFree

### DIFF
--- a/v2/internal/define/vpc_router.go
+++ b/v2/internal/define/vpc_router.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sacloud/libsacloud/v2/internal/dsl"
 	"github.com/sacloud/libsacloud/v2/internal/dsl/meta"
 	"github.com/sacloud/libsacloud/v2/sacloud/naked"
+	"github.com/sacloud/libsacloud/v2/sacloud/types"
 )
 
 const (
@@ -244,6 +245,7 @@ var (
 			fields.Def("FirewallSendLogs", meta.TypeStringSlice),
 			fields.Def("VPNLogs", meta.TypeStringSlice),
 			fields.Def("SessionCount", meta.TypeInt),
+			fields.Def("PercentageOfMemoryFree", meta.Static([]types.StringNumber{})),
 			{
 				Name: "WireGuard",
 				Type: &dsl.Model{

--- a/v2/sacloud/naked/vpc_router.go
+++ b/v2/sacloud/naked/vpc_router.go
@@ -502,11 +502,12 @@ type VPCRouterStaticRouteConfig struct {
 
 // VPCRouterStatus ステータス
 type VPCRouterStatus struct {
-	FirewallReceiveLogs []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	FirewallSendLogs    []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	VPNLogs             []string `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	SessionCount        int      `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
-	DHCPServerLeases    []struct {
+	FirewallReceiveLogs    []string             `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	FirewallSendLogs       []string             `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	VPNLogs                []string             `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	SessionCount           int                  `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	PercentageOfMemoryFree []types.StringNumber `json:",omitempty" yaml:",omitempty" structs:",omitempty"`
+	DHCPServerLeases       []struct {
 		IPAddress  string
 		MACAddress string
 	} `json:",omitempty" yaml:",omitempty" structs:",omitempty"`

--- a/v2/sacloud/zz_models.go
+++ b/v2/sacloud/zz_models.go
@@ -14711,7 +14711,7 @@ func (o *LoadBalancerVirtualIPAddress) SetPort(v types.StringNumber) {
 
 // GetDelayLoop returns value of DelayLoop
 func (o *LoadBalancerVirtualIPAddress) GetDelayLoop() types.StringNumber {
-	if o.DelayLoop == types.StringNumber(int64(0)) {
+	if o.DelayLoop == types.StringNumber(float64(0)) {
 		return 10
 	}
 	return o.DelayLoop
@@ -30375,6 +30375,7 @@ type VPCRouterStatus struct {
 	FirewallSendLogs        []string
 	VPNLogs                 []string
 	SessionCount            int
+	PercentageOfMemoryFree  []types.StringNumber
 	WireGuard               *WireGuardStatus
 	DHCPServerLeases        []*VPCRouterDHCPServerLease        `mapconv:"[]DHCPServerLeases,recursive"`
 	L2TPIPsecServerSessions []*VPCRouterL2TPIPsecServerSession `mapconv:"[]L2TPIPsecServerSessions,recursive"`
@@ -30395,6 +30396,7 @@ func (o *VPCRouterStatus) setDefaults() interface{} {
 		FirewallSendLogs        []string
 		VPNLogs                 []string
 		SessionCount            int
+		PercentageOfMemoryFree  []types.StringNumber
 		WireGuard               *WireGuardStatus
 		DHCPServerLeases        []*VPCRouterDHCPServerLease        `mapconv:"[]DHCPServerLeases,recursive"`
 		L2TPIPsecServerSessions []*VPCRouterL2TPIPsecServerSession `mapconv:"[]L2TPIPsecServerSessions,recursive"`
@@ -30406,6 +30408,7 @@ func (o *VPCRouterStatus) setDefaults() interface{} {
 		FirewallSendLogs:        o.GetFirewallSendLogs(),
 		VPNLogs:                 o.GetVPNLogs(),
 		SessionCount:            o.GetSessionCount(),
+		PercentageOfMemoryFree:  o.GetPercentageOfMemoryFree(),
 		WireGuard:               o.GetWireGuard(),
 		DHCPServerLeases:        o.GetDHCPServerLeases(),
 		L2TPIPsecServerSessions: o.GetL2TPIPsecServerSessions(),
@@ -30453,6 +30456,16 @@ func (o *VPCRouterStatus) GetSessionCount() int {
 // SetSessionCount sets value to SessionCount
 func (o *VPCRouterStatus) SetSessionCount(v int) {
 	o.SessionCount = v
+}
+
+// GetPercentageOfMemoryFree returns value of PercentageOfMemoryFree
+func (o *VPCRouterStatus) GetPercentageOfMemoryFree() []types.StringNumber {
+	return o.PercentageOfMemoryFree
+}
+
+// SetPercentageOfMemoryFree sets value to PercentageOfMemoryFree
+func (o *VPCRouterStatus) SetPercentageOfMemoryFree(v []types.StringNumber) {
+	o.PercentageOfMemoryFree = v
 }
 
 // GetWireGuard returns value of WireGuard


### PR DESCRIPTION
from #835 

VPCルータのステータスAPIに`PercentageOfMemoryFree`フィールドを追加

Note: []types.StringNumberにしてあるが、値が2つ以上返ってくるところを確認できていない。(確認できた範囲では常に値は1つだけ)
確実に値が1つだけか不明なため型変換などは実施せずそのまま[]types.StringNumberを返す実装とした。