### PR TITLE
Added MonitorCPU func to appliance

### DIFF
--- a/v2/internal/define/load_balancer.go
+++ b/v2/internal/define/load_balancer.go
@@ -58,6 +58,8 @@ var loadBalancerAPI = &dsl.Resource{
 		ops.Reset(loadBalancerAPIName),
 
 		// monitor
+		ops.MonitorChild(loadBalancerAPIName, "CPU", "cpu",
+			monitorParameter, monitors.cpuTimeModel()),
 		ops.MonitorChild(loadBalancerAPIName, "Interface", "interface",
 			monitorParameter, monitors.interfaceModel()),
 

--- a/v2/internal/define/nfs.go
+++ b/v2/internal/define/nfs.go
@@ -53,6 +53,8 @@ var nfsAPI = &dsl.Resource{
 		ops.Reset(nfsAPIName),
 
 		// monitor
+		ops.MonitorChild(nfsAPIName, "CPU", "cpu",
+			monitorParameter, monitors.cpuTimeModel()),
 		ops.MonitorChild(nfsAPIName, "FreeDiskSize", "database",
 			monitorParameter, monitors.freeDiskSizeModel()),
 		ops.MonitorChild(nfsAPIName, "Interface", "interface",

--- a/v2/internal/define/vpc_router.go
+++ b/v2/internal/define/vpc_router.go
@@ -83,6 +83,8 @@ var vpcRouterAPI = &dsl.Resource{
 		),
 
 		// monitor
+		ops.MonitorChild(vpcRouterAPIName, "CPU", "cpu",
+			monitorParameter, monitors.cpuTimeModel()),
 		ops.MonitorChildBy(vpcRouterAPIName, "Interface", "interface",
 			monitorParameter, monitors.interfaceModel()),
 

--- a/v2/sacloud/fake/ops_load_balancer.go
+++ b/v2/sacloud/fake/ops_load_balancer.go
@@ -237,3 +237,27 @@ func (o *LoadBalancerOp) Status(ctx context.Context, zone string, id types.ID) (
 		Status: results,
 	}, nil
 }
+
+// MonitorCPU is fake implementation
+func (o *LoadBalancerOp) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().Truncate(time.Second)
+	m := now.Minute() % 5
+	if m != 0 {
+		now.Add(time.Duration(m) * time.Minute)
+	}
+
+	res := &sacloud.CPUTimeActivity{}
+	for i := 0; i < 5; i++ {
+		res.Values = append(res.Values, &sacloud.MonitorCPUTimeValue{
+			Time:    now.Add(time.Duration(i*-5) * time.Minute),
+			CPUTime: float64(random(1000)),
+		})
+	}
+
+	return res, nil
+}

--- a/v2/sacloud/fake/ops_nfs.go
+++ b/v2/sacloud/fake/ops_nfs.go
@@ -197,3 +197,27 @@ func (o *NFSOp) MonitorInterface(ctx context.Context, zone string, id types.ID, 
 
 	return res, nil
 }
+
+// MonitorCPU is fake implementation
+func (o *NFSOp) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().Truncate(time.Second)
+	m := now.Minute() % 5
+	if m != 0 {
+		now.Add(time.Duration(m) * time.Minute)
+	}
+
+	res := &sacloud.CPUTimeActivity{}
+	for i := 0; i < 5; i++ {
+		res.Values = append(res.Values, &sacloud.MonitorCPUTimeValue{
+			Time:    now.Add(time.Duration(i*-5) * time.Minute),
+			CPUTime: float64(random(1000)),
+		})
+	}
+
+	return res, nil
+}

--- a/v2/sacloud/fake/ops_vpc_router.go
+++ b/v2/sacloud/fake/ops_vpc_router.go
@@ -346,3 +346,27 @@ func (o *VPCRouterOp) Status(ctx context.Context, zone string, id types.ID) (*sa
 	}
 	return &sacloud.VPCRouterStatus{}, nil
 }
+
+// MonitorCPU is fake implementation
+func (o *VPCRouterOp) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	_, err := o.Read(ctx, zone, id)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now().Truncate(time.Second)
+	m := now.Minute() % 5
+	if m != 0 {
+		now.Add(time.Duration(m) * time.Minute)
+	}
+
+	res := &sacloud.CPUTimeActivity{}
+	for i := 0; i < 5; i++ {
+		res.Values = append(res.Values, &sacloud.MonitorCPUTimeValue{
+			Time:    now.Add(time.Duration(i*-5) * time.Minute),
+			CPUTime: float64(random(1000)),
+		})
+	}
+
+	return res, nil
+}

