### PR TITLE
helper/api: client builder

### DIFF
--- a/v2/helper/api/caller.go
+++ b/v2/helper/api/caller.go
@@ -30,38 +30,18 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-// CallerOptions sacloud.APICallerを作成する際のオプション
-type CallerOptions struct {
-	AccessToken       string
-	AccessTokenSecret string
-
-	APIRootURL     string
-	DefaultZone    string
-	AcceptLanguage string
-
-	HTTPClient *http.Client
-
-	HTTPRequestTimeout   int
-	HTTPRequestRateLimit int
-
-	RetryMax     int
-	RetryWaitMax int
-	RetryWaitMin int
-
-	UserAgent string
-
-	TraceAPI             bool
-	TraceHTTP            bool
-	OpenTelemetry        bool
-	OpenTelemetryOptions []otel.Option
-
-	FakeMode      bool
-	FakeStorePath string
-}
-
 // NewCaller 指定のオプションでsacloud.APICallerを構築して返す
 func NewCaller(opts *CallerOptions) sacloud.APICaller {
 	return newCaller(opts)
+}
+
+// NewDefaultCaller デフォルトのオプションでsacloud.APICallerを構築して返す
+func NewDefaultCaller() (sacloud.APICaller, error) {
+	opts, err := DefaultOption()
+	if err != nil {
+		return nil, err
+	}
+	return NewCaller(opts), nil
 }
 
 func newCaller(opts *CallerOptions) sacloud.APICaller {

--- a/v2/helper/api/options.go
+++ b/v2/helper/api/options.go
@@ -1,0 +1,251 @@
+// Copyright 2016-2022 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	sacloudhttp "github.com/sacloud/go-http"
+	"github.com/sacloud/libsacloud/v2/sacloud"
+	"github.com/sacloud/libsacloud/v2/sacloud/profile"
+	"github.com/sacloud/libsacloud/v2/sacloud/trace/otel"
+)
+
+// CallerOptions sacloud.APICallerを作成する際のオプション
+type CallerOptions struct {
+	AccessToken       string
+	AccessTokenSecret string
+
+	APIRootURL     string
+	DefaultZone    string
+	Zones          []string
+	AcceptLanguage string
+
+	HTTPClient *http.Client
+
+	HTTPRequestTimeout   int
+	HTTPRequestRateLimit int
+
+	RetryMax     int
+	RetryWaitMax int
+	RetryWaitMin int
+
+	UserAgent string
+
+	TraceAPI             bool
+	TraceHTTP            bool
+	OpenTelemetry        bool
+	OpenTelemetryOptions []otel.Option
+
+	FakeMode      bool
+	FakeStorePath string
+}
+
+// DefaultOption 環境変数、プロファイルからCallerOptionsを組み立てて返す
+//
+// プロファイルは環境変数`SAKURACLOUD_PROFILE`または`USACLOUD_PROFILE`でプロファイル名が指定されていればそちらを優先し、
+// 未指定の場合は通常のプロファイル処理(~/.usacloud/currentファイルから読み込み)される。
+// 同じ項目を複数箇所で指定していた場合、環境変数->プロファイルの順で上書きされたものが返される
+func DefaultOption() (*CallerOptions, error) {
+	profileName := stringFromEnvMulti([]string{"SAKURACLOUD_PROFILE", "USACLOUD_PROFILE"}, "")
+	fromProfile, err := OptionsFromProfile(profileName)
+	if err != nil {
+		return nil, err
+	}
+	return MergeOptions(OptionsFromEnv(), fromProfile, defaultOption), nil
+}
+
+var defaultOption = &CallerOptions{
+	APIRootURL:           sacloud.SakuraCloudAPIRoot,
+	DefaultZone:          sacloud.APIDefaultZone,
+	HTTPRequestTimeout:   300,
+	HTTPRequestRateLimit: 5,
+	RetryMax:             sacloudhttp.DefaultRetryMax,
+	RetryWaitMax:         int(sacloudhttp.DefaultRetryWaitMax.Seconds()),
+	RetryWaitMin:         int(sacloudhttp.DefaultRetryWaitMin.Seconds()),
+}
+
+// MergeOptions 指定のCallerOptionsの非ゼロ値フィールドをoのコピーにマージして返す
+func MergeOptions(opts ...*CallerOptions) *CallerOptions {
+	merged := &CallerOptions{}
+	for _, opt := range opts {
+		if opt.AccessToken != "" {
+			merged.AccessToken = opt.AccessToken
+		}
+		if opt.AccessTokenSecret != "" {
+			merged.AccessTokenSecret = opt.AccessTokenSecret
+		}
+		if opt.APIRootURL != "" {
+			merged.APIRootURL = opt.APIRootURL
+		}
+		if opt.DefaultZone != "" {
+			merged.DefaultZone = opt.DefaultZone
+		}
+		if len(opt.Zones) > 0 {
+			merged.Zones = opt.Zones
+		}
+		if opt.AcceptLanguage != "" {
+			merged.AcceptLanguage = opt.AcceptLanguage
+		}
+		if opt.HTTPClient != nil {
+			merged.HTTPClient = opt.HTTPClient
+		}
+		if opt.HTTPRequestTimeout > 0 {
+			merged.HTTPRequestTimeout = opt.HTTPRequestTimeout
+		}
+		if opt.HTTPRequestRateLimit > 0 {
+			merged.HTTPRequestRateLimit = opt.HTTPRequestRateLimit
+		}
+		if opt.RetryMax > 0 {
+			merged.RetryMax = opt.RetryMax
+		}
+		if opt.RetryWaitMax > 0 {
+			merged.RetryWaitMax = opt.RetryWaitMax
+		}
+		if opt.RetryWaitMin > 0 {
+			merged.RetryWaitMin = opt.RetryWaitMin
+		}
+		if opt.UserAgent != "" {
+			merged.UserAgent = opt.UserAgent
+		}
+
+		// Note: bool値は一度trueにしたらMergeでfalseになることがない
+		if opt.TraceAPI {
+			merged.TraceAPI = true
+		}
+		if opt.TraceHTTP {
+			merged.TraceHTTP = true
+		}
+		if opt.OpenTelemetry {
+			merged.OpenTelemetry = true
+		}
+		if len(opt.OpenTelemetryOptions) > 0 {
+			merged.OpenTelemetryOptions = opt.OpenTelemetryOptions
+		}
+		if opt.FakeMode {
+			merged.FakeMode = true
+		}
+		if opt.FakeStorePath != "" {
+			merged.FakeStorePath = opt.FakeStorePath
+		}
+	}
+	return merged
+}
+
+// OptionsFromEnv 環境変数からCallerOptionsを組み立てて返す
+func OptionsFromEnv() *CallerOptions {
+	return &CallerOptions{
+		AccessToken:       stringFromEnv("SAKURACLOUD_ACCESS_TOKEN", ""),
+		AccessTokenSecret: stringFromEnv("SAKURACLOUD_ACCESS_TOKEN_SECRET", ""),
+
+		APIRootURL:     stringFromEnv("SAKURACLOUD_API_ROOT_URL", ""),
+		DefaultZone:    stringFromEnv("SAKURACLOUD_DEFAULT_ZONE", ""),
+		Zones:          stringSliceFromEnv("SAKURACLOUD_ZONES", []string{}),
+		AcceptLanguage: stringFromEnv("SAKURACLOUD_ACCEPT_LANGUAGE", ""),
+
+		HTTPRequestTimeout:   intFromEnv("SAKURACLOUD_API_REQUEST_TIMEOUT", 0),
+		HTTPRequestRateLimit: intFromEnv("SAKURACLOUD_API_REQUEST_RATE_LIMIT", 0),
+
+		RetryMax:     intFromEnv("SAKURACLOUD_RETRY_MAX", 0),
+		RetryWaitMax: intFromEnv("SAKURACLOUD_RETRY_WAIT_MAX", 0),
+		RetryWaitMin: intFromEnv("SAKURACLOUD_RETRY_WAIT_MIN", 0),
+
+		TraceAPI:  profile.EnableAPITrace(stringFromEnv("SAKURACLOUD_TRACE", "")),
+		TraceHTTP: profile.EnableHTTPTrace(stringFromEnv("SAKURACLOUD_TRACE", "")),
+
+		FakeMode:      os.Getenv("SAKURACLOUD_FAKE_MODE") != "",
+		FakeStorePath: stringFromEnv("SAKURACLOUD_FAKE_STORE_PATH", ""),
+	}
+}
+
+// OptionsFromProfile 指定のプロファイルからCallerOptionsを組み立てて返す
+// プロファイル名に空文字が指定された場合はカレントプロファイルが利用される
+func OptionsFromProfile(profileName string) (*CallerOptions, error) {
+	if profileName == "" {
+		current, err := profile.CurrentName()
+		if err != nil {
+			return nil, err
+		}
+		profileName = current
+	}
+
+	config := profile.ConfigValue{}
+	if err := profile.Load(profileName, &config); err != nil {
+		return nil, err
+	}
+
+	return &CallerOptions{
+		AccessToken:          config.AccessToken,
+		AccessTokenSecret:    config.AccessTokenSecret,
+		APIRootURL:           config.APIRootURL,
+		DefaultZone:          config.DefaultZone,
+		Zones:                config.Zones,
+		AcceptLanguage:       config.AcceptLanguage,
+		HTTPRequestTimeout:   config.HTTPRequestTimeout,
+		HTTPRequestRateLimit: config.HTTPRequestRateLimit,
+		RetryMax:             config.RetryMax,
+		RetryWaitMax:         config.RetryWaitMax,
+		RetryWaitMin:         config.RetryWaitMin,
+		TraceAPI:             config.EnableAPITrace(),
+		TraceHTTP:            config.EnableHTTPTrace(),
+		FakeMode:             config.FakeMode,
+		FakeStorePath:        config.FakeStorePath,
+	}, nil
+}
+
+func stringFromEnv(key, defaultValue string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultValue
+	}
+	return v
+}
+
+func stringFromEnvMulti(keys []string, defaultValue string) string {
+	for _, key := range keys {
+		v := os.Getenv(key)
+		if v != "" {
+			return v
+		}
+	}
+	return defaultValue
+}
+
+func stringSliceFromEnv(key string, defaultValue []string) []string {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultValue
+	}
+	values := strings.Split(v, ",")
+	for i := range values {
+		values[i] = strings.Trim(values[i], " ")
+	}
+	return values
+}
+
+func intFromEnv(key string, defaultValue int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return defaultValue
+	}
+	i, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return defaultValue
+	}
+	return int(i)
+}

