### PR TITLE
helper/apiで環境変数SAKURACLOUD_ZONESが反映されない問題を修正

### DIFF
--- a/v2/helper/api/caller.go
+++ b/v2/helper/api/caller.go
@@ -135,6 +135,10 @@ func newCaller(opts *CallerOptions) sacloud.APICaller {
 		}
 		sacloud.SakuraCloudAPIRoot = opts.APIRootURL
 	}
+
+	if len(opts.Zones) > 0 {
+		sacloud.SakuraCloudZones = opts.Zones
+	}
 	return caller
 }
 


### PR DESCRIPTION
https://github.com/sacloud/iaas-api-go/pull/6 のバックポート

SAKURACLOUD_ZONESを指定するとapi.Optionsには反映されるものの、sacloud.SakuraCloudZonesに反映されていなかった問題を修正