--- a/v2/sacloud/stub/zz_api_stubs.go
+++ b/v2/sacloud/stub/zz_api_stubs.go
@@ -2944,6 +2944,12 @@ type LoadBalancerResetStubResult struct {
 	Err error
 }
 
+// LoadBalancerMonitorCPUStubResult is expected values of the MonitorCPU operation
+type LoadBalancerMonitorCPUStubResult struct {
+	CPUTimeActivity *sacloud.CPUTimeActivity
+	Err             error
+}
+
 // LoadBalancerMonitorInterfaceStubResult is expected values of the MonitorInterface operation
 type LoadBalancerMonitorInterfaceStubResult struct {
 	InterfaceActivity *sacloud.InterfaceActivity
@@ -2968,6 +2974,7 @@ type LoadBalancerStub struct {
 	BootStubResult             *LoadBalancerBootStubResult
 	ShutdownStubResult         *LoadBalancerShutdownStubResult
 	ResetStubResult            *LoadBalancerResetStubResult
+	MonitorCPUStubResult       *LoadBalancerMonitorCPUStubResult
 	MonitorInterfaceStubResult *LoadBalancerMonitorInterfaceStubResult
 	StatusStubResult           *LoadBalancerStatusStubResult
 }
@@ -3055,6 +3062,14 @@ func (s *LoadBalancerStub) Reset(ctx context.Context, zone string, id types.ID) 
 		log.Fatal("LoadBalancerStub.ResetStubResult is not set")
 	}
 	return s.ResetStubResult.Err
+}
+
+// MonitorCPU is API call with trace log
+func (s *LoadBalancerStub) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	if s.MonitorCPUStubResult == nil {
+		log.Fatal("LoadBalancerStub.MonitorCPUStubResult is not set")
+	}
+	return s.MonitorCPUStubResult.CPUTimeActivity, s.MonitorCPUStubResult.Err
 }
 
 // MonitorInterface is API call with trace log
@@ -3628,6 +3643,12 @@ type NFSResetStubResult struct {
 	Err error
 }
 
+// NFSMonitorCPUStubResult is expected values of the MonitorCPU operation
+type NFSMonitorCPUStubResult struct {
+	CPUTimeActivity *sacloud.CPUTimeActivity
+	Err             error
+}
+
 // NFSMonitorFreeDiskSizeStubResult is expected values of the MonitorFreeDiskSize operation
 type NFSMonitorFreeDiskSizeStubResult struct {
 	FreeDiskSizeActivity *sacloud.FreeDiskSizeActivity
@@ -3650,6 +3671,7 @@ type NFSStub struct {
 	BootStubResult                *NFSBootStubResult
 	ShutdownStubResult            *NFSShutdownStubResult
 	ResetStubResult               *NFSResetStubResult
+	MonitorCPUStubResult          *NFSMonitorCPUStubResult
 	MonitorFreeDiskSizeStubResult *NFSMonitorFreeDiskSizeStubResult
 	MonitorInterfaceStubResult    *NFSMonitorInterfaceStubResult
 }
@@ -3721,6 +3743,14 @@ func (s *NFSStub) Reset(ctx context.Context, zone string, id types.ID) error {
 		log.Fatal("NFSStub.ResetStubResult is not set")
 	}
 	return s.ResetStubResult.Err
+}
+
+// MonitorCPU is API call with trace log
+func (s *NFSStub) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	if s.MonitorCPUStubResult == nil {
+		log.Fatal("NFSStub.MonitorCPUStubResult is not set")
+	}
+	return s.MonitorCPUStubResult.CPUTimeActivity, s.MonitorCPUStubResult.Err
 }
 
 // MonitorFreeDiskSize is API call with trace log
@@ -5356,6 +5386,12 @@ type VPCRouterDisconnectFromSwitchStubResult struct {
 	Err error
 }
 