--- a/v2/helper/api/options_test.go
+++ b/v2/helper/api/options_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016-2022 The Libsacloud Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMergeOptions(t *testing.T) {
+	type args struct {
+		opts []*CallerOptions
+	}
+	tests := []struct {
+		name string
+		args args
+		want *CallerOptions
+	}{
+		{
+			name: "minimum",
+			args: args{
+				opts: []*CallerOptions{},
+			},
+			want: &CallerOptions{},
+		},
+		{
+			name: "merge",
+			args: args{
+				opts: []*CallerOptions{
+					{
+						AccessToken: "1",
+					},
+					{
+						AccessToken: "2",
+					},
+					{
+						AccessToken: "3",
+					},
+				},
+			},
+			want: &CallerOptions{
+				AccessToken: "3",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.EqualValues(t, tt.want, MergeOptions(tt.args.opts...))
+		})
+	}
+}

--- a/v2/sacloud/profile/profile.go
+++ b/v2/sacloud/profile/profile.go
@@ -174,12 +174,20 @@ type ConfigValue struct {
 	FakeStorePath string
 }
 
-func (o *ConfigValue) traceModeValue() string {
-	return strings.ToLower(strings.TrimSpace(o.TraceMode))
+func (o *ConfigValue) EnableHTTPTrace() bool {
+	return EnableHTTPTrace(o.TraceMode)
 }
 
-func (o *ConfigValue) EnableHTTPTrace() bool {
-	traceMode := o.traceModeValue()
+func (o *ConfigValue) EnableAPITrace() bool {
+	return EnableAPITrace(o.TraceMode)
+}
+
+func traceModeValue(strTraceMode string) string {
+	return strings.ToLower(strings.TrimSpace(strTraceMode))
+}
+
+func EnableHTTPTrace(strTraceMode string) bool {
+	traceMode := traceModeValue(strTraceMode)
 	if traceMode == "" {
 		return false
 	}
@@ -191,8 +199,8 @@ func (o *ConfigValue) EnableHTTPTrace() bool {
 	return true
 }
 
-func (o *ConfigValue) EnableAPITrace() bool {
-	traceMode := o.traceModeValue()
+func EnableAPITrace(strTraceMode string) bool {
+	traceMode := traceModeValue(strTraceMode)
 	if traceMode == "" {
 		return false
 	}


### PR DESCRIPTION
closes #784 

環境変数やプロファイルからのAPIクライアント構築処理をUsacloudから切り出して移植する。

## 実装

互換性維持のため、既存のfunc `api.NewCaller()`のシグニチャを変更しないように実装する。

既存のfunc:
```go
 // NewCaller 指定のオプションでsacloud.APICallerを構築して返す 
 func NewCaller(opts *CallerOptions) sacloud.APICaller
```

これに対し追加で以下のようなfuncを提供する。

環境変数/プロファイル対応:
```go
// OptionsFromEnv 環境変数からCallerOptionsを組み立てて返す
func OptionsFromEnv() *CallerOptions

// OptionsFromProfile 指定のプロファイルからCallerOptionsを組み立てて返す
// プロファイル名に空文字が指定された場合はカレントプロファイルが利用される
func OptionsFromProfile(profileName string) (*CallerOptions, error)
```

複数のオプションのマージ:
```go
// MergeOptions 指定のCallerOptionsの非ゼロ値フィールドをoのコピーにマージして返す
func MergeOptions(opts ...*CallerOptions) *CallerOptions
```

ユーティリティ:
```go
// DefaultOption 環境変数、プロファイルからCallerOptionsを組み立てて返す
//
// プロファイルは環境変数`SAKURACLOUD_PROFILE`または`USACLOUD_PROFILE`でプロファイル名が指定されていればそちらを優先し、
// 未指定の場合は通常のプロファイル処理(~/.usacloud/currentファイルから読み込み)される。
// 同じ項目を複数箇所で指定していた場合、環境変数->プロファイルの順で上書きされたものが返される
func DefaultOption() (*CallerOptions, error)

// NewDefaultCaller デフォルトのオプションでsacloud.APICallerを構築して返す
func NewDefaultCaller() (sacloud.APICaller, error)
```

## 関連する環境変数

`OptionsFromEnv()`では以下の環境変数が参照される。

- AccessToken:       `SAKURACLOUD_ACCESS_TOKEN`
- AccessTokenSecret: `SAKURACLOUD_ACCESS_TOKEN_SECRET`
- APIRootURL:     `SAKURACLOUD_API_ROOT_URL`
- DefaultZone:    `SAKURACLOUD_DEFAULT_ZONE`
- Zones:          `SAKURACLOUD_ZONES`
- AcceptLanguage: `SAKURACLOUD_ACCEPT_LANGUAGE`
- HTTPRequestTimeout:   `SAKURACLOUD_API_REQUEST_TIMEOUT`
- HTTPRequestRateLimit: `SAKURACLOUD_API_REQUEST_RATE_LIMIT`
- RetryMax:     `SAKURACLOUD_RETRY_MAX`
- RetryWaitMax: `SAKURACLOUD_RETRY_WAIT_MAX`
- RetryWaitMin: `SAKURACLOUD_RETRY_WAIT_MIN`
- TraceAPI:  `SAKURACLOUD_TRACE`
- TraceHTTP: `SAKURACLOUD_TRACE`
- FakeMode:      `SAKURACLOUD_FAKE_MODE`
- FakeStorePath: `SAKURACLOUD_FAKE_STORE_PATH`

また、`DefaultOption()`では`SAKURACLOUD_PROFILE`または`USACLOUD_PROFILE`も利用可能。
ただし`Zones`についてはアプリケーション側で適切にハンドリングする必要がある。

## 注意事項 

FakeModeやTraceなどのbool値でオプションを指定するケースでは、
非ゼロ値(true)の場合のみプロファイル/環境変数で上書き可能にする。
これにより、プロファイル/環境変数/直接指定いずれかでtrueになった場合はfalseに戻せない仕様となっている。