### PR TITLE
helper/api: Added NewCallerWithDefaults func

### DIFF
--- a/v2/helper/api/caller.go
+++ b/v2/helper/api/caller.go
@@ -35,13 +35,15 @@ func NewCaller(opts *CallerOptions) sacloud.APICaller {
 	return newCaller(opts)
 }
 
-// NewDefaultCaller デフォルトのオプションでsacloud.APICallerを構築して返す
-func NewDefaultCaller() (sacloud.APICaller, error) {
-	opts, err := DefaultOption()
+// NewCallerWithDefaults 指定のオプション+環境変数/プロファイルを用いてsacloud.APICallerを構築して返す
+//
+// DefaultOption()で得られる*CallerOptionsにoptsをマージしてからNewCallerが呼ばれる
+func NewCallerWithDefaults(opts *CallerOptions) (sacloud.APICaller, error) {
+	defaultOpts, err := DefaultOption()
 	if err != nil {
 		return nil, err
 	}
-	return NewCaller(opts), nil
+	return NewCaller(MergeOptions(defaultOpts, opts)), nil
 }
 
 func newCaller(opts *CallerOptions) sacloud.APICaller {


### PR DESCRIPTION
#861 のフォロー

`NewDefaultCaller()`を`NewCallerWithDefaults(opts *CallerOptions)`に修正する。

基本的に各アプリケーション側で何らかのオプション指定を行うことが多く、環境変数/デフォルト値のみ利用というケースはほとんどないため。
もし必要であれば`NewCallerWithDefaults(opts *CallerOptions)`に空のCallerOptionsを渡せば良い。