+// VPCRouterMonitorCPUStubResult is expected values of the MonitorCPU operation
+type VPCRouterMonitorCPUStubResult struct {
+	CPUTimeActivity *sacloud.CPUTimeActivity
+	Err             error
+}
+
 // VPCRouterMonitorInterfaceStubResult is expected values of the MonitorInterface operation
 type VPCRouterMonitorInterfaceStubResult struct {
 	InterfaceActivity *sacloud.InterfaceActivity
@@ -5382,6 +5418,7 @@ type VPCRouterStub struct {
 	ResetStubResult                *VPCRouterResetStubResult
 	ConnectToSwitchStubResult      *VPCRouterConnectToSwitchStubResult
 	DisconnectFromSwitchStubResult *VPCRouterDisconnectFromSwitchStubResult
+	MonitorCPUStubResult           *VPCRouterMonitorCPUStubResult
 	MonitorInterfaceStubResult     *VPCRouterMonitorInterfaceStubResult
 	StatusStubResult               *VPCRouterStatusStubResult
 }
@@ -5485,6 +5522,14 @@ func (s *VPCRouterStub) DisconnectFromSwitch(ctx context.Context, zone string, i
 		log.Fatal("VPCRouterStub.DisconnectFromSwitchStubResult is not set")
 	}
 	return s.DisconnectFromSwitchStubResult.Err
+}
+
+// MonitorCPU is API call with trace log
+func (s *VPCRouterStub) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	if s.MonitorCPUStubResult == nil {
+		log.Fatal("VPCRouterStub.MonitorCPUStubResult is not set")
+	}
+	return s.MonitorCPUStubResult.CPUTimeActivity, s.MonitorCPUStubResult.Err
 }
 
 // MonitorInterface is API call with trace log

--- a/v2/sacloud/trace/otel/zz_api_tracer.go
+++ b/v2/sacloud/trace/otel/zz_api_tracer.go
@@ -5322,6 +5322,33 @@ func (t *LoadBalancerTracer) Reset(ctx context.Context, zone string, id types.ID
 	return err
 }
 
+// MonitorCPU is API call with trace log
+func (t *LoadBalancerTracer) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libsacloud.api.arguments.zone", zone),
+		attribute.String("libsacloud.api.arguments.id", forceString(id)),
+		attribute.String("libsacloud.api.arguments.condition", forceString(condition)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "LoadBalancerAPI.MonitorCPU", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	resultCPUTimeActivity, err := t.Internal.MonitorCPU(ctx, zone, id, condition)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+		span.SetAttributes(attribute.String("libsacloud.api.results.resultCPUTimeActivity", forceString(resultCPUTimeActivity)))
+
+	}
+	return resultCPUTimeActivity, err
+}
+
 // MonitorInterface is API call with trace log
 func (t *LoadBalancerTracer) MonitorInterface(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
 	var span trace.Span
@@ -6483,6 +6510,33 @@ func (t *NFSTracer) Reset(ctx context.Context, zone string, id types.ID) error {
 
 	}
 	return err
+}
+
+// MonitorCPU is API call with trace log
+func (t *NFSTracer) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libsacloud.api.arguments.zone", zone),
+		attribute.String("libsacloud.api.arguments.id", forceString(id)),
+		attribute.String("libsacloud.api.arguments.condition", forceString(condition)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "NFSAPI.MonitorCPU", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	resultCPUTimeActivity, err := t.Internal.MonitorCPU(ctx, zone, id, condition)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+		span.SetAttributes(attribute.String("libsacloud.api.results.resultCPUTimeActivity", forceString(resultCPUTimeActivity)))
+
+	}
+	return resultCPUTimeActivity, err
 }
 
 // MonitorFreeDiskSize is API call with trace log
@@ -9487,6 +9541,33 @@ func (t *VPCRouterTracer) DisconnectFromSwitch(ctx context.Context, zone string,
 
 	}
 	return err
+}
+
+// MonitorCPU is API call with trace log
+func (t *VPCRouterTracer) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	var span trace.Span
+	options := append(t.config.SpanStartOptions, trace.WithAttributes(
+		attribute.String("libsacloud.api.arguments.zone", zone),
+		attribute.String("libsacloud.api.arguments.id", forceString(id)),
+		attribute.String("libsacloud.api.arguments.condition", forceString(condition)),
+	))
+	ctx, span = t.config.Tracer.Start(ctx, "VPCRouterAPI.MonitorCPU", options...)
+	defer func() {
+		span.End()
+	}()
+
+	// for http trace
+	ctx = httptrace.WithClientTrace(ctx, otelhttptrace.NewClientTrace(ctx))
+	resultCPUTimeActivity, err := t.Internal.MonitorCPU(ctx, zone, id, condition)
+
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+		span.SetAttributes(attribute.String("libsacloud.api.results.resultCPUTimeActivity", forceString(resultCPUTimeActivity)))
+
+	}
+	return resultCPUTimeActivity, err
 }
 
 // MonitorInterface is API call with trace log

--- a/v2/sacloud/trace/zz_api_tracer.go
+++ b/v2/sacloud/trace/zz_api_tracer.go
@@ -6505,6 +6505,41 @@ func (t *LoadBalancerTracer) Reset(ctx context.Context, zone string, id types.ID
 	return err
 }
 
+// MonitorCPU is API call with trace log
+func (t *LoadBalancerTracer) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	log.Println("[TRACE] LoadBalancerAPI.MonitorCPU start")
+	targetArguments := struct {
+		Argzone      string
+		Argid        types.ID                  `json:"id"`
+		Argcondition *sacloud.MonitorCondition `json:"condition"`
+	}{
+		Argzone:      zone,
+		Argid:        id,
+		Argcondition: condition,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] LoadBalancerAPI.MonitorCPU end")
+	}()
+
+	resultCPUTimeActivity, err := t.Internal.MonitorCPU(ctx, zone, id, condition)
+	targetResults := struct {
+		CPUTimeActivity *sacloud.CPUTimeActivity
+		Error           error
+	}{
+		CPUTimeActivity: resultCPUTimeActivity,
+		Error:           err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultCPUTimeActivity, err
+}
+
 // MonitorInterface is API call with trace log
 func (t *LoadBalancerTracer) MonitorInterface(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.InterfaceActivity, error) {
 	log.Println("[TRACE] LoadBalancerAPI.MonitorInterface start")
@@ -7952,6 +7987,41 @@ func (t *NFSTracer) Reset(ctx context.Context, zone string, id types.ID) error {
 	}
 
 	return err
+}
+
+// MonitorCPU is API call with trace log
+func (t *NFSTracer) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	log.Println("[TRACE] NFSAPI.MonitorCPU start")
+	targetArguments := struct {
+		Argzone      string
+		Argid        types.ID                  `json:"id"`
+		Argcondition *sacloud.MonitorCondition `json:"condition"`
+	}{
+		Argzone:      zone,
+		Argid:        id,
+		Argcondition: condition,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] NFSAPI.MonitorCPU end")
+	}()
+
+	resultCPUTimeActivity, err := t.Internal.MonitorCPU(ctx, zone, id, condition)
+	targetResults := struct {
+		CPUTimeActivity *sacloud.CPUTimeActivity
+		Error           error
+	}{
+		CPUTimeActivity: resultCPUTimeActivity,
+		Error:           err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultCPUTimeActivity, err
 }
 
 // MonitorFreeDiskSize is API call with trace log
@@ -11627,6 +11697,41 @@ func (t *VPCRouterTracer) DisconnectFromSwitch(ctx context.Context, zone string,
 	}
 
 	return err
+}
+
+// MonitorCPU is API call with trace log
+func (t *VPCRouterTracer) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *sacloud.MonitorCondition) (*sacloud.CPUTimeActivity, error) {
+	log.Println("[TRACE] VPCRouterAPI.MonitorCPU start")
+	targetArguments := struct {
+		Argzone      string
+		Argid        types.ID                  `json:"id"`
+		Argcondition *sacloud.MonitorCondition `json:"condition"`
+	}{
+		Argzone:      zone,
+		Argid:        id,
+		Argcondition: condition,
+	}
+	if d, err := json.Marshal(targetArguments); err == nil {
+		log.Printf("[TRACE] \targs: %s\n", string(d))
+	}
+
+	defer func() {
+		log.Println("[TRACE] VPCRouterAPI.MonitorCPU end")
+	}()
+
+	resultCPUTimeActivity, err := t.Internal.MonitorCPU(ctx, zone, id, condition)
+	targetResults := struct {
+		CPUTimeActivity *sacloud.CPUTimeActivity
+		Error           error
+	}{
+		CPUTimeActivity: resultCPUTimeActivity,
+		Error:           err,
+	}
+	if d, err := json.Marshal(targetResults); err == nil {
+		log.Printf("[TRACE] \tresults: %s\n", string(d))
+	}
+
+	return resultCPUTimeActivity, err
 }
 
 // MonitorInterface is API call with trace log

--- a/v2/sacloud/zz_api_ops.go
+++ b/v2/sacloud/zz_api_ops.go
@@ -7155,6 +7155,44 @@ func (o *LoadBalancerOp) Reset(ctx context.Context, zone string, id types.ID) er
 	return nil
 }
 
+// MonitorCPU is API call
+func (o *LoadBalancerOp) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*CPUTimeActivity, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"condition":  condition,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/cpu/monitor", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformMonitorCPUArgs(id, condition)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformMonitorCPUResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.CPUTimeActivity, nil
+}
+
 // MonitorInterface is API call
 func (o *LoadBalancerOp) MonitorInterface(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*InterfaceActivity, error) {
 	// build request URL
@@ -8685,6 +8723,44 @@ func (o *NFSOp) Reset(ctx context.Context, zone string, id types.ID) error {
 	// build results
 
 	return nil
+}
+
+// MonitorCPU is API call
+func (o *NFSOp) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*CPUTimeActivity, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"condition":  condition,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/cpu/monitor", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformMonitorCPUArgs(id, condition)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformMonitorCPUResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.CPUTimeActivity, nil
 }
 
 // MonitorFreeDiskSize is API call
@@ -12661,6 +12737,44 @@ func (o *VPCRouterOp) DisconnectFromSwitch(ctx context.Context, zone string, id 
 	// build results
 
 	return nil
+}
+
+// MonitorCPU is API call
+func (o *VPCRouterOp) MonitorCPU(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*CPUTimeActivity, error) {
+	// build request URL
+	pathBuildParameter := map[string]interface{}{
+		"rootURL":    SakuraCloudAPIRoot,
+		"pathSuffix": o.PathSuffix,
+		"pathName":   o.PathName,
+		"zone":       zone,
+		"id":         id,
+		"condition":  condition,
+	}
+
+	url, err := buildURL("{{.rootURL}}/{{.zone}}/{{.pathSuffix}}/{{.pathName}}/{{.id}}/cpu/monitor", pathBuildParameter)
+	if err != nil {
+		return nil, err
+	}
+	// build request body
+	var body interface{}
+	v, err := o.transformMonitorCPUArgs(id, condition)
+	if err != nil {
+		return nil, err
+	}
+	body = v
+
+	// do request
+	data, err := o.Client.Do(ctx, "GET", url, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// build results
+	results, err := o.transformMonitorCPUResults(data)
+	if err != nil {
+		return nil, err
+	}
+	return results.CPUTimeActivity, nil
 }
 
 // MonitorInterface is API call

--- a/v2/sacloud/zz_api_transformers.go
+++ b/v2/sacloud/zz_api_transformers.go
@@ -4291,6 +4291,49 @@ func (o *LoadBalancerOp) transformShutdownArgs(id types.ID, shutdownOption *Shut
 	return v, nil
 }
 
+func (o *LoadBalancerOp) transformMonitorCPUArgs(id types.ID, condition *MonitorCondition) (*loadBalancerMonitorCPURequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if condition == nil {
+		condition = &MonitorCondition{}
+	}
+	var arg1 interface{} = condition
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &loadBalancerMonitorCPURequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *LoadBalancerOp) transformMonitorCPUResults(data []byte) (*loadBalancerMonitorCPUResult, error) {
+	nakedResponse := &loadBalancerMonitorCPUResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &loadBalancerMonitorCPUResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
 func (o *LoadBalancerOp) transformMonitorInterfaceArgs(id types.ID, condition *MonitorCondition) (*loadBalancerMonitorInterfaceRequestEnvelope, error) {
 	if id == types.ID(int64(0)) {
 		id = types.ID(int64(0))
@@ -5169,6 +5212,49 @@ func (o *NFSOp) transformShutdownArgs(id types.ID, shutdownOption *ShutdownOptio
 		return nil, err
 	}
 	return v, nil
+}
+
+func (o *NFSOp) transformMonitorCPUArgs(id types.ID, condition *MonitorCondition) (*nFSMonitorCPURequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if condition == nil {
+		condition = &MonitorCondition{}
+	}
+	var arg1 interface{} = condition
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &nFSMonitorCPURequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *NFSOp) transformMonitorCPUResults(data []byte) (*nFSMonitorCPUResult, error) {
+	nakedResponse := &nFSMonitorCPUResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &nFSMonitorCPUResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 func (o *NFSOp) transformMonitorFreeDiskSizeArgs(id types.ID, condition *MonitorCondition) (*nFSMonitorFreeDiskSizeRequestEnvelope, error) {
@@ -7637,6 +7723,49 @@ func (o *VPCRouterOp) transformShutdownArgs(id types.ID, shutdownOption *Shutdow
 		return nil, err
 	}
 	return v, nil
+}
+
+func (o *VPCRouterOp) transformMonitorCPUArgs(id types.ID, condition *MonitorCondition) (*vPCRouterMonitorCPURequestEnvelope, error) {
+	if id == types.ID(int64(0)) {
+		id = types.ID(int64(0))
+	}
+	var arg0 interface{} = id
+	if v, ok := arg0.(argumentDefaulter); ok {
+		arg0 = v.setDefaults()
+	}
+	if condition == nil {
+		condition = &MonitorCondition{}
+	}
+	var arg1 interface{} = condition
+	if v, ok := arg1.(argumentDefaulter); ok {
+		arg1 = v.setDefaults()
+	}
+	args := &struct {
+		Arg0 interface{}
+		Arg1 interface{} `mapconv:",squash"`
+	}{
+		Arg0: arg0,
+		Arg1: arg1,
+	}
+
+	v := &vPCRouterMonitorCPURequestEnvelope{}
+	if err := mapconv.ConvertTo(args, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+func (o *VPCRouterOp) transformMonitorCPUResults(data []byte) (*vPCRouterMonitorCPUResult, error) {
+	nakedResponse := &vPCRouterMonitorCPUResponseEnvelope{}
+	if err := json.Unmarshal(data, nakedResponse); err != nil {
+		return nil, err
+	}
+
+	results := &vPCRouterMonitorCPUResult{}
+	if err := mapconv.ConvertFrom(nakedResponse, results); err != nil {
+		return nil, err
+	}
+	return results, nil
 }
 
 func (o *VPCRouterOp) transformMonitorInterfaceArgs(id types.ID, index int, condition *MonitorCondition) (*vPCRouterMonitorInterfaceRequestEnvelope, error) {

--- a/v2/sacloud/zz_apis.go
+++ b/v2/sacloud/zz_apis.go
@@ -410,6 +410,7 @@ type LoadBalancerAPI interface {
 	Boot(ctx context.Context, zone string, id types.ID) error
 	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *ShutdownOption) error
 	Reset(ctx context.Context, zone string, id types.ID) error
+	MonitorCPU(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*CPUTimeActivity, error)
 	MonitorInterface(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*InterfaceActivity, error)
 	Status(ctx context.Context, zone string, id types.ID) (*LoadBalancerStatusResult, error)
 }
@@ -477,6 +478,7 @@ type NFSAPI interface {
 	Boot(ctx context.Context, zone string, id types.ID) error
 	Shutdown(ctx context.Context, zone string, id types.ID, shutdownOption *ShutdownOption) error
 	Reset(ctx context.Context, zone string, id types.ID) error
+	MonitorCPU(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*CPUTimeActivity, error)
 	MonitorFreeDiskSize(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*FreeDiskSizeActivity, error)
 	MonitorInterface(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*InterfaceActivity, error)
 }
@@ -704,6 +706,7 @@ type VPCRouterAPI interface {
 	Reset(ctx context.Context, zone string, id types.ID) error
 	ConnectToSwitch(ctx context.Context, zone string, id types.ID, nicIndex int, switchID types.ID) error
 	DisconnectFromSwitch(ctx context.Context, zone string, id types.ID, nicIndex int) error
+	MonitorCPU(ctx context.Context, zone string, id types.ID, condition *MonitorCondition) (*CPUTimeActivity, error)
 	MonitorInterface(ctx context.Context, zone string, id types.ID, index int, condition *MonitorCondition) (*InterfaceActivity, error)
 	Status(ctx context.Context, zone string, id types.ID) (*VPCRouterStatus, error)
 }

--- a/v2/sacloud/zz_envelopes.go
+++ b/v2/sacloud/zz_envelopes.go
@@ -1720,6 +1720,20 @@ type loadBalancerShutdownRequestEnvelope struct {
 	Force bool `json:",omitempty"`
 }
 
+// loadBalancerMonitorCPURequestEnvelope is envelop of API request
+type loadBalancerMonitorCPURequestEnvelope struct {
+	Start time.Time `json:",omitempty"`
+	End   time.Time `json:",omitempty"`
+}
+
+// loadBalancerMonitorCPUResponseEnvelope is envelop of API response
+type loadBalancerMonitorCPUResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Data *naked.MonitorValues `json:",omitempty"`
+}
+
 // loadBalancerMonitorInterfaceRequestEnvelope is envelop of API request
 type loadBalancerMonitorInterfaceRequestEnvelope struct {
 	Start time.Time `json:",omitempty"`
@@ -2040,6 +2054,20 @@ type nFSUpdateResponseEnvelope struct {
 // nFSShutdownRequestEnvelope is envelop of API request
 type nFSShutdownRequestEnvelope struct {
 	Force bool `json:",omitempty"`
+}
+
+// nFSMonitorCPURequestEnvelope is envelop of API request
+type nFSMonitorCPURequestEnvelope struct {
+	Start time.Time `json:",omitempty"`
+	End   time.Time `json:",omitempty"`
+}
+
+// nFSMonitorCPUResponseEnvelope is envelop of API response
+type nFSMonitorCPUResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Data *naked.MonitorValues `json:",omitempty"`
 }
 
 // nFSMonitorFreeDiskSizeRequestEnvelope is envelop of API request
@@ -3008,6 +3036,20 @@ type vPCRouterUpdateSettingsResponseEnvelope struct {
 // vPCRouterShutdownRequestEnvelope is envelop of API request
 type vPCRouterShutdownRequestEnvelope struct {
 	Force bool `json:",omitempty"`
+}
+
+// vPCRouterMonitorCPURequestEnvelope is envelop of API request
+type vPCRouterMonitorCPURequestEnvelope struct {
+	Start time.Time `json:",omitempty"`
+	End   time.Time `json:",omitempty"`
+}
+
+// vPCRouterMonitorCPUResponseEnvelope is envelop of API response
+type vPCRouterMonitorCPUResponseEnvelope struct {
+	IsOk    bool            `json:"is_ok,omitempty"` // is_ok項目
+	Success types.APIResult `json:",omitempty"`      // success項目
+
+	Data *naked.MonitorValues `json:",omitempty"`
 }
 
 // vPCRouterMonitorInterfaceRequestEnvelope is envelop of API request

--- a/v2/sacloud/zz_result.go
+++ b/v2/sacloud/zz_result.go
@@ -1287,6 +1287,13 @@ type loadBalancerUpdateSettingsResult struct {
 	LoadBalancer *LoadBalancer `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
 }
 
+// loadBalancerMonitorCPUResult represents the Result of API
+type loadBalancerMonitorCPUResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	CPUTimeActivity *CPUTimeActivity `json:",omitempty" mapconv:"Data,omitempty,recursive"`
+}
+
 // loadBalancerMonitorInterfaceResult represents the Result of API
 type loadBalancerMonitorInterfaceResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
@@ -1504,6 +1511,13 @@ type nFSUpdateResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	NFS *NFS `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// nFSMonitorCPUResult represents the Result of API
+type nFSMonitorCPUResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	CPUTimeActivity *CPUTimeActivity `json:",omitempty" mapconv:"Data,omitempty,recursive"`
 }
 
 // nFSMonitorFreeDiskSizeResult represents the Result of API
@@ -2188,6 +2202,13 @@ type vPCRouterUpdateSettingsResult struct {
 	IsOk bool `json:",omitempty"` // is_ok
 
 	VPCRouter *VPCRouter `json:",omitempty" mapconv:"Appliance,omitempty,recursive"`
+}
+
+// vPCRouterMonitorCPUResult represents the Result of API
+type vPCRouterMonitorCPUResult struct {
+	IsOk bool `json:",omitempty"` // is_ok
+
+	CPUTimeActivity *CPUTimeActivity `json:",omitempty" mapconv:"Data,omitempty,recursive"`
 }
 
 // vPCRouterMonitorInterfaceResult represents the Result of API


### PR DESCRIPTION
closes #835 

CPU時間を取得するAPI `GET /appliance/:id/cpu/monitor`への対応を